### PR TITLE
fix(provider/preview_api_key): report failure to retrieve preview api keys

### DIFF
--- a/internal/provider/data_source_app_definition.go
+++ b/internal/provider/data_source_app_definition.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package provider
 
 import (

--- a/internal/provider/data_source_preview_api_key.go
+++ b/internal/provider/data_source_preview_api_key.go
@@ -1,8 +1,8 @@
+//nolint:dupl
 package provider
 
 import (
 	"context"
-	"net/http"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
@@ -77,15 +77,6 @@ func (d *previewAPIKeyDataSource) Read(ctx context.Context, req datasource.ReadR
 		data = responseModel
 
 	default:
-		if response, ok := response.(cm.StatusCodeResponse); ok {
-			if response.GetStatusCode() == http.StatusNotFound {
-				resp.Diagnostics.AddWarning("Failed to read preview api key", util.ErrorDetailFromContentfulManagementResponse(response, err))
-				resp.State.RemoveResource(ctx)
-
-				return
-			}
-		}
-
 		resp.Diagnostics.AddError("Failed to read preview api key", util.ErrorDetailFromContentfulManagementResponse(response, err))
 	}
 

--- a/internal/provider/data_source_preview_api_key_test.go
+++ b/internal/provider/data_source_preview_api_key_test.go
@@ -24,7 +24,7 @@ func TestAccPreviewApiKeyDataSourceNotFound(t *testing.T) {
 			{
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: configVariables,
-				ExpectError:     regexp.MustCompile(`Provider produced null object`),
+				ExpectError:     regexp.MustCompile(`Failed to read preview api key`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- return an explicit data source diagnostic when a preview API key is not found
- stop relying on Terraform's generic null-object provider error

## Validation
- TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -run TestAccPreviewApiKeyDataSourceNotFound -count=1