### PR TITLE
feat(provider): apply a small minimum duration to resource timeouts read from state

### DIFF
--- a/internal/provider/resource_app_definition.go
+++ b/internal/provider/resource_app_definition.go
@@ -139,6 +139,8 @@ func (r *appDefinitionResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -273,6 +275,8 @@ func (r *appDefinitionResource) Delete(ctx context.Context, req resource.DeleteR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_app_installation.go
+++ b/internal/provider/resource_app_installation.go
@@ -146,6 +146,8 @@ func (r *appInstallationResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -286,6 +288,8 @@ func (r *appInstallationResource) Delete(ctx context.Context, req resource.Delet
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_app_signing_secret.go
+++ b/internal/provider/resource_app_signing_secret.go
@@ -142,6 +142,8 @@ func (r *appSigningSecretResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -288,6 +290,8 @@ func (r *appSigningSecretResource) Delete(ctx context.Context, req resource.Dele
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_content_type.go
+++ b/internal/provider/resource_content_type.go
@@ -174,6 +174,8 @@ func (r *contentTypeResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -349,6 +351,8 @@ func (r *contentTypeResource) Delete(ctx context.Context, req resource.DeleteReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_delivery_api_key.go
+++ b/internal/provider/resource_delivery_api_key.go
@@ -143,6 +143,8 @@ func (r *deliveryAPIKeyResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -288,6 +290,8 @@ func (r *deliveryAPIKeyResource) Delete(ctx context.Context, req resource.Delete
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_editor_interface.go
+++ b/internal/provider/resource_editor_interface.go
@@ -149,6 +149,8 @@ func (r *editorInterfaceResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/internal/provider/resource_entry.go
+++ b/internal/provider/resource_entry.go
@@ -136,6 +136,8 @@ func (r *entryResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -274,6 +276,8 @@ func (r *entryResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -148,6 +148,8 @@ func (r *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -295,6 +297,8 @@ func (r *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_environment_alias.go
+++ b/internal/provider/resource_environment_alias.go
@@ -144,6 +144,8 @@ func (r *environmentAliasResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -289,6 +291,8 @@ func (r *environmentAliasResource) Delete(ctx context.Context, req resource.Dele
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_extension.go
+++ b/internal/provider/resource_extension.go
@@ -146,6 +146,8 @@ func (r *extensionResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -293,6 +295,8 @@ func (r *extensionResource) Delete(ctx context.Context, req resource.DeleteReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_personal_access_token.go
+++ b/internal/provider/resource_personal_access_token.go
@@ -130,6 +130,8 @@ func (r *personalAccessTokenResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -199,6 +201,8 @@ func (r *personalAccessTokenResource) Delete(ctx context.Context, req resource.D
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_resource_provider.go
+++ b/internal/provider/resource_resource_provider.go
@@ -141,6 +141,8 @@ func (r *appDefinitionResourceProviderResource) Read(ctx context.Context, req re
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -275,6 +277,8 @@ func (r *appDefinitionResourceProviderResource) Delete(ctx context.Context, req 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_resource_type.go
+++ b/internal/provider/resource_resource_type.go
@@ -142,6 +142,8 @@ func (r *appDefinitionResourceTypeResource) Read(ctx context.Context, req resour
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -277,6 +279,8 @@ func (r *appDefinitionResourceTypeResource) Delete(ctx context.Context, req reso
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -143,6 +143,8 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -288,6 +290,8 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_space_enablements.go
+++ b/internal/provider/resource_space_enablements.go
@@ -140,6 +140,8 @@ func (r *spaceEnablementsResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/internal/provider/resource_tag.go
+++ b/internal/provider/resource_tag.go
@@ -135,6 +135,8 @@ func (r *tagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -267,6 +269,8 @@ func (r *tagResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -143,6 +143,8 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -289,6 +291,8 @@ func (r *teamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_team_space_membership.go
+++ b/internal/provider/resource_team_space_membership.go
@@ -141,6 +141,8 @@ func (r *teamSpaceMembershipResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -275,6 +277,8 @@ func (r *teamSpaceMembershipResource) Delete(ctx context.Context, req resource.D
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/provider/resource_timeouts.go
+++ b/internal/provider/resource_timeouts.go
@@ -5,3 +5,5 @@ import (
 )
 
 const defaultResourceOperationTimeout = 2 * time.Minute
+
+const minimumStoredResourceOperationTimeout = 10 * time.Second

--- a/internal/provider/resource_webhook.go
+++ b/internal/provider/resource_webhook.go
@@ -141,6 +141,8 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
+
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -286,6 +288,8 @@ func (r *webhookResource) Delete(ctx context.Context, req resource.DeleteRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	timeout = max(timeout, minimumStoredResourceOperationTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()


### PR DESCRIPTION
## Summary
- add a minimum duration for resource read/delete timeouts loaded from Terraform state