### PR TITLE
test(provider/entry): cover localised entry fields

### DIFF
--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -20,12 +20,15 @@ resource "contentful_entry" "example" {
 
   fields = {
     title = jsonencode({
+      "en-AU" = "My First Blog Post"
       "en-US" = "My First Blog Post"
     })
     body = jsonencode({
+      "en-AU" = "This is the content of my first blog post."
       "en-US" = "This is the content of my first blog post."
     })
     slug = jsonencode({
+      "en-AU" = "my-first-blog-post"
       "en-US" = "my-first-blog-post"
     })
   }

--- a/examples/resources/contentful_entry/resource.tf
+++ b/examples/resources/contentful_entry/resource.tf
@@ -5,12 +5,15 @@ resource "contentful_entry" "example" {
 
   fields = {
     title = jsonencode({
+      "en-AU" = "My First Blog Post"
       "en-US" = "My First Blog Post"
     })
     body = jsonencode({
+      "en-AU" = "This is the content of my first blog post."
       "en-US" = "This is the content of my first blog post."
     })
     slug = jsonencode({
+      "en-AU" = "my-first-blog-post"
       "en-US" = "my-first-blog-post"
     })
   }

--- a/internal/provider/resource_entry_test.go
+++ b/internal/provider/resource_entry_test.go
@@ -1,7 +1,11 @@
 package provider_test
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"maps"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -13,6 +17,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	errInvalidExpectedJSON = errors.New("invalid expected JSON")
+	errInvalidActualJSON   = errors.New("invalid actual JSON")
+	errJSONNotEqual        = errors.New("JSON values are not equal")
 )
 
 func TestAccEntryResourceImport(t *testing.T) {
@@ -186,7 +196,8 @@ func TestAccEntryResourceCreate(t *testing.T) {
 		"environment_id":  config.StringVariable("test"),
 		"content_type_id": config.StringVariable("author"),
 		"fields": config.MapVariable(map[string]config.Variable{
-			"name": config.StringVariable(`{"en-AU":"name"}`),
+			"name":  config.StringVariable(`{"en-AU":"name"}`),
+			"blurb": config.StringVariable(`{"en-AU":{"nodeType":"document","data":{},"content":[]}}`),
 		}),
 	}
 
@@ -195,6 +206,16 @@ func TestAccEntryResourceCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("contentful_entry.test", tfjsonpath.New("fields"), knownvalue.MapExact(map[string]knownvalue.Check{
+							"name": knownvalue.StringExact(`{"en-AU":"name"}`),
+							"blurb": knownvalue.StringFunc(func(actual string) error {
+								return checkJSONEqual(`{"en-AU":{"nodeType":"document","data":{},"content":[]}}`, actual)
+							}),
+						})),
+					},
+				},
 			},
 		},
 	})
@@ -428,6 +449,28 @@ func TestAccEntryResourceMissingFields(t *testing.T) {
 			},
 		},
 	})
+}
+
+func checkJSONEqual(expected string, actual string) error {
+	var expectedJSON any
+
+	err := json.Unmarshal([]byte(expected), &expectedJSON)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errInvalidExpectedJSON, err)
+	}
+
+	var actualJSON any
+
+	err = json.Unmarshal([]byte(actual), &actualJSON)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errInvalidActualJSON, err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		return fmt.Errorf("%w: expected %s, got %s", errJSONNotEqual, expected, actual)
+	}
+
+	return nil
 }
 
 //nolint:dupl


### PR DESCRIPTION
## Summary

- expands the contentful_entry example to show multiple locale values per field
- adds mocked acceptance coverage for localised scalar and rich text entry fields
- regenerates the generated entry resource docs

## Validation

- go test ./internal/provider -run 'TestAccEntryResource(Create|Update|ImportWhitespaceDiff|ImportPropertyOrderDiff|MissingFields)$' -count=1
- go test ./...
