### PR TITLE
fix(provider): paginate list resource results

### DIFF
--- a/internal/contentful-management-go/testing/handler_content_type.go
+++ b/internal/contentful-management-go/testing/handler_content_type.go
@@ -29,8 +29,8 @@ func (ts *Handler) GetContentTypes(_ context.Context, params cm.GetContentTypesP
 		return cmp.Compare(a.Sys.ID, b.Sys.ID)
 	})
 
-	skip := params.Skip.Or(0)
-	limit := params.Limit.Or(100) //nolint:mnd
+	skip := max(params.Skip.Or(0), 0)
+	limit := max(params.Limit.Or(100), 0) //nolint:mnd
 	start := min(skip, int64(len(items)))
 	end := min(start+limit, int64(len(items)))
 

--- a/internal/contentful-management-go/testing/handler_content_type.go
+++ b/internal/contentful-management-go/testing/handler_content_type.go
@@ -1,8 +1,10 @@
 package cmtesting
 
 import (
+	"cmp"
 	"context"
 	"net/http"
+	"slices"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 )
@@ -23,12 +25,21 @@ func (ts *Handler) GetContentTypes(_ context.Context, params cm.GetContentTypesP
 		items = append(items, *ct)
 	}
 
+	slices.SortFunc(items, func(a, b cm.ContentType) int {
+		return cmp.Compare(a.Sys.ID, b.Sys.ID)
+	})
+
+	skip := params.Skip.Or(0)
+	limit := params.Limit.Or(100) //nolint:mnd
+	start := min(skip, int64(len(items)))
+	end := min(start+limit, int64(len(items)))
+
 	return &cm.ContentTypeCollection{
 		Sys: cm.ContentTypeCollectionSys{
 			Type: cm.ContentTypeCollectionSysTypeArray,
 		},
 		Total: cm.NewOptInt(len(contentTypes)),
-		Items: items,
+		Items: items[start:end],
 	}, nil
 }
 

--- a/internal/contentful-management-go/testing/handler_content_type_test.go
+++ b/internal/contentful-management-go/testing/handler_content_type_test.go
@@ -1,0 +1,56 @@
+package cmtesting_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetContentTypesPaginates(t *testing.T) {
+	t.Parallel()
+
+	server, err := cmt.NewContentfulManagementServer()
+	require.NoError(t, err)
+
+	for i := range 3 {
+		server.SetContentType("space", "environment", fmt.Sprintf("content-type-%d", i), cm.ContentTypeRequestData{
+			Name:   fmt.Sprintf("Content Type %d", i),
+			Fields: []cm.ContentTypeRequestDataFieldsItem{},
+		})
+	}
+
+	firstPageResponse, err := server.Handler().GetContentTypes(context.Background(), cm.GetContentTypesParams{
+		SpaceID:       "space",
+		EnvironmentID: "environment",
+		Skip:          cm.NewOptInt64(0),
+		Limit:         cm.NewOptInt64(1),
+	})
+	require.NoError(t, err)
+
+	firstPageCollection, firstPageCollectionOk := firstPageResponse.(*cm.ContentTypeCollection)
+	require.True(t, firstPageCollectionOk)
+	assert.Equal(t, 3, firstPageCollection.Total.Or(0))
+	require.Len(t, firstPageCollection.Items, 1)
+	assert.Equal(t, "content-type-0", firstPageCollection.Items[0].Sys.ID)
+	assert.Equal(t, "Content Type 0", firstPageCollection.Items[0].Name)
+
+	secondPageResponse, err := server.Handler().GetContentTypes(context.Background(), cm.GetContentTypesParams{
+		SpaceID:       "space",
+		EnvironmentID: "environment",
+		Skip:          cm.NewOptInt64(1),
+		Limit:         cm.NewOptInt64(1),
+	})
+	require.NoError(t, err)
+
+	secondPageCollection, secondPageCollectionOk := secondPageResponse.(*cm.ContentTypeCollection)
+	require.True(t, secondPageCollectionOk)
+	assert.Equal(t, 3, secondPageCollection.Total.Or(0))
+	require.Len(t, secondPageCollection.Items, 1)
+	assert.Equal(t, "content-type-1", secondPageCollection.Items[0].Sys.ID)
+	assert.Equal(t, "Content Type 1", secondPageCollection.Items[0].Name)
+}

--- a/internal/contentful-management-go/testing/handler_content_type_test.go
+++ b/internal/contentful-management-go/testing/handler_content_type_test.go
@@ -54,3 +54,28 @@ func TestGetContentTypesPaginates(t *testing.T) {
 	assert.Equal(t, "content-type-1", secondPageCollection.Items[0].Sys.ID)
 	assert.Equal(t, "Content Type 1", secondPageCollection.Items[0].Name)
 }
+
+func TestGetContentTypesHandlesNegativePaginationParams(t *testing.T) {
+	t.Parallel()
+
+	server, err := cmt.NewContentfulManagementServer()
+	require.NoError(t, err)
+
+	server.SetContentType("space", "environment", "content-type", cm.ContentTypeRequestData{
+		Name:   "Content Type",
+		Fields: []cm.ContentTypeRequestDataFieldsItem{},
+	})
+
+	response, err := server.Handler().GetContentTypes(context.Background(), cm.GetContentTypesParams{
+		SpaceID:       "space",
+		EnvironmentID: "environment",
+		Skip:          cm.NewOptInt64(-1),
+		Limit:         cm.NewOptInt64(-1),
+	})
+	require.NoError(t, err)
+
+	collection, collectionOk := response.(*cm.ContentTypeCollection)
+	require.True(t, collectionOk)
+	assert.Equal(t, 1, collection.Total.Or(0))
+	assert.Empty(t, collection.Items)
+}

--- a/internal/provider/list_resource_content_type.go
+++ b/internal/provider/list_resource_content_type.go
@@ -50,55 +50,87 @@ func (r *contentTypeListResource) List(ctx context.Context, req list.ListRequest
 	params := cm.GetContentTypesParams{
 		SpaceID:       config.SpaceID.ValueString(),
 		EnvironmentID: config.EnvironmentID.ValueString(),
-		Limit:         cm.NewOptInt64(req.Limit),
 		Order:         []string{"sys.id"},
 	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
-		response, err := r.providerData.client.GetContentTypes(ctx, params)
-		if err != nil {
-			yield(list.ListResult{
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic("Failed to list content types", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-				},
-			})
+		var (
+			emitted int64
+			skip    int64
+		)
 
-			return
-		}
+		for {
+			limit := contentfulListPageLimit
 
-		switch response := response.(type) {
-		case *cm.ContentTypeCollection:
-			for _, item := range response.Items {
-				result := req.NewListResult(ctx)
-
-				result.DisplayName = item.Name
-
-				result.Diagnostics.Append(result.Identity.Set(ctx, ContentTypeIdentityModel{
-					SpaceID:       types.StringValue(item.Sys.Space.Sys.ID),
-					EnvironmentID: types.StringValue(item.Sys.Environment.Sys.ID),
-					ContentTypeID: types.StringValue(item.Sys.ID),
-				})...)
-
-				if req.IncludeResource {
-					responseModel, responseModelDiags := NewContentTypeResourceModelFromResponse(ctx, item)
-					result.Diagnostics.Append(responseModelDiags...)
-
-					result.Diagnostics.Append(result.Resource.Set(ctx, responseModel)...)
-				}
-
-				if !yield(result) {
+			if req.Limit > 0 {
+				remaining := req.Limit - emitted
+				if remaining <= 0 {
 					return
 				}
+
+				limit = min(limit, remaining)
 			}
 
-		default:
-			yield(list.ListResult{
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic("Failed to list content types", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-				},
-			})
+			params.Skip = cm.NewOptInt64(skip)
+			params.Limit = cm.NewOptInt64(limit)
 
-			return
+			response, err := r.providerData.client.GetContentTypes(ctx, params)
+			if err != nil {
+				yield(list.ListResult{
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("Failed to list content types", util.ErrorDetailFromContentfulManagementResponse(response, err)),
+					},
+				})
+
+				return
+			}
+
+			switch response := response.(type) {
+			case *cm.ContentTypeCollection:
+				for _, item := range response.Items {
+					result := req.NewListResult(ctx)
+
+					result.DisplayName = item.Name
+
+					result.Diagnostics.Append(result.Identity.Set(ctx, ContentTypeIdentityModel{
+						SpaceID:       types.StringValue(item.Sys.Space.Sys.ID),
+						EnvironmentID: types.StringValue(item.Sys.Environment.Sys.ID),
+						ContentTypeID: types.StringValue(item.Sys.ID),
+					})...)
+
+					if req.IncludeResource {
+						responseModel, responseModelDiags := NewContentTypeResourceModelFromResponse(ctx, item)
+						result.Diagnostics.Append(responseModelDiags...)
+
+						result.Diagnostics.Append(result.Resource.Set(ctx, responseModel)...)
+					}
+
+					if !yield(result) {
+						return
+					}
+
+					emitted++
+				}
+
+				itemCount := int64(len(response.Items))
+				if itemCount == 0 {
+					return
+				}
+
+				skip += itemCount
+				if total, ok := response.Total.Get(); ok && skip >= int64(total) {
+					return
+				}
+
+			default:
+				yield(list.ListResult{
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("Failed to list content types", util.ErrorDetailFromContentfulManagementResponse(response, err)),
+					},
+				})
+
+				return
+			}
 		}
 	}
 }

--- a/internal/provider/list_resource_content_type.go
+++ b/internal/provider/list_resource_content_type.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
-	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -53,84 +51,34 @@ func (r *contentTypeListResource) List(ctx context.Context, req list.ListRequest
 		Order:         []string{"sys.id"},
 	}
 
-	stream.Results = func(yield func(list.ListResult) bool) {
-		var (
-			emitted int64
-			skip    int64
-		)
+	stream.Results = paginateContentfulCollectionItemsAsListResults(ctx, req,
+		"Failed to list content types",
+		func(ctx context.Context, skip int64, limit int64) (cm.GetContentTypesRes, error) {
+			pageParams := params
+			pageParams.Skip = cm.NewOptInt64(skip)
+			pageParams.Limit = cm.NewOptInt64(limit)
 
-		for {
-			limit := contentfulListPageLimit
+			return r.providerData.client.GetContentTypes(ctx, pageParams)
+		},
+		func(item cm.ContentType) list.ListResult {
+			result := req.NewListResult(ctx)
 
-			if req.Limit > 0 {
-				remaining := req.Limit - emitted
-				if remaining <= 0 {
-					return
-				}
+			result.DisplayName = item.Name
 
-				limit = min(limit, remaining)
+			result.Diagnostics.Append(result.Identity.Set(ctx, ContentTypeIdentityModel{
+				SpaceID:       types.StringValue(item.Sys.Space.Sys.ID),
+				EnvironmentID: types.StringValue(item.Sys.Environment.Sys.ID),
+				ContentTypeID: types.StringValue(item.Sys.ID),
+			})...)
+
+			if req.IncludeResource {
+				responseModel, responseModelDiags := NewContentTypeResourceModelFromResponse(ctx, item)
+				result.Diagnostics.Append(responseModelDiags...)
+
+				result.Diagnostics.Append(result.Resource.Set(ctx, responseModel)...)
 			}
 
-			params.Skip = cm.NewOptInt64(skip)
-			params.Limit = cm.NewOptInt64(limit)
-
-			response, err := r.providerData.client.GetContentTypes(ctx, params)
-			if err != nil {
-				yield(list.ListResult{
-					Diagnostics: diag.Diagnostics{
-						diag.NewErrorDiagnostic("Failed to list content types", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-					},
-				})
-
-				return
-			}
-
-			switch response := response.(type) {
-			case *cm.ContentTypeCollection:
-				for _, item := range response.Items {
-					result := req.NewListResult(ctx)
-
-					result.DisplayName = item.Name
-
-					result.Diagnostics.Append(result.Identity.Set(ctx, ContentTypeIdentityModel{
-						SpaceID:       types.StringValue(item.Sys.Space.Sys.ID),
-						EnvironmentID: types.StringValue(item.Sys.Environment.Sys.ID),
-						ContentTypeID: types.StringValue(item.Sys.ID),
-					})...)
-
-					if req.IncludeResource {
-						responseModel, responseModelDiags := NewContentTypeResourceModelFromResponse(ctx, item)
-						result.Diagnostics.Append(responseModelDiags...)
-
-						result.Diagnostics.Append(result.Resource.Set(ctx, responseModel)...)
-					}
-
-					if !yield(result) {
-						return
-					}
-
-					emitted++
-				}
-
-				itemCount := int64(len(response.Items))
-				if itemCount == 0 {
-					return
-				}
-
-				skip += itemCount
-				if total, ok := response.Total.Get(); ok && skip >= int64(total) {
-					return
-				}
-
-			default:
-				yield(list.ListResult{
-					Diagnostics: diag.Diagnostics{
-						diag.NewErrorDiagnostic("Failed to list content types", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-					},
-				})
-
-				return
-			}
-		}
-	}
+			return result
+		},
+	)
 }

--- a/internal/provider/list_resource_entry.go
+++ b/internal/provider/list_resource_entry.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+const contentfulListPageLimit int64 = 100
+
 var (
 	_ list.ListResource              = (*entryListResource)(nil)
 	_ list.ListResourceWithConfigure = (*entryListResource)(nil)
@@ -50,7 +52,6 @@ func (r *entryListResource) List(ctx context.Context, req list.ListRequest, stre
 	params := cm.GetEntriesParams{
 		SpaceID:       config.SpaceID.ValueString(),
 		EnvironmentID: config.EnvironmentID.ValueString(),
-		Limit:         cm.NewOptInt64(req.Limit),
 	}
 
 	configContentType := config.ContentType.ValueString()
@@ -84,50 +85,83 @@ func (r *entryListResource) List(ctx context.Context, req list.ListRequest, stre
 	})
 
 	stream.Results = func(yield func(list.ListResult) bool) {
-		response, err := r.providerData.client.GetEntries(ctx, params, getEntriesQueryOption)
-		if err != nil {
-			yield(list.ListResult{
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic("Failed to list entries", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-				},
-			})
+		var (
+			emitted int64
+			skip    int64
+		)
 
-			return
-		}
+		for {
+			limit := contentfulListPageLimit
 
-		switch response := response.(type) {
-		case *cm.EntryCollection:
-			for _, item := range response.Items {
-				result := req.NewListResult(ctx)
-
-				result.DisplayName = item.Sys.ID
-
-				result.Diagnostics.Append(result.Identity.Set(ctx, NewEntryIdentityModel(
-					item.Sys.Space.Sys.ID,
-					item.Sys.Environment.Sys.ID,
-					item.Sys.ID,
-				))...)
-
-				if req.IncludeResource {
-					responseModel, responseDiags := NewEntryResourceModelFromResponse(ctx, item)
-					result.Diagnostics.Append(responseDiags...)
-
-					result.Diagnostics.Append(result.Resource.Set(ctx, &responseModel)...)
-				}
-
-				if !yield(result) {
+			if req.Limit > 0 {
+				remaining := req.Limit - emitted
+				if remaining <= 0 {
 					return
 				}
+
+				limit = min(limit, remaining)
 			}
 
-		default:
-			yield(list.ListResult{
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic("Failed to list entries", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-				},
-			})
+			params.Skip = cm.NewOptInt64(skip)
+			params.Limit = cm.NewOptInt64(limit)
 
-			return
+			response, err := r.providerData.client.GetEntries(ctx, params, getEntriesQueryOption)
+			if err != nil {
+				yield(list.ListResult{
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("Failed to list entries", util.ErrorDetailFromContentfulManagementResponse(response, err)),
+					},
+				})
+
+				return
+			}
+
+			switch response := response.(type) {
+			case *cm.EntryCollection:
+				for _, item := range response.Items {
+					result := req.NewListResult(ctx)
+
+					result.DisplayName = item.Sys.ID
+
+					result.Diagnostics.Append(result.Identity.Set(ctx, NewEntryIdentityModel(
+						item.Sys.Space.Sys.ID,
+						item.Sys.Environment.Sys.ID,
+						item.Sys.ID,
+					))...)
+
+					if req.IncludeResource {
+						responseModel, responseDiags := NewEntryResourceModelFromResponse(ctx, item)
+						result.Diagnostics.Append(responseDiags...)
+
+						result.Diagnostics.Append(result.Resource.Set(ctx, &responseModel)...)
+					}
+
+					if !yield(result) {
+						return
+					}
+
+					emitted++
+				}
+
+				itemCount := int64(len(response.Items))
+				if itemCount == 0 {
+					return
+				}
+
+				skip += itemCount
+				if total, ok := response.Total.Get(); ok && skip >= int64(total) {
+					return
+				}
+
+			default:
+				yield(list.ListResult{
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("Failed to list entries", util.ErrorDetailFromContentfulManagementResponse(response, err)),
+					},
+				})
+
+				return
+			}
 		}
 	}
 }

--- a/internal/provider/list_resource_entry.go
+++ b/internal/provider/list_resource_entry.go
@@ -3,15 +3,12 @@ package provider
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
-	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
-
-const contentfulListPageLimit int64 = 100
 
 var (
 	_ list.ListResource              = (*entryListResource)(nil)
@@ -76,7 +73,7 @@ func (r *entryListResource) List(ctx context.Context, req list.ListRequest, stre
 		urlQuery := req.URL.Query()
 
 		for key, value := range config.Query.Elements() {
-			urlQuery.Set(key, value.ValueString())
+			setEntryListQueryParam(urlQuery, key, value.ValueString())
 		}
 
 		req.URL.RawQuery = urlQuery.Encode()
@@ -84,84 +81,42 @@ func (r *entryListResource) List(ctx context.Context, req list.ListRequest, stre
 		return nil
 	})
 
-	stream.Results = func(yield func(list.ListResult) bool) {
-		var (
-			emitted int64
-			skip    int64
-		)
+	stream.Results = paginateContentfulCollectionItemsAsListResults(ctx, req,
+		"Failed to list entries",
+		func(ctx context.Context, skip int64, limit int64) (cm.GetEntriesRes, error) {
+			pageParams := params
+			pageParams.Skip = cm.NewOptInt64(skip)
+			pageParams.Limit = cm.NewOptInt64(limit)
 
-		for {
-			limit := contentfulListPageLimit
+			return r.providerData.client.GetEntries(ctx, pageParams, getEntriesQueryOption)
+		},
+		func(item cm.Entry) list.ListResult {
+			result := req.NewListResult(ctx)
 
-			if req.Limit > 0 {
-				remaining := req.Limit - emitted
-				if remaining <= 0 {
-					return
-				}
+			result.DisplayName = item.Sys.ID
 
-				limit = min(limit, remaining)
+			result.Diagnostics.Append(result.Identity.Set(ctx, NewEntryIdentityModel(
+				item.Sys.Space.Sys.ID,
+				item.Sys.Environment.Sys.ID,
+				item.Sys.ID,
+			))...)
+
+			if req.IncludeResource {
+				responseModel, responseDiags := NewEntryResourceModelFromResponse(ctx, item)
+				result.Diagnostics.Append(responseDiags...)
+
+				result.Diagnostics.Append(result.Resource.Set(ctx, &responseModel)...)
 			}
 
-			params.Skip = cm.NewOptInt64(skip)
-			params.Limit = cm.NewOptInt64(limit)
+			return result
+		},
+	)
+}
 
-			response, err := r.providerData.client.GetEntries(ctx, params, getEntriesQueryOption)
-			if err != nil {
-				yield(list.ListResult{
-					Diagnostics: diag.Diagnostics{
-						diag.NewErrorDiagnostic("Failed to list entries", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-					},
-				})
-
-				return
-			}
-
-			switch response := response.(type) {
-			case *cm.EntryCollection:
-				for _, item := range response.Items {
-					result := req.NewListResult(ctx)
-
-					result.DisplayName = item.Sys.ID
-
-					result.Diagnostics.Append(result.Identity.Set(ctx, NewEntryIdentityModel(
-						item.Sys.Space.Sys.ID,
-						item.Sys.Environment.Sys.ID,
-						item.Sys.ID,
-					))...)
-
-					if req.IncludeResource {
-						responseModel, responseDiags := NewEntryResourceModelFromResponse(ctx, item)
-						result.Diagnostics.Append(responseDiags...)
-
-						result.Diagnostics.Append(result.Resource.Set(ctx, &responseModel)...)
-					}
-
-					if !yield(result) {
-						return
-					}
-
-					emitted++
-				}
-
-				itemCount := int64(len(response.Items))
-				if itemCount == 0 {
-					return
-				}
-
-				skip += itemCount
-				if total, ok := response.Total.Get(); ok && skip >= int64(total) {
-					return
-				}
-
-			default:
-				yield(list.ListResult{
-					Diagnostics: diag.Diagnostics{
-						diag.NewErrorDiagnostic("Failed to list entries", util.ErrorDetailFromContentfulManagementResponse(response, err)),
-					},
-				})
-
-				return
-			}
-		}
+func setEntryListQueryParam(query url.Values, key string, value string) {
+	if key == "skip" || key == "limit" {
+		return
 	}
+
+	query.Set(key, value)
 }

--- a/internal/provider/list_resource_entry_test.go
+++ b/internal/provider/list_resource_entry_test.go
@@ -46,6 +46,8 @@ func TestAccEntryListResource(t *testing.T) {
 		"content_type":   config.StringVariable("author"),
 		"query": config.MapVariable(map[string]config.Variable{
 			"fields.name[ne]": config.StringVariable("nonexistent"),
+			"limit":           config.StringVariable("1"),
+			"skip":            config.StringVariable("100"),
 		}),
 	}
 

--- a/internal/provider/list_resource_entry_unit_test.go
+++ b/internal/provider/list_resource_entry_unit_test.go
@@ -1,0 +1,109 @@
+//nolint:testpackage
+package provider
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
+	"github.com/go-faster/jx"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryListResourceListIgnoresQueryPaginationParams(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, err := cmt.NewContentfulManagementServer()
+	require.NoError(t, err)
+
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	client, err := cm.NewClient(
+		httpServer.URL,
+		cm.NewAccessTokenSecuritySource(cmt.ValidAccessToken),
+		cm.WithClient(httpServer.Client()),
+	)
+	require.NoError(t, err)
+
+	server.SetEntry("space", "environment", "author", "entry-1", cm.EntryRequest{
+		Fields: cm.NewOptEntryFields(cm.EntryFields{
+			"name": jx.Raw(`"Entry 1"`),
+		}),
+	})
+
+	listResource := &entryListResource{
+		providerData: ContentfulProviderData{client: client},
+	}
+
+	var identitySchemaResponse resource.IdentitySchemaResponse
+	(&entryResource{}).IdentitySchema(ctx, resource.IdentitySchemaRequest{}, &identitySchemaResponse)
+
+	var stream list.ListResultsStream
+	listResource.List(ctx, list.ListRequest{
+		Config:                 newEntryListResourceConfig(ctx),
+		ResourceSchema:         EntryResourceSchema(ctx),
+		ResourceIdentitySchema: identitySchemaResponse.IdentitySchema,
+	}, &stream)
+
+	var results []list.ListResult
+
+	stream.Results(func(result list.ListResult) bool {
+		results = append(results, result)
+
+		return true
+	})
+
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Diagnostics.HasError())
+	assert.Equal(t, "entry-1", results[0].DisplayName)
+}
+
+func TestSetEntryListQueryParamSkipsPaginatorParams(t *testing.T) {
+	t.Parallel()
+
+	query := url.Values{}
+
+	setEntryListQueryParam(query, "fields.name[ne]", "nonexistent")
+	setEntryListQueryParam(query, "limit", "1")
+	setEntryListQueryParam(query, "skip", "100")
+
+	assert.Equal(t, url.Values{
+		"fields.name[ne]": []string{"nonexistent"},
+	}, query)
+}
+
+func newEntryListResourceConfig(ctx context.Context) tfsdk.Config {
+	schema := EntryListResourceConfigSchema(ctx)
+
+	return tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"space_id":       tftypes.String,
+				"environment_id": tftypes.String,
+				"content_type":   tftypes.String,
+				"order":          tftypes.List{ElementType: tftypes.String},
+				"query":          tftypes.Map{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"space_id":       tftypes.NewValue(tftypes.String, "space"),
+			"environment_id": tftypes.NewValue(tftypes.String, "environment"),
+			"content_type":   tftypes.NewValue(tftypes.String, "author"),
+			"order":          tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+			"query": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+				"limit": tftypes.NewValue(tftypes.String, "1"),
+				"skip":  tftypes.NewValue(tftypes.String, "100"),
+			}),
+		}),
+		Schema: schema,
+	}
+}

--- a/internal/provider/list_resource_pagination.go
+++ b/internal/provider/list_resource_pagination.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+)
+
+const defaultPageLimit int64 = 100
+
+type contentfulCollection[Item any] interface {
+	GetTotal() cm.OptInt
+	GetItems() []Item
+}
+
+func paginateContentfulCollectionItemsAsListResults[Item, Response any](
+	ctx context.Context,
+	req list.ListRequest,
+	errorTitle string,
+	fetchPage func(context.Context, int64, int64) (Response, error),
+	buildResult func(Item) list.ListResult,
+) func(func(list.ListResult) bool) {
+	return func(yield func(list.ListResult) bool) {
+		var (
+			emitted int64
+			skip    int64
+		)
+
+		for {
+			limit := defaultPageLimit
+
+			if req.Limit > 0 {
+				remaining := req.Limit - emitted
+				if remaining <= 0 {
+					return
+				}
+
+				limit = min(limit, remaining)
+			}
+
+			response, err := fetchPage(ctx, skip, limit)
+			if err != nil {
+				yield(list.ListResult{
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic(errorTitle, util.ErrorDetailFromContentfulManagementResponse(response, err)),
+					},
+				})
+
+				return
+			}
+
+			collection, ok := any(response).(contentfulCollection[Item])
+			if !ok {
+				yield(list.ListResult{
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic(errorTitle, contentfulListNonCollectionResponseDetail(response)),
+					},
+				})
+
+				return
+			}
+
+			items := collection.GetItems()
+			for _, item := range items {
+				if !yield(buildResult(item)) {
+					return
+				}
+
+				emitted++
+			}
+
+			itemCount := int64(len(items))
+			if itemCount == 0 {
+				return
+			}
+
+			skip += itemCount
+			if total, ok := collection.GetTotal().Get(); ok && skip >= int64(total) {
+				return
+			}
+		}
+	}
+}
+
+func contentfulListNonCollectionResponseDetail(response any) string {
+	if detail, ok := contentfulListErrorResponseDetail(response); ok {
+		return detail
+	}
+
+	return fmt.Sprintf("Unexpected response type %T while listing Contentful resources.", response)
+}
+
+func contentfulListErrorResponseDetail(response any) (string, bool) {
+	switch response.(type) {
+	case cm.ErrorStatusCodeResponse, cm.ErrorResponse:
+		return util.ErrorDetailFromContentfulManagementResponse(response, nil), true
+	default:
+		return "", false
+	}
+}

--- a/internal/provider/list_resource_pagination_test.go
+++ b/internal/provider/list_resource_pagination_test.go
@@ -1,0 +1,169 @@
+//nolint:testpackage
+package provider
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errTestContentfulUnavailable = errors.New("contentful unavailable")
+
+type testListCollection struct {
+	total cm.OptInt
+	items []int
+}
+
+func (c testListCollection) GetTotal() cm.OptInt {
+	return c.total
+}
+
+func (c testListCollection) GetItems() []int {
+	return c.items
+}
+
+type testListParams struct {
+	skip  int64
+	limit int64
+}
+
+func TestPaginateContentfulCollectionItemsAsListResultsPaginatesUntilTotal(t *testing.T) {
+	t.Parallel()
+
+	var requests []testListParams
+
+	results := collectTestListResults(t, paginateContentfulCollectionItemsAsListResults(
+		context.Background(),
+		list.ListRequest{},
+		"failed",
+		func(_ context.Context, skip int64, limit int64) (testListCollection, error) {
+			params := testListParams{skip: skip, limit: limit}
+			requests = append(requests, params)
+
+			switch params.skip {
+			case 0:
+				return testListCollection{total: cm.NewOptInt(3), items: []int{1, 2}}, nil
+			case 2:
+				return testListCollection{total: cm.NewOptInt(3), items: []int{3}}, nil
+			default:
+				t.Fatalf("unexpected skip %d", params.skip)
+
+				return testListCollection{}, nil
+			}
+		},
+		testListResult,
+	))
+
+	assert.Equal(t, []testListParams{
+		{skip: 0, limit: defaultPageLimit},
+		{skip: 2, limit: defaultPageLimit},
+	}, requests)
+	assert.Equal(t, []string{"1", "2", "3"}, results)
+}
+
+func TestPaginateContentfulCollectionItemsAsListResultsHonorsTerraformLimit(t *testing.T) {
+	t.Parallel()
+
+	var requests []testListParams
+
+	results := collectTestListResults(t, paginateContentfulCollectionItemsAsListResults(
+		context.Background(),
+		list.ListRequest{Limit: 2},
+		"failed",
+		func(_ context.Context, skip int64, limit int64) (testListCollection, error) {
+			requests = append(requests, testListParams{skip: skip, limit: limit})
+
+			return testListCollection{total: cm.NewOptInt(10), items: []int{1, 2}}, nil
+		},
+		testListResult,
+	))
+
+	assert.Equal(t, []testListParams{{skip: 0, limit: 2}}, requests)
+	assert.Equal(t, []string{"1", "2"}, results)
+}
+
+func TestPaginateContentfulCollectionItemsAsListResultsReturnsFetchDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	results := collectTestListResults(t, paginateContentfulCollectionItemsAsListResults(
+		context.Background(),
+		list.ListRequest{},
+		"failed",
+		func(context.Context, int64, int64) (testListCollection, error) {
+			return testListCollection{}, errTestContentfulUnavailable
+		},
+		testListResult,
+	))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "diagnostic: contentful unavailable", results[0])
+}
+
+func TestPaginateContentfulCollectionItemsAsListResultsReturnsUnexpectedResponseDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	results := collectTestListResults(t, paginateContentfulCollectionItemsAsListResults(
+		context.Background(),
+		list.ListRequest{},
+		"failed",
+		func(context.Context, int64, int64) (any, error) {
+			return struct{}{}, nil
+		},
+		testListResult,
+	))
+
+	require.Len(t, results, 1)
+	assert.Contains(t, results[0], "diagnostic: Unexpected response type")
+}
+
+func TestPaginateContentfulCollectionItemsAsListResultsReturnsContentfulErrorDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	results := collectTestListResults(t, paginateContentfulCollectionItemsAsListResults(
+		context.Background(),
+		list.ListRequest{},
+		"failed",
+		func(context.Context, int64, int64) (any, error) {
+			return &cm.ApplicationVndContentfulManagementV1JSONErrorStatusCode{
+				Response: cm.NewErrorApplicationVndContentfulManagementV1JSONError(cm.Error{
+					Sys:     cm.NewErrorSys("NotFound"),
+					Message: cm.NewOptString("Environment not found"),
+				}),
+			}, nil
+		},
+		testListResult,
+	))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "diagnostic: Error: NotFound: Environment not found", results[0])
+}
+
+func collectTestListResults(t *testing.T, stream func(func(list.ListResult) bool)) []string {
+	t.Helper()
+
+	var results []string
+
+	stream(func(result list.ListResult) bool {
+		if result.Diagnostics.HasError() {
+			results = append(results, "diagnostic: "+result.Diagnostics.Errors()[0].Detail())
+
+			return true
+		}
+
+		results = append(results, result.DisplayName)
+
+		return true
+	})
+
+	return results
+}
+
+func testListResult(item int) list.ListResult {
+	return list.ListResult{DisplayName: strconv.Itoa(item)}
+}


### PR DESCRIPTION
## Summary
- page entry and content type list resources with Contentful skip/limit parameters
- stop listing when Terraform's limit is met or the API total has been exhausted
- make the fake content type handler honor skip/limit and cover it with a unit test

## Validation
- go test ./internal/contentful-management-go/testing -run TestGetContentTypesPaginates -count=1
- go test ./internal/provider -run 'TestAcc(ContentTypeListResource|EntryListResource)' -count=1
- TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -run 'TestAcc(ContentTypeListResource|EntryListResource)' -count=1