### PR TITLE
fix(provider): return after client creation failure

### DIFF
--- a/internal/provider/contentful_provider.go
+++ b/internal/provider/contentful_provider.go
@@ -152,7 +152,9 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 		cm.WithClient(util.NewClientWithUserAgent(retryableClient.StandardClient(), "terraform-provider-contentful/"+p.version)),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to create Contentful client: %s", err.Error())
+		resp.Diagnostics.AddError("Failed to create Contentful client", err.Error())
+
+		return
 	}
 
 	providerData := ContentfulProviderData{

--- a/internal/provider/contentful_provider_test.go
+++ b/internal/provider/contentful_provider_test.go
@@ -65,6 +65,7 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 		config          map[string]any
 		env             map[string]string
 		expectedSuccess bool
+		expectedSummary string
 	}{
 		"config: url": {
 			config: map[string]any{
@@ -91,6 +92,7 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 				"access_token": "CFPAT-12345",
 			},
 			expectedSuccess: false,
+			expectedSummary: "Failed to create Contentful client",
 		},
 		"env: url": {
 			env: map[string]string{
@@ -140,6 +142,9 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 				assert.Empty(t, resp.Diagnostics)
 			} else {
 				assert.NotEmpty(t, resp.Diagnostics)
+				if test.expectedSummary != "" {
+					assert.Equal(t, test.expectedSummary, resp.Diagnostics[0].Summary)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- use a proper Terraform diagnostic summary/detail when client creation fails
- stop provider configuration immediately after the client cannot be built
- cover the invalid URL diagnostic summary in provider tests

## Validation
- go test ./internal/provider -run TestProtocol6ProviderServerConfigure -count=1