### PR TITLE
feat(provider/entry): encode localised entry fields in schema

### DIFF
--- a/cmd/terraform-provider-contentful-migrate/main.go
+++ b/cmd/terraform-provider-contentful-migrate/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/cysp/terraform-provider-contentful/internal/migrate"
+)
+
+const checkFailedExitCode = 2
+
+func main() {
+	var write bool
+
+	var check bool
+
+	flag.BoolVar(&write, "write", false, "rewrite files in place")
+	flag.BoolVar(&check, "check", false, "exit non-zero when migrations would change files")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags] [path ...]\n\n", os.Args[0])
+		fmt.Fprintln(flag.CommandLine.Output(), "Migrates Terraform configuration for terraform-provider-contentful schema changes.")
+		fmt.Fprintln(flag.CommandLine.Output(), "When no paths are provided, the current directory is scanned recursively.")
+		fmt.Fprintln(flag.CommandLine.Output(), "\nFlags:")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	paths := flag.Args()
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	report, err := migrate.Run(context.Background(), migrate.Options{
+		Paths: paths,
+		Write: write,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	for _, change := range report.Changes {
+		action := "would update"
+		if write {
+			action = "updated"
+		}
+
+		fmt.Fprintf(os.Stdout, "%s: %s: %s\n", action, change.Path, change.Description)
+	}
+
+	for _, skip := range report.Skips {
+		fmt.Fprintf(os.Stderr, "skipped: %s: %s: %s\n", skip.Path, skip.Address, skip.Reason)
+	}
+
+	if check && !write && len(report.Changes) > 0 {
+		os.Exit(checkFailedExitCode)
+	}
+}

--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -46,12 +46,12 @@ resource "contentful_entry" "example" {
 
 - `content_type_id` (String) ID of the content type for this entry.
 - `environment_id` (String) ID of the environment containing the entry.
-- `fields` (Map of Map of String) Fields that are custom defined by a user through the definition of content types, keyed by field ID and locale.
 - `space_id` (String) ID of the space containing the entry.
 
 ### Optional
 
 - `entry_id` (String) ID of the entry.
+- `fields` (Map of Map of String) Fields that are custom defined by a user through the definition of content types, keyed by field ID and locale.
 - `metadata` (Attributes) Metadata for the entry. Once set, metadata properties may not be removed, but the list of tags may be reduced to the empty list (see [below for nested schema](#nestedatt--metadata))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -19,18 +19,18 @@ resource "contentful_entry" "example" {
   content_type_id = "blogPost"
 
   fields = {
-    title = jsonencode({
-      "en-AU" = "My First Blog Post"
-      "en-US" = "My First Blog Post"
-    })
-    body = jsonencode({
-      "en-AU" = "This is the content of my first blog post."
-      "en-US" = "This is the content of my first blog post."
-    })
-    slug = jsonencode({
-      "en-AU" = "my-first-blog-post"
-      "en-US" = "my-first-blog-post"
-    })
+    title = {
+      "en-AU" = jsonencode("My First Blog Post")
+      "en-US" = jsonencode("My First Blog Post")
+    }
+    body = {
+      "en-AU" = jsonencode("This is the content of my first blog post.")
+      "en-US" = jsonencode("This is the content of my first blog post.")
+    }
+    slug = {
+      "en-AU" = jsonencode("my-first-blog-post")
+      "en-US" = jsonencode("my-first-blog-post")
+    }
   }
 
   metadata = {
@@ -46,7 +46,7 @@ resource "contentful_entry" "example" {
 
 - `content_type_id` (String) ID of the content type for this entry.
 - `environment_id` (String) ID of the environment containing the entry.
-- `fields` (Map of String) Fields that are custom defined by a user through the definition of content types. Fields object always includes locale.
+- `fields` (Map of Map of String) Fields that are custom defined by a user through the definition of content types, keyed by field ID and locale.
 - `space_id` (String) ID of the space containing the entry.
 
 ### Optional

--- a/examples/resources/contentful_entry/resource.tf
+++ b/examples/resources/contentful_entry/resource.tf
@@ -4,18 +4,18 @@ resource "contentful_entry" "example" {
   content_type_id = "blogPost"
 
   fields = {
-    title = jsonencode({
-      "en-AU" = "My First Blog Post"
-      "en-US" = "My First Blog Post"
-    })
-    body = jsonencode({
-      "en-AU" = "This is the content of my first blog post."
-      "en-US" = "This is the content of my first blog post."
-    })
-    slug = jsonencode({
-      "en-AU" = "my-first-blog-post"
-      "en-US" = "my-first-blog-post"
-    })
+    title = {
+      "en-AU" = jsonencode("My First Blog Post")
+      "en-US" = jsonencode("My First Blog Post")
+    }
+    body = {
+      "en-AU" = jsonencode("This is the content of my first blog post.")
+      "en-US" = jsonencode("This is the content of my first blog post.")
+    }
+    slug = {
+      "en-AU" = jsonencode("my-first-blog-post")
+      "en-US" = jsonencode("my-first-blog-post")
+    }
   }
 
   metadata = {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
@@ -17,6 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/ogen-go/ogen v1.20.3
 	github.com/stretchr/testify v1.11.1
+	github.com/zclconf/go-cty v1.18.1
 	golang.org/x/sync v0.20.0
 	pgregory.net/rapid v1.3.0
 )
@@ -57,7 +59,6 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.5 // indirect
-	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.2 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
@@ -91,7 +92,6 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yuin/goldmark-meta v1.1.0 // indirect
-	github.com/zclconf/go-cty v1.18.1 // indirect
 	go.abhg.dev/goldmark/frontmatter v0.3.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect

--- a/internal/migrate/entry_fields.go
+++ b/internal/migrate/entry_fields.go
@@ -1,0 +1,284 @@
+package migrate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const entryFieldsMigrationDescription = "contentful_entry.fields from map(json) to map(map(json))"
+
+var (
+	errInvalidExpressionRange = errors.New("invalid expression range")
+	errLexExpression          = errors.New("lex expression")
+	errParseConfig            = errors.New("parse config")
+	errParseFieldsExpression  = errors.New("parse contentful_entry.fields expression")
+)
+
+type entryFieldsMigration struct{}
+
+func (m entryFieldsMigration) Apply(path string, src []byte) ([]byte, fileReport, error) {
+	file, diags := hclwrite.ParseConfig(src, path, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fileReport{}, fmt.Errorf("%w: %s: %s", errParseConfig, path, diags.Error())
+	}
+
+	report := fileReport{}
+
+	for _, block := range file.Body().Blocks() {
+		change, skip, migrated, err := migrateEntryBlock(path, block)
+		if err != nil {
+			return nil, fileReport{}, err
+		}
+
+		if skip != nil {
+			report.Skips = append(report.Skips, *skip)
+		}
+
+		if migrated {
+			report.Changes = append(report.Changes, change)
+		}
+	}
+
+	if len(report.Changes) == 0 {
+		return src, report, nil
+	}
+
+	return hclwrite.Format(file.Bytes()), report, nil
+}
+
+func migrateEntryBlock(path string, block *hclwrite.Block) (Change, *Skip, bool, error) {
+	if block.Type() != "resource" {
+		return Change{}, nil, false, nil
+	}
+
+	labels := block.Labels()
+	if len(labels) != 2 || labels[0] != "contentful_entry" {
+		return Change{}, nil, false, nil
+	}
+
+	address := fmt.Sprintf("%s.%s", labels[0], labels[1])
+
+	fields := block.Body().GetAttribute("fields")
+	if fields == nil {
+		return Change{}, nil, false, nil
+	}
+
+	fieldTokens, migrated, skip, err := migrateEntryFieldsAttribute(path, address, fields)
+	if err != nil {
+		return Change{}, nil, false, err
+	}
+
+	if skip != nil {
+		return Change{}, skip, false, nil
+	}
+
+	if !migrated {
+		return Change{}, nil, false, nil
+	}
+
+	block.Body().SetAttributeRaw("fields", fieldTokens)
+
+	return Change{
+		Path:        path,
+		Description: fmt.Sprintf("%s on %s", entryFieldsMigrationDescription, address),
+	}, nil, true, nil
+}
+
+func migrateEntryFieldsAttribute(path string, address string, fields *hclwrite.Attribute) (hclwrite.Tokens, bool, *Skip, error) {
+	exprBytes := fields.Expr().BuildTokens(nil).Bytes()
+
+	expr, diags := hclsyntax.ParseExpression(exprBytes, path, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, false, nil, fmt.Errorf("%w: %s %s: %s", errParseFieldsExpression, path, address, diags.Error())
+	}
+
+	fieldsObject, ok := expr.(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return nil, false, &Skip{
+			Path:    path,
+			Address: address,
+			Reason:  "fields is not a literal object expression",
+		}, nil
+	}
+
+	fieldAttrs := make([]hclwrite.ObjectAttrTokens, 0, len(fieldsObject.Items))
+	changed := false
+
+	for _, field := range fieldsObject.Items {
+		fieldAttr, fieldChanged, skip, err := migrateEntryField(path, address, exprBytes, field)
+		if err != nil {
+			return nil, false, nil, err
+		}
+
+		if skip != nil {
+			return nil, false, skip, nil
+		}
+
+		fieldAttrs = append(fieldAttrs, fieldAttr)
+		changed = changed || fieldChanged
+	}
+
+	if !changed {
+		return nil, false, nil, nil
+	}
+
+	return hclwrite.TokensForObject(fieldAttrs), true, nil, nil
+}
+
+func migrateEntryField(
+	path string,
+	address string,
+	exprBytes []byte,
+	field hclsyntax.ObjectConsItem,
+) (hclwrite.ObjectAttrTokens, bool, *Skip, error) {
+	fieldKey, keyStatic := staticObjectKey(field.KeyExpr)
+	if !keyStatic {
+		return hclwrite.ObjectAttrTokens{}, false, &Skip{
+			Path:    path,
+			Address: address,
+			Reason:  "fields contains a dynamic field key",
+		}, nil
+	}
+
+	fieldName, err := expressionTokens(exprBytes, field.KeyExpr)
+	if err != nil {
+		return hclwrite.ObjectAttrTokens{}, false, nil, fmt.Errorf("read %s %s fields.%s key: %w", path, address, fieldKey, err)
+	}
+
+	fieldObject, alreadyMigrated := field.ValueExpr.(*hclsyntax.ObjectConsExpr)
+	if alreadyMigrated {
+		fieldValue, err := expressionTokens(exprBytes, fieldObject)
+		if err != nil {
+			return hclwrite.ObjectAttrTokens{}, false, nil, fmt.Errorf("read %s %s fields.%s value: %w", path, address, fieldKey, err)
+		}
+
+		return hclwrite.ObjectAttrTokens{
+			Name:  fieldName,
+			Value: fieldValue,
+		}, false, nil, nil
+	}
+
+	localesObject, skip := jsonEncodedLocaleObject(path, address, fieldKey, field.ValueExpr)
+	if skip != nil {
+		return hclwrite.ObjectAttrTokens{}, false, skip, nil
+	}
+
+	localeAttrs, skip, err := migrateEntryFieldLocales(path, address, fieldKey, exprBytes, localesObject)
+	if err != nil {
+		return hclwrite.ObjectAttrTokens{}, false, nil, err
+	}
+
+	if skip != nil {
+		return hclwrite.ObjectAttrTokens{}, false, skip, nil
+	}
+
+	return hclwrite.ObjectAttrTokens{
+		Name:  fieldName,
+		Value: hclwrite.TokensForObject(localeAttrs),
+	}, true, nil, nil
+}
+
+func jsonEncodedLocaleObject(path string, address string, fieldKey string, value hclsyntax.Expression) (*hclsyntax.ObjectConsExpr, *Skip) {
+	call, isFunctionCall := value.(*hclsyntax.FunctionCallExpr)
+	if !isFunctionCall || call.Name != "jsonencode" || call.ExpandFinal || len(call.Args) != 1 {
+		return nil, &Skip{
+			Path:    path,
+			Address: address,
+			Reason:  fmt.Sprintf("fields.%s is not a direct jsonencode({...}) expression", fieldKey),
+		}
+	}
+
+	localesObject, ok := call.Args[0].(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return nil, &Skip{
+			Path:    path,
+			Address: address,
+			Reason:  fmt.Sprintf("fields.%s jsonencode argument is not a literal locale object", fieldKey),
+		}
+	}
+
+	return localesObject, nil
+}
+
+func migrateEntryFieldLocales(
+	path string,
+	address string,
+	fieldKey string,
+	exprBytes []byte,
+	localesObject *hclsyntax.ObjectConsExpr,
+) ([]hclwrite.ObjectAttrTokens, *Skip, error) {
+	localeAttrs := make([]hclwrite.ObjectAttrTokens, 0, len(localesObject.Items))
+
+	for _, locale := range localesObject.Items {
+		localeKey, keyStatic := staticObjectKey(locale.KeyExpr)
+		if !keyStatic {
+			return nil, &Skip{
+				Path:    path,
+				Address: address,
+				Reason:  fmt.Sprintf("fields.%s contains a dynamic locale key", fieldKey),
+			}, nil
+		}
+
+		localeName, err := expressionTokens(exprBytes, locale.KeyExpr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s %s fields.%s.%s key: %w", path, address, fieldKey, localeKey, err)
+		}
+
+		localeValue, err := expressionTokens(exprBytes, locale.ValueExpr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s %s fields.%s.%s value: %w", path, address, fieldKey, localeKey, err)
+		}
+
+		localeAttrs = append(localeAttrs, hclwrite.ObjectAttrTokens{
+			Name:  localeName,
+			Value: hclwrite.TokensForFunctionCall("jsonencode", localeValue),
+		})
+	}
+
+	return localeAttrs, nil, nil
+}
+
+func staticObjectKey(expr hclsyntax.Expression) (string, bool) {
+	value, diags := expr.Value(nil)
+	if diags.HasErrors() || !value.IsKnown() || value.Type() != cty.String {
+		return "", false
+	}
+
+	return value.AsString(), true
+}
+
+func expressionTokens(src []byte, expr hclsyntax.Expression) (hclwrite.Tokens, error) {
+	exprRange := expr.Range()
+	if exprRange.Start.Byte < 0 || exprRange.End.Byte > len(src) || exprRange.Start.Byte > exprRange.End.Byte {
+		return nil, fmt.Errorf("%w: %d:%d", errInvalidExpressionRange, exprRange.Start.Byte, exprRange.End.Byte)
+	}
+
+	tokens, diags := hclsyntax.LexExpression(src[exprRange.Start.Byte:exprRange.End.Byte], exprRange.Filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("%w: %s", errLexExpression, diags.Error())
+	}
+
+	return hclwriteTokens(tokens), nil
+}
+
+func hclwriteTokens(tokens hclsyntax.Tokens) hclwrite.Tokens {
+	result := make(hclwrite.Tokens, 0, len(tokens))
+
+	for _, token := range tokens {
+		if token.Type == hclsyntax.TokenEOF {
+			continue
+		}
+
+		result = append(result, &hclwrite.Token{
+			Type:  token.Type,
+			Bytes: token.Bytes,
+		})
+	}
+
+	return result
+}

--- a/internal/migrate/entry_fields_test.go
+++ b/internal/migrate/entry_fields_test.go
@@ -1,0 +1,203 @@
+package migrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cysp/terraform-provider-contentful/internal/migrate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMigratesContentfulEntryFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.tf")
+	require.NoError(t, os.WriteFile(path, []byte(`
+resource "contentful_entry" "example" {
+  space_id        = var.space_id
+  environment_id  = var.environment_id
+  content_type_id = "blogPost"
+
+  fields = {
+    title = jsonencode({
+      "en-AU" = "My First Blog Post"
+      "en-US" = upper(var.title)
+    })
+    body = jsonencode({
+      "en-AU" = {
+        nodeType = "document"
+        data     = {}
+        content  = []
+      }
+    })
+  }
+}
+`), 0o600))
+
+	report, err := migrate.Run(context.Background(), migrate.Options{
+		Paths: []string{path},
+		Write: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Changes, 1)
+	assert.Empty(t, report.Skips)
+
+	gotBytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	got := string(gotBytes)
+
+	assert.Contains(t, got, `"en-AU" = jsonencode("My First Blog Post")`)
+	assert.Contains(t, got, `"en-US" = jsonencode(upper(var.title))`)
+	assert.Contains(t, got, `body = {`)
+	assert.NotContains(t, got, `title = jsonencode({`)
+}
+
+func TestRunDryRunDoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.tf")
+	original := []byte(`
+resource "contentful_entry" "example" {
+  fields = {
+    title = jsonencode({
+      "en-AU" = "Title"
+    })
+  }
+}
+`)
+	require.NoError(t, os.WriteFile(path, original, 0o600))
+
+	report, err := migrate.Run(context.Background(), migrate.Options{Paths: []string{path}})
+	require.NoError(t, err)
+	require.Len(t, report.Changes, 1)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(original), string(got))
+}
+
+func TestRunSkipsDynamicFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.tf")
+	require.NoError(t, os.WriteFile(path, []byte(`
+resource "contentful_entry" "example" {
+  fields = var.fields
+}
+`), 0o600))
+
+	report, err := migrate.Run(context.Background(), migrate.Options{
+		Paths: []string{path},
+		Write: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, report.Changes)
+	require.Len(t, report.Skips, 1)
+	assert.Equal(t, "contentful_entry.example", report.Skips[0].Address)
+	assert.Contains(t, report.Skips[0].Reason, "literal object")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "fields = var.fields")
+}
+
+func TestRunSkipsPartiallyMigratableResource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.tf")
+	original := `
+resource "contentful_entry" "example" {
+  fields = {
+    title = jsonencode({
+      "en-AU" = "Title"
+    })
+    body = var.body
+  }
+}
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	report, err := migrate.Run(context.Background(), migrate.Options{
+		Paths: []string{path},
+		Write: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, report.Changes)
+	require.Len(t, report.Skips, 1)
+	assert.Contains(t, report.Skips[0].Reason, "fields.body")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(original), strings.TrimSpace(string(got)))
+}
+
+func TestRunDoesNotReportAlreadyMigratedFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.tf")
+	original := `
+resource "contentful_entry" "example" {
+  fields = {
+    title = {
+      "en-AU" = jsonencode("Title")
+    }
+  }
+}
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	report, err := migrate.Run(context.Background(), migrate.Options{
+		Paths: []string{path},
+		Write: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, report.Changes)
+	assert.Empty(t, report.Skips)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(original), strings.TrimSpace(string(got)))
+}
+
+func TestRunMigratesMixedOldAndNewLiteralFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.tf")
+	require.NoError(t, os.WriteFile(path, []byte(`
+resource "contentful_entry" "example" {
+  fields = {
+    title = jsonencode({
+      "en-AU" = "Title"
+    })
+    slug = {
+      "en-AU" = jsonencode("title")
+    }
+  }
+}
+`), 0o600))
+
+	report, err := migrate.Run(context.Background(), migrate.Options{
+		Paths: []string{path},
+		Write: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Changes, 1)
+	assert.Empty(t, report.Skips)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `"en-AU" = jsonencode("Title")`)
+	assert.Contains(t, string(got), `"en-AU" = jsonencode("title")`)
+	assert.NotContains(t, string(got), `title = jsonencode({`)
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,152 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+type Options struct {
+	Paths []string
+	Write bool
+}
+
+type Report struct {
+	Changes []Change
+	Skips   []Skip
+}
+
+type Change struct {
+	Path        string
+	Description string
+}
+
+type Skip struct {
+	Path    string
+	Address string
+	Reason  string
+}
+
+type fileReport struct {
+	Changes []Change
+	Skips   []Skip
+}
+
+type migration interface {
+	Apply(path string, src []byte) ([]byte, fileReport, error)
+}
+
+func Run(ctx context.Context, options Options) (Report, error) {
+	if len(options.Paths) == 0 {
+		options.Paths = []string{"."}
+	}
+
+	migrations := []migration{
+		entryFieldsMigration{},
+	}
+
+	files, err := terraformFiles(options.Paths)
+	if err != nil {
+		return Report{}, err
+	}
+
+	report := Report{}
+
+	for _, path := range files {
+		err := ctx.Err()
+		if err != nil {
+			return report, fmt.Errorf("migration cancelled: %w", err)
+		}
+
+		original, err := os.ReadFile(path)
+		if err != nil {
+			return report, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		next := slices.Clone(original)
+		fileReport := fileReport{}
+
+		for _, migration := range migrations {
+			migrated, migrationReport, err := migration.Apply(path, next)
+			if err != nil {
+				return report, fmt.Errorf("apply migration to %s: %w", path, err)
+			}
+
+			next = migrated
+
+			fileReport.Changes = append(fileReport.Changes, migrationReport.Changes...)
+			fileReport.Skips = append(fileReport.Skips, migrationReport.Skips...)
+		}
+
+		report.Changes = append(report.Changes, fileReport.Changes...)
+		report.Skips = append(report.Skips, fileReport.Skips...)
+
+		if options.Write && !bytes.Equal(original, next) {
+			info, err := os.Stat(path)
+			if err != nil {
+				return report, fmt.Errorf("stat %s: %w", path, err)
+			}
+
+			//nolint:gosec // This CLI intentionally writes user-selected Terraform files.
+			err = os.WriteFile(path, next, info.Mode())
+			if err != nil {
+				return report, fmt.Errorf("write %s: %w", path, err)
+			}
+		}
+	}
+
+	return report, nil
+}
+
+func terraformFiles(paths []string) ([]string, error) {
+	var files []string
+
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, err)
+		}
+
+		if !info.IsDir() {
+			if strings.HasSuffix(path, ".tf") {
+				files = append(files, path)
+			}
+
+			continue
+		}
+
+		err = filepath.WalkDir(path, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if entry.IsDir() {
+				switch entry.Name() {
+				case ".git", ".terraform":
+					return filepath.SkipDir
+				}
+
+				return nil
+			}
+
+			if strings.HasSuffix(path, ".tf") {
+				files = append(files, path)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("walk %s: %w", path, err)
+		}
+	}
+
+	slices.Sort(files)
+	files = slices.Compact(files)
+
+	return files, nil
+}

--- a/internal/provider/entry_model.go
+++ b/internal/provider/entry_model.go
@@ -26,8 +26,8 @@ type EntryModel struct {
 
 	ContentTypeID types.String `tfsdk:"content_type_id"`
 
-	Fields   TypedMap[jsontypes.Normalized]  `tfsdk:"fields"`
-	Metadata TypedObject[EntryMetadataValue] `tfsdk:"metadata"`
+	Fields   TypedMap[TypedMap[jsontypes.Normalized]] `tfsdk:"fields"`
+	Metadata TypedObject[EntryMetadataValue]          `tfsdk:"metadata"`
 
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/provider/entry_model_fields_test.go
+++ b/internal/provider/entry_model_fields_test.go
@@ -56,14 +56,13 @@ func TestEntryModelToOptEntryFieldsReportsInvalidLocalizedJSON(t *testing.T) {
 	assert.Equal(t, path.Root("fields").AtMapKey("title").AtMapKey("en-AU").String(), diagWithPath.Path().String())
 }
 
-func TestNewEntryFieldsFromResponseReturnsEmptyMapForUnsetFields(t *testing.T) {
+func TestNewEntryFieldsFromResponseReturnsNullForUnsetFields(t *testing.T) {
 	t.Parallel()
 
 	fields, diags := NewEntryFieldsFromResponse(context.Background(), path.Root("fields"), cm.OptEntryFields{})
 
 	require.False(t, diags.HasError())
-	assert.False(t, fields.IsNull())
-	assert.Empty(t, fields.Elements())
+	assert.True(t, fields.IsNull())
 }
 
 func TestNewEntryFieldsFromResponseSkipsInvalidLocalizedFields(t *testing.T) {

--- a/internal/provider/entry_model_fields_test.go
+++ b/internal/provider/entry_model_fields_test.go
@@ -35,6 +35,20 @@ func TestEntryModelToOptEntryFieldsSkipsNullUnknownAndEncodesLocalizedValues(t *
 	assert.NotContains(t, fields.Value, "ignored-unknown")
 }
 
+func TestEntryModelToOptEntryFieldsPreservesNullFieldValue(t *testing.T) {
+	t.Parallel()
+
+	fields, diags := entryModelToOptEntryFields(context.Background(), EntryModel{
+		Fields: NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{
+			"title": NewTypedMapNull[jsontypes.Normalized](),
+		}),
+	})
+
+	require.False(t, diags.HasError())
+	require.True(t, fields.IsSet())
+	assert.Equal(t, "null", string(fields.Value["title"]))
+}
+
 func TestEntryModelToOptEntryFieldsReportsInvalidLocalizedJSON(t *testing.T) {
 	t.Parallel()
 
@@ -89,5 +103,14 @@ func TestNewEntryLocalizedFieldFromRawReportsInvalidLocalizedJSON(t *testing.T) 
 	field, diags := NewEntryLocalizedFieldFromRaw(path.Root("fields").AtMapKey("title"), []byte(`invalid`))
 
 	require.True(t, diags.HasError())
+	assert.True(t, field.IsNull())
+}
+
+func TestNewEntryLocalizedFieldFromRawPreservesNull(t *testing.T) {
+	t.Parallel()
+
+	field, diags := NewEntryLocalizedFieldFromRaw(path.Root("fields").AtMapKey("title"), []byte(`null`))
+
+	require.False(t, diags.HasError())
 	assert.True(t, field.IsNull())
 }

--- a/internal/provider/entry_model_fields_test.go
+++ b/internal/provider/entry_model_fields_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEntryModelToOptEntryFieldsSkipsNullUnknownAndEncodesLocalizedValues(t *testing.T) {
+func TestEntryModelToOptEntryFieldsPreservesNullAndSkipsUnknownValues(t *testing.T) {
 	t.Parallel()
 
 	fields, diags := entryModelToOptEntryFields(context.Background(), EntryModel{

--- a/internal/provider/entry_model_fields_test.go
+++ b/internal/provider/entry_model_fields_test.go
@@ -7,6 +7,7 @@ import (
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,15 +49,21 @@ func TestEntryModelToOptEntryFieldsReportsInvalidLocalizedJSON(t *testing.T) {
 	require.True(t, diags.HasError())
 	require.True(t, fields.IsSet())
 	assert.Empty(t, fields.Value)
+	require.Len(t, diags, 1)
+
+	diagWithPath, ok := diags[0].(diag.DiagnosticWithPath)
+	require.True(t, ok)
+	assert.Equal(t, path.Root("fields").AtMapKey("title").AtMapKey("en-AU").String(), diagWithPath.Path().String())
 }
 
-func TestNewEntryFieldsFromResponseReturnsNullForUnsetFields(t *testing.T) {
+func TestNewEntryFieldsFromResponseReturnsEmptyMapForUnsetFields(t *testing.T) {
 	t.Parallel()
 
 	fields, diags := NewEntryFieldsFromResponse(context.Background(), path.Root("fields"), cm.OptEntryFields{})
 
 	require.False(t, diags.HasError())
-	assert.True(t, fields.IsNull())
+	assert.False(t, fields.IsNull())
+	assert.Empty(t, fields.Elements())
 }
 
 func TestNewEntryFieldsFromResponseSkipsInvalidLocalizedFields(t *testing.T) {

--- a/internal/provider/entry_model_fields_test.go
+++ b/internal/provider/entry_model_fields_test.go
@@ -31,7 +31,7 @@ func TestEntryModelToOptEntryFieldsPreservesNullAndSkipsUnknownValues(t *testing
 	require.False(t, diags.HasError())
 	require.True(t, fields.IsSet())
 	assert.JSONEq(t, `{"en-AU":"Title"}`, string(fields.Value["title"]))
-	assert.NotContains(t, fields.Value, "ignored-null")
+	assert.Equal(t, "null", string(fields.Value["ignored-null"]))
 	assert.NotContains(t, fields.Value, "ignored-unknown")
 }
 

--- a/internal/provider/entry_model_fields_test.go
+++ b/internal/provider/entry_model_fields_test.go
@@ -1,0 +1,87 @@
+//nolint:testpackage
+package provider
+
+import (
+	"context"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryModelToOptEntryFieldsSkipsNullUnknownAndEncodesLocalizedValues(t *testing.T) {
+	t.Parallel()
+
+	fields, diags := entryModelToOptEntryFields(context.Background(), EntryModel{
+		Fields: NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{
+			"title": NewTypedMap(map[string]jsontypes.Normalized{
+				"en-AU": NewNormalizedJSONTypesNormalizedValue([]byte(`"Title"`)),
+				"en-US": jsontypes.NewNormalizedNull(),
+				"fr-FR": jsontypes.NewNormalizedUnknown(),
+			}),
+			"ignored-null":    NewTypedMapNull[jsontypes.Normalized](),
+			"ignored-unknown": NewTypedMapUnknown[jsontypes.Normalized](),
+		}),
+	})
+
+	require.False(t, diags.HasError())
+	require.True(t, fields.IsSet())
+	assert.JSONEq(t, `{"en-AU":"Title"}`, string(fields.Value["title"]))
+	assert.NotContains(t, fields.Value, "ignored-null")
+	assert.NotContains(t, fields.Value, "ignored-unknown")
+}
+
+func TestEntryModelToOptEntryFieldsReportsInvalidLocalizedJSON(t *testing.T) {
+	t.Parallel()
+
+	fields, diags := entryModelToOptEntryFields(context.Background(), EntryModel{
+		Fields: NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{
+			"title": NewTypedMap(map[string]jsontypes.Normalized{
+				"en-AU": NewNormalizedJSONTypesNormalizedValue([]byte(`invalid`)),
+			}),
+		}),
+	})
+
+	require.True(t, diags.HasError())
+	require.True(t, fields.IsSet())
+	assert.Empty(t, fields.Value)
+}
+
+func TestNewEntryFieldsFromResponseReturnsNullForUnsetFields(t *testing.T) {
+	t.Parallel()
+
+	fields, diags := NewEntryFieldsFromResponse(context.Background(), path.Root("fields"), cm.OptEntryFields{})
+
+	require.False(t, diags.HasError())
+	assert.True(t, fields.IsNull())
+}
+
+func TestNewEntryFieldsFromResponseSkipsInvalidLocalizedFields(t *testing.T) {
+	t.Parallel()
+
+	fields, diags := NewEntryFieldsFromResponse(
+		context.Background(),
+		path.Root("fields"),
+		cm.NewOptEntryFields(cm.EntryFields{
+			"title": []byte(`[]`),
+			"name":  []byte(`{"en-AU":"Name"}`),
+		}),
+	)
+
+	require.True(t, diags.HasError())
+	require.False(t, fields.IsNull())
+	assert.NotContains(t, fields.Elements(), "title")
+	assert.Equal(t, `"Name"`, fields.Elements()["name"].Elements()["en-AU"].ValueString())
+}
+
+func TestNewEntryLocalizedFieldFromRawReportsInvalidLocalizedJSON(t *testing.T) {
+	t.Parallel()
+
+	field, diags := NewEntryLocalizedFieldFromRaw(path.Root("fields").AtMapKey("title"), []byte(`invalid`))
+
+	require.True(t, diags.HasError())
+	assert.True(t, field.IsNull())
+}

--- a/internal/provider/entry_model_request.go
+++ b/internal/provider/entry_model_request.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/go-faster/jx"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
 func (m EntryModel) ToEntryRequest(ctx context.Context) (cm.EntryRequest, diag.Diagnostics) {
@@ -33,15 +36,43 @@ func entryModelToOptEntryFields(_ context.Context, model EntryModel) (cm.OptEntr
 	fields := make(cm.EntryFields)
 
 	attrs := model.Fields.Elements()
-	for k, v := range attrs {
-		if v.IsNull() {
+	for fieldID, localizedValues := range attrs {
+		if localizedValues.IsNull() || localizedValues.IsUnknown() {
 			continue
 		}
 
-		fields[k] = jx.Raw(v.ValueString())
+		fieldValue, fieldValueDiags := entryLocalizedFieldToRaw(path.Root("fields").AtMapKey(fieldID), localizedValues)
+		diags.Append(fieldValueDiags...)
+
+		if fieldValueDiags.HasError() {
+			continue
+		}
+
+		fields[fieldID] = fieldValue
 	}
 
 	return cm.NewOptEntryFields(fields), diags
+}
+
+func entryLocalizedFieldToRaw(path path.Path, localizedValues TypedMap[jsontypes.Normalized]) (jx.Raw, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	values := map[string]json.RawMessage{}
+
+	for locale, value := range localizedValues.Elements() {
+		if value.IsNull() || value.IsUnknown() {
+			continue
+		}
+
+		values[locale] = json.RawMessage(value.ValueString())
+	}
+
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		diags.AddAttributeError(path, "Invalid Entry Field Value", err.Error())
+	}
+
+	return jx.Raw(encoded), diags
 }
 
 func entryModelToOptEntryMetadata(_ context.Context, model EntryModel) (cm.OptEntryMetadata, diag.Diagnostics) {

--- a/internal/provider/entry_model_request.go
+++ b/internal/provider/entry_model_request.go
@@ -64,7 +64,14 @@ func entryLocalizedFieldToRaw(path path.Path, localizedValues TypedMap[jsontypes
 			continue
 		}
 
-		values[locale] = json.RawMessage(value.ValueString())
+		raw := []byte(value.ValueString())
+		if !json.Valid(raw) {
+			diags.AddAttributeError(path.AtMapKey(locale), "Invalid Entry Field Value", "Expected a valid JSON value.")
+
+			continue
+		}
+
+		values[locale] = json.RawMessage(raw)
 	}
 
 	encoded, err := json.Marshal(values)

--- a/internal/provider/entry_model_request.go
+++ b/internal/provider/entry_model_request.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/go-faster/jx"
@@ -37,7 +38,13 @@ func entryModelToOptEntryFields(_ context.Context, model EntryModel) (cm.OptEntr
 
 	attrs := model.Fields.Elements()
 	for fieldID, localizedValues := range attrs {
-		if localizedValues.IsNull() || localizedValues.IsUnknown() {
+		if localizedValues.IsUnknown() {
+			continue
+		}
+
+		if localizedValues.IsNull() {
+			fields[fieldID] = jx.Raw("null")
+
 			continue
 		}
 
@@ -80,6 +87,10 @@ func entryLocalizedFieldToRaw(path path.Path, localizedValues TypedMap[jsontypes
 	}
 
 	return jx.Raw(encoded), diags
+}
+
+func isRawJSONNull(raw []byte) bool {
+	return strings.TrimSpace(string(raw)) == "null"
 }
 
 func entryModelToOptEntryMetadata(_ context.Context, model EntryModel) (cm.OptEntryMetadata, diag.Diagnostics) {

--- a/internal/provider/entry_model_response.go
+++ b/internal/provider/entry_model_response.go
@@ -67,6 +67,10 @@ func NewEntryFieldsFromResponse(_ context.Context, path path.Path, fields cm.Opt
 func NewEntryLocalizedFieldFromRaw(path path.Path, raw []byte) (TypedMap[jsontypes.Normalized], diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
+	if isRawJSONNull(raw) {
+		return NewTypedMapNull[jsontypes.Normalized](), diags
+	}
+
 	var localizedValues map[string]json.RawMessage
 
 	err := json.Unmarshal(raw, &localizedValues)

--- a/internal/provider/entry_model_response.go
+++ b/internal/provider/entry_model_response.go
@@ -45,7 +45,7 @@ func NewEntryFieldsFromResponse(_ context.Context, path path.Path, fields cm.Opt
 	diags := diag.Diagnostics{}
 
 	if !fields.IsSet() {
-		return NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{}), diags
+		return NewTypedMapNull[TypedMap[jsontypes.Normalized]](), diags
 	}
 
 	elements := map[string]TypedMap[jsontypes.Normalized]{}

--- a/internal/provider/entry_model_response.go
+++ b/internal/provider/entry_model_response.go
@@ -45,7 +45,7 @@ func NewEntryFieldsFromResponse(_ context.Context, path path.Path, fields cm.Opt
 	diags := diag.Diagnostics{}
 
 	if !fields.IsSet() {
-		return NewTypedMapNull[TypedMap[jsontypes.Normalized]](), diags
+		return NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{}), diags
 	}
 
 	elements := map[string]TypedMap[jsontypes.Normalized]{}

--- a/internal/provider/entry_model_response.go
+++ b/internal/provider/entry_model_response.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -39,16 +41,44 @@ func NewEntryResourceModelFromResponse(ctx context.Context, entry cm.Entry) (Ent
 	return model, diags
 }
 
-func NewEntryFieldsFromResponse(_ context.Context, _ path.Path, fields cm.OptEntryFields) (TypedMap[jsontypes.Normalized], diag.Diagnostics) {
+func NewEntryFieldsFromResponse(_ context.Context, path path.Path, fields cm.OptEntryFields) (TypedMap[TypedMap[jsontypes.Normalized]], diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	if !fields.IsSet() {
+		return NewTypedMapNull[TypedMap[jsontypes.Normalized]](), diags
+	}
+
+	elements := map[string]TypedMap[jsontypes.Normalized]{}
+
+	for fieldID, fieldValue := range fields.Value {
+		localizedValues, localizedValuesDiags := NewEntryLocalizedFieldFromRaw(path.AtMapKey(fieldID), fieldValue)
+		diags.Append(localizedValuesDiags...)
+
+		if localizedValuesDiags.HasError() {
+			continue
+		}
+
+		elements[fieldID] = localizedValues
+	}
+
+	return NewTypedMap(elements), diags
+}
+
+func NewEntryLocalizedFieldFromRaw(path path.Path, raw []byte) (TypedMap[jsontypes.Normalized], diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	var localizedValues map[string]json.RawMessage
+
+	err := json.Unmarshal(raw, &localizedValues)
+	if err != nil {
+		diags.AddAttributeError(path, "Invalid Entry Field Value", fmt.Sprintf("Expected a JSON object keyed by locale: %s", err))
+
 		return NewTypedMapNull[jsontypes.Normalized](), diags
 	}
 
-	elements := map[string]jsontypes.Normalized{}
-	for k, v := range fields.Value {
-		elements[k] = NewNormalizedJSONTypesNormalizedValue(v)
+	elements := make(map[string]jsontypes.Normalized, len(localizedValues))
+	for locale, value := range localizedValues {
+		elements[locale] = NewNormalizedJSONTypesNormalizedValue(value)
 	}
 
 	return NewTypedMap(elements), diags

--- a/internal/provider/list_resource_entry_test.go
+++ b/internal/provider/list_resource_entry_test.go
@@ -116,7 +116,9 @@ func TestAccEntryListResource(t *testing.T) {
 						{
 							Path: tfjsonpath.New("fields"),
 							KnownValue: knownvalue.MapExact(map[string]knownvalue.Check{
-								"name": knownvalue.StringExact(`{"en-AU":"name"}`),
+								"name": knownvalue.MapExact(map[string]knownvalue.Check{
+									"en-AU": knownvalue.StringExact(`"name"`),
+								}),
 							}),
 						},
 						{

--- a/internal/provider/resource_entry.go
+++ b/internal/provider/resource_entry.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*entryResource)(nil)
-	_ resource.ResourceWithConfigure   = (*entryResource)(nil)
-	_ resource.ResourceWithIdentity    = (*entryResource)(nil)
-	_ resource.ResourceWithImportState = (*entryResource)(nil)
+	_ resource.Resource                 = (*entryResource)(nil)
+	_ resource.ResourceWithConfigure    = (*entryResource)(nil)
+	_ resource.ResourceWithIdentity     = (*entryResource)(nil)
+	_ resource.ResourceWithImportState  = (*entryResource)(nil)
+	_ resource.ResourceWithUpgradeState = (*entryResource)(nil)
 )
 
 //nolint:ireturn

--- a/internal/provider/resource_entry.go
+++ b/internal/provider/resource_entry.go
@@ -6,6 +6,7 @@ import (
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -98,11 +99,7 @@ func (r *entryResource) Create(ctx context.Context, req resource.CreateRequest, 
 	var identityModel EntryIdentityModel
 	resp.Diagnostics.Append(CopyAttributeValues(ctx, &identityModel, &responseModel)...)
 
-	for fieldKey, fieldValue := range plan.Fields.Elements() {
-		if !responseModel.Fields.Has(fieldKey) {
-			responseModel.Fields.Set(fieldKey, fieldValue)
-		}
-	}
+	mergeMissingEntryFields(&responseModel.Fields, plan.Fields)
 
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseModel)...)
@@ -190,11 +187,7 @@ func (r *entryResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	var identityModel EntryIdentityModel
 	resp.Diagnostics.Append(CopyAttributeValues(ctx, &identityModel, &data)...)
 
-	for fieldKey, fieldValue := range state.Fields.Elements() {
-		if !data.Fields.Has(fieldKey) {
-			data.Fields.Set(fieldKey, fieldValue)
-		}
-	}
+	mergeMissingEntryFields(&data.Fields, state.Fields)
 
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -239,11 +232,7 @@ func (r *entryResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	var identityModel EntryIdentityModel
 	resp.Diagnostics.Append(CopyAttributeValues(ctx, &identityModel, &responseModel)...)
 
-	for fieldKey, fieldValue := range plan.Fields.Elements() {
-		if !responseModel.Fields.Has(fieldKey) {
-			responseModel.Fields.Set(fieldKey, fieldValue)
-		}
-	}
+	mergeMissingEntryFields(&responseModel.Fields, plan.Fields)
 
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseModel)...)
@@ -260,6 +249,23 @@ func (r *entryResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	resp.Diagnostics.Append(SetPrivateProviderData(ctx, resp.Private, "version", currentVersion)...)
+}
+
+func mergeMissingEntryFields(target *TypedMap[TypedMap[jsontypes.Normalized]], fallback TypedMap[TypedMap[jsontypes.Normalized]]) {
+	fallbackElements := fallback.Elements()
+	if len(fallbackElements) == 0 {
+		return
+	}
+
+	if target.IsNull() || target.IsUnknown() {
+		*target = NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{})
+	}
+
+	for fieldKey, fieldValue := range fallbackElements {
+		if !target.Has(fieldKey) {
+			target.Set(fieldKey, fieldValue)
+		}
+	}
 }
 
 func (r *entryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_entry_fields_merge_test.go
+++ b/internal/provider/resource_entry_fields_merge_test.go
@@ -1,0 +1,48 @@
+//nolint:testpackage
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeMissingEntryFieldsInitializesNullTarget(t *testing.T) {
+	t.Parallel()
+
+	target := NewTypedMapNull[TypedMap[jsontypes.Normalized]]()
+	fallback := NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{
+		"name": NewTypedMap(map[string]jsontypes.Normalized{
+			"en-AU": NewNormalizedJSONTypesNormalizedValue([]byte(`"name"`)),
+		}),
+	})
+
+	mergeMissingEntryFields(&target, fallback)
+
+	assert.False(t, target.IsNull())
+	assert.Equal(t, `"name"`, target.Elements()["name"].Elements()["en-AU"].ValueString())
+}
+
+func TestMergeMissingEntryFieldsPreservesExistingValues(t *testing.T) {
+	t.Parallel()
+
+	target := NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{
+		"name": NewTypedMap(map[string]jsontypes.Normalized{
+			"en-AU": NewNormalizedJSONTypesNormalizedValue([]byte(`"server"`)),
+		}),
+	})
+	fallback := NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{
+		"name": NewTypedMap(map[string]jsontypes.Normalized{
+			"en-AU": NewNormalizedJSONTypesNormalizedValue([]byte(`"plan"`)),
+		}),
+		"blurb": NewTypedMap(map[string]jsontypes.Normalized{
+			"en-AU": NewNormalizedJSONTypesNormalizedValue([]byte(`"added"`)),
+		}),
+	})
+
+	mergeMissingEntryFields(&target, fallback)
+
+	assert.Equal(t, `"server"`, target.Elements()["name"].Elements()["en-AU"].ValueString())
+	assert.Equal(t, `"added"`, target.Elements()["blurb"].Elements()["en-AU"].ValueString())
+}

--- a/internal/provider/resource_entry_schema.go
+++ b/internal/provider/resource_entry_schema.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -96,9 +95,6 @@ func localizedEntryFieldsSchemaAttribute(ctx context.Context) schema.MapAttribut
 		CustomType:  NewTypedMapNull[TypedMap[jsontypes.Normalized]]().CustomType(ctx),
 		Optional:    true,
 		Computed:    true,
-		PlanModifiers: []planmodifier.Map{
-			mapplanmodifier.UseStateForUnknown(),
-		},
 	}
 }
 

--- a/internal/provider/resource_entry_schema.go
+++ b/internal/provider/resource_entry_schema.go
@@ -14,12 +14,21 @@ import (
 )
 
 func EntryResourceSchema(ctx context.Context) schema.Schema {
+	return entryResourceSchema(ctx, 1, localizedEntryFieldsSchemaAttribute(ctx))
+}
+
+func EntryResourceSchemaV0(ctx context.Context) schema.Schema {
+	return entryResourceSchema(ctx, 0, rawEntryFieldsSchemaAttribute(ctx))
+}
+
+func entryResourceSchema(ctx context.Context, version int64, fieldsAttribute schema.Attribute) schema.Schema {
 	defaultMetadataObjectValue, _ := NewTypedObject[EntryMetadataValue](EntryMetadataValue{
 		Concepts: NewTypedListFromStringSlice([]string{}),
 		Tags:     NewTypedListFromStringSlice([]string{}),
 	}).ToObjectValue(ctx)
 
 	return schema.Schema{
+		Version:     version,
 		Description: "Manages a Contentful Entry.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -62,12 +71,7 @@ func EntryResourceSchema(ctx context.Context) schema.Schema {
 					UseStateForUnknown(),
 				},
 			},
-			"fields": schema.MapAttribute{
-				Description: "Fields that are custom defined by a user through the definition of content types. Fields object always includes locale.",
-				ElementType: jsontypes.NormalizedType{},
-				CustomType:  NewTypedMapNull[jsontypes.Normalized]().CustomType(ctx),
-				Required:    true,
-			},
+			"fields": fieldsAttribute,
 			"metadata": schema.SingleNestedAttribute{
 				Attributes:  EntryMetadataValue{}.SchemaAttributes(ctx),
 				CustomType:  NewTypedObjectNull[EntryMetadataValue]().CustomType(ctx),
@@ -81,6 +85,24 @@ func EntryResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
 		},
+	}
+}
+
+func localizedEntryFieldsSchemaAttribute(ctx context.Context) schema.MapAttribute {
+	return schema.MapAttribute{
+		Description: "Fields that are custom defined by a user through the definition of content types, keyed by field ID and locale.",
+		ElementType: NewTypedMapNull[jsontypes.Normalized]().CustomType(ctx),
+		CustomType:  NewTypedMapNull[TypedMap[jsontypes.Normalized]]().CustomType(ctx),
+		Required:    true,
+	}
+}
+
+func rawEntryFieldsSchemaAttribute(ctx context.Context) schema.MapAttribute {
+	return schema.MapAttribute{
+		Description: "Fields that are custom defined by a user through the definition of content types. Fields object always includes locale.",
+		ElementType: jsontypes.NormalizedType{},
+		CustomType:  NewTypedMapNull[jsontypes.Normalized]().CustomType(ctx),
+		Required:    true,
 	}
 }
 

--- a/internal/provider/resource_entry_schema.go
+++ b/internal/provider/resource_entry_schema.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -93,7 +94,11 @@ func localizedEntryFieldsSchemaAttribute(ctx context.Context) schema.MapAttribut
 		Description: "Fields that are custom defined by a user through the definition of content types, keyed by field ID and locale.",
 		ElementType: NewTypedMapNull[jsontypes.Normalized]().CustomType(ctx),
 		CustomType:  NewTypedMapNull[TypedMap[jsontypes.Normalized]]().CustomType(ctx),
-		Required:    true,
+		Optional:    true,
+		Computed:    true,
+		PlanModifiers: []planmodifier.Map{
+			mapplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
 

--- a/internal/provider/resource_entry_state_upgrade.go
+++ b/internal/provider/resource_entry_state_upgrade.go
@@ -41,7 +41,7 @@ func upgradeEntryResourceStateV0ToV1(ctx context.Context, req resource.UpgradeSt
 		return
 	}
 
-	fields := NewTypedMapNull[TypedMap[jsontypes.Normalized]]()
+	fields := NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{})
 
 	if !stateV0.Fields.IsNull() && !stateV0.Fields.IsUnknown() {
 		elements := make(map[string]TypedMap[jsontypes.Normalized], len(stateV0.Fields.Elements()))

--- a/internal/provider/resource_entry_state_upgrade.go
+++ b/internal/provider/resource_entry_state_upgrade.go
@@ -41,7 +41,7 @@ func upgradeEntryResourceStateV0ToV1(ctx context.Context, req resource.UpgradeSt
 		return
 	}
 
-	fields := NewTypedMap(map[string]TypedMap[jsontypes.Normalized]{})
+	fields := NewTypedMapNull[TypedMap[jsontypes.Normalized]]()
 
 	if !stateV0.Fields.IsNull() && !stateV0.Fields.IsUnknown() {
 		elements := make(map[string]TypedMap[jsontypes.Normalized], len(stateV0.Fields.Elements()))

--- a/internal/provider/resource_entry_state_upgrade.go
+++ b/internal/provider/resource_entry_state_upgrade.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type EntryModelV0 struct {
+	IDIdentityModel
+	EntryIdentityModel
+
+	ContentTypeID types.String `tfsdk:"content_type_id"`
+
+	Fields   TypedMap[jsontypes.Normalized]  `tfsdk:"fields"`
+	Metadata TypedObject[EntryMetadataValue] `tfsdk:"metadata"`
+
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
+}
+
+func (r *entryResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := EntryResourceSchemaV0(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &schemaV0,
+			StateUpgrader: upgradeEntryResourceStateV0ToV1,
+		},
+	}
+}
+
+func upgradeEntryResourceStateV0ToV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	var stateV0 EntryModelV0
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateV0)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	fields := NewTypedMapNull[TypedMap[jsontypes.Normalized]]()
+
+	if !stateV0.Fields.IsNull() && !stateV0.Fields.IsUnknown() {
+		elements := make(map[string]TypedMap[jsontypes.Normalized], len(stateV0.Fields.Elements()))
+
+		for fieldID, fieldValue := range stateV0.Fields.Elements() {
+			if fieldValue.IsNull() || fieldValue.IsUnknown() {
+				continue
+			}
+
+			localizedValues, localizedValuesDiags := NewEntryLocalizedFieldFromRaw(path.Root("fields").AtMapKey(fieldID), []byte(fieldValue.ValueString()))
+			resp.Diagnostics.Append(localizedValuesDiags...)
+
+			if localizedValuesDiags.HasError() {
+				continue
+			}
+
+			elements[fieldID] = localizedValues
+		}
+
+		fields = NewTypedMap(elements)
+	}
+
+	stateV1 := EntryModel{
+		IDIdentityModel:    stateV0.IDIdentityModel,
+		EntryIdentityModel: stateV0.EntryIdentityModel,
+		ContentTypeID:      stateV0.ContentTypeID,
+		Fields:             fields,
+		Metadata:           stateV0.Metadata,
+		Timeouts:           stateV0.Timeouts,
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateV1)...)
+}

--- a/internal/provider/resource_entry_state_upgrade_test.go
+++ b/internal/provider/resource_entry_state_upgrade_test.go
@@ -142,3 +142,38 @@ func TestUpgradeEntryResourceStateV0ToV1ReportsInvalidLocalizedField(t *testing.
 	assert.NotContains(t, stateV1.Fields.Elements(), "empty-value")
 	assert.Equal(t, `"Name"`, stateV1.Fields.Elements()["name"].Elements()["en-AU"].ValueString())
 }
+
+func TestUpgradeEntryResourceStateV0ToV1PreservesRawNullFieldValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	schemaV0 := EntryResourceSchemaV0(ctx)
+	schemaV1 := EntryResourceSchema(ctx)
+
+	stateV0 := EntryModelV0{
+		IDIdentityModel:    NewIDIdentityModelFromMultipartID("space", "environment", "entry"),
+		EntryIdentityModel: NewEntryIdentityModel("space", "environment", "entry"),
+		ContentTypeID:      types.StringValue("author"),
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"title": NewNormalizedJSONTypesNormalizedValue([]byte(`null`)),
+		}),
+		Metadata: NewTypedObjectNull[EntryMetadataValue](),
+		Timeouts: TimeoutsNull(),
+	}
+
+	priorState := tfsdk.State{Schema: schemaV0}
+	require.False(t, priorState.Set(ctx, &stateV0).HasError())
+
+	response := resource.UpgradeStateResponse{
+		State: tfsdk.State{Schema: schemaV1},
+	}
+
+	upgradeEntryResourceStateV0ToV1(ctx, resource.UpgradeStateRequest{
+		State: &priorState,
+	}, &response)
+	require.False(t, response.Diagnostics.HasError())
+
+	var stateV1 EntryModel
+	require.False(t, response.State.Get(ctx, &stateV1).HasError())
+	assert.True(t, stateV1.Fields.Elements()["title"].IsNull())
+}

--- a/internal/provider/resource_entry_state_upgrade_test.go
+++ b/internal/provider/resource_entry_state_upgrade_test.go
@@ -70,7 +70,7 @@ func TestEntryResourceUpgradeStateRegistersV0Upgrader(t *testing.T) {
 	assert.NotNil(t, upgraders[0].StateUpgrader)
 }
 
-func TestUpgradeEntryResourceStateV0ToV1PreservesNullFields(t *testing.T) {
+func TestUpgradeEntryResourceStateV0ToV1NormalizesNullFieldsToEmptyMap(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -100,7 +100,8 @@ func TestUpgradeEntryResourceStateV0ToV1PreservesNullFields(t *testing.T) {
 
 	var stateV1 EntryModel
 	require.False(t, response.State.Get(ctx, &stateV1).HasError())
-	assert.True(t, stateV1.Fields.IsNull())
+	assert.False(t, stateV1.Fields.IsNull())
+	assert.Empty(t, stateV1.Fields.Elements())
 }
 
 func TestUpgradeEntryResourceStateV0ToV1ReportsInvalidLocalizedField(t *testing.T) {

--- a/internal/provider/resource_entry_state_upgrade_test.go
+++ b/internal/provider/resource_entry_state_upgrade_test.go
@@ -1,0 +1,144 @@
+//nolint:testpackage
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeEntryResourceStateV0ToV1LocalizesFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	schemaV0 := EntryResourceSchemaV0(ctx)
+	schemaV1 := EntryResourceSchema(ctx)
+
+	stateV0 := EntryModelV0{
+		IDIdentityModel:    NewIDIdentityModelFromMultipartID("space", "environment", "entry"),
+		EntryIdentityModel: NewEntryIdentityModel("space", "environment", "entry"),
+		ContentTypeID:      types.StringValue("author"),
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"name":  NewNormalizedJSONTypesNormalizedValue([]byte(`{"en-AU":"Name","en-US":"Name"}`)),
+			"blurb": NewNormalizedJSONTypesNormalizedValue([]byte(`{"en-AU":{"nodeType":"document","data":{},"content":[]}}`)),
+		}),
+		Metadata: NewTypedObject[EntryMetadataValue](EntryMetadataValue{
+			Concepts: NewTypedListFromStringSlice([]string{}),
+			Tags:     NewTypedListFromStringSlice([]string{"blog"}),
+		}),
+		Timeouts: TimeoutsNull(),
+	}
+
+	priorState := tfsdk.State{Schema: schemaV0}
+	require.False(t, priorState.Set(ctx, &stateV0).HasError())
+
+	response := resource.UpgradeStateResponse{
+		State: tfsdk.State{Schema: schemaV1},
+	}
+
+	upgradeEntryResourceStateV0ToV1(ctx, resource.UpgradeStateRequest{
+		State: &priorState,
+	}, &response)
+	require.False(t, response.Diagnostics.HasError())
+
+	var stateV1 EntryModel
+	require.False(t, response.State.Get(ctx, &stateV1).HasError())
+
+	name := stateV1.Fields.Elements()["name"].Elements()
+	assert.Equal(t, `"Name"`, name["en-AU"].ValueString())
+	assert.Equal(t, `"Name"`, name["en-US"].ValueString())
+
+	blurb := stateV1.Fields.Elements()["blurb"].Elements()
+	assert.JSONEq(t, `{"content":[],"data":{},"nodeType":"document"}`, blurb["en-AU"].ValueString())
+	require.Len(t, stateV1.Metadata.Value().Tags.Elements(), 1)
+	assert.Equal(t, "blog", stateV1.Metadata.Value().Tags.Elements()[0].ValueString())
+}
+
+func TestEntryResourceUpgradeStateRegistersV0Upgrader(t *testing.T) {
+	t.Parallel()
+
+	upgraders := (&entryResource{}).UpgradeState(context.Background())
+
+	require.Contains(t, upgraders, int64(0))
+	assert.NotNil(t, upgraders[0].PriorSchema)
+	assert.NotNil(t, upgraders[0].StateUpgrader)
+}
+
+func TestUpgradeEntryResourceStateV0ToV1PreservesNullFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	schemaV0 := EntryResourceSchemaV0(ctx)
+	schemaV1 := EntryResourceSchema(ctx)
+
+	stateV0 := EntryModelV0{
+		IDIdentityModel:    NewIDIdentityModelFromMultipartID("space", "environment", "entry"),
+		EntryIdentityModel: NewEntryIdentityModel("space", "environment", "entry"),
+		ContentTypeID:      types.StringValue("author"),
+		Fields:             NewTypedMapNull[jsontypes.Normalized](),
+		Metadata:           NewTypedObjectNull[EntryMetadataValue](),
+		Timeouts:           TimeoutsNull(),
+	}
+
+	priorState := tfsdk.State{Schema: schemaV0}
+	require.False(t, priorState.Set(ctx, &stateV0).HasError())
+
+	response := resource.UpgradeStateResponse{
+		State: tfsdk.State{Schema: schemaV1},
+	}
+
+	upgradeEntryResourceStateV0ToV1(ctx, resource.UpgradeStateRequest{
+		State: &priorState,
+	}, &response)
+	require.False(t, response.Diagnostics.HasError())
+
+	var stateV1 EntryModel
+	require.False(t, response.State.Get(ctx, &stateV1).HasError())
+	assert.True(t, stateV1.Fields.IsNull())
+}
+
+func TestUpgradeEntryResourceStateV0ToV1ReportsInvalidLocalizedField(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	schemaV0 := EntryResourceSchemaV0(ctx)
+	schemaV1 := EntryResourceSchema(ctx)
+
+	stateV0 := EntryModelV0{
+		IDIdentityModel:    NewIDIdentityModelFromMultipartID("space", "environment", "entry"),
+		EntryIdentityModel: NewEntryIdentityModel("space", "environment", "entry"),
+		ContentTypeID:      types.StringValue("author"),
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"title":       NewNormalizedJSONTypesNormalizedValue([]byte(`[]`)),
+			"name":        NewNormalizedJSONTypesNormalizedValue([]byte(`{"en-AU":"Name"}`)),
+			"empty-value": jsontypes.NewNormalizedNull(),
+		}),
+		Metadata: NewTypedObjectNull[EntryMetadataValue](),
+		Timeouts: TimeoutsNull(),
+	}
+
+	priorState := tfsdk.State{Schema: schemaV0}
+	require.False(t, priorState.Set(ctx, &stateV0).HasError())
+
+	response := resource.UpgradeStateResponse{
+		State: tfsdk.State{Schema: schemaV1},
+	}
+
+	upgradeEntryResourceStateV0ToV1(ctx, resource.UpgradeStateRequest{
+		State: &priorState,
+	}, &response)
+
+	require.True(t, response.Diagnostics.HasError())
+
+	var stateV1 EntryModel
+	require.False(t, response.State.Get(ctx, &stateV1).HasError())
+	assert.NotContains(t, stateV1.Fields.Elements(), "title")
+	assert.NotContains(t, stateV1.Fields.Elements(), "empty-value")
+	assert.Equal(t, `"Name"`, stateV1.Fields.Elements()["name"].Elements()["en-AU"].ValueString())
+}

--- a/internal/provider/resource_entry_state_upgrade_test.go
+++ b/internal/provider/resource_entry_state_upgrade_test.go
@@ -70,7 +70,7 @@ func TestEntryResourceUpgradeStateRegistersV0Upgrader(t *testing.T) {
 	assert.NotNil(t, upgraders[0].StateUpgrader)
 }
 
-func TestUpgradeEntryResourceStateV0ToV1NormalizesNullFieldsToEmptyMap(t *testing.T) {
+func TestUpgradeEntryResourceStateV0ToV1PreservesNullFields(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -100,8 +100,7 @@ func TestUpgradeEntryResourceStateV0ToV1NormalizesNullFieldsToEmptyMap(t *testin
 
 	var stateV1 EntryModel
 	require.False(t, response.State.Get(ctx, &stateV1).HasError())
-	assert.False(t, stateV1.Fields.IsNull())
-	assert.Empty(t, stateV1.Fields.Elements())
+	assert.True(t, stateV1.Fields.IsNull())
 }
 
 func TestUpgradeEntryResourceStateV0ToV1ReportsInvalidLocalizedField(t *testing.T) {

--- a/internal/provider/resource_entry_test.go
+++ b/internal/provider/resource_entry_test.go
@@ -1,7 +1,11 @@
 package provider_test
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"maps"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -13,6 +17,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+var (
+	errInvalidExpectedJSON = errors.New("invalid expected JSON")
+	errInvalidActualJSON   = errors.New("invalid actual JSON")
+	errJSONNotEqual        = errors.New("JSON values are not equal")
 )
 
 func TestAccEntryResourceImport(t *testing.T) {
@@ -207,7 +217,9 @@ func TestAccEntryResourceCreate(t *testing.T) {
 								"en-AU": knownvalue.StringExact(`"name"`),
 							}),
 							"blurb": knownvalue.MapExact(map[string]knownvalue.Check{
-								"en-AU": knownvalue.StringExact(`{"content":[],"data":{},"nodeType":"document"}`),
+								"en-AU": knownvalue.StringFunc(func(actual string) error {
+									return checkJSONEqual(`{"nodeType":"document","data":{},"content":[]}`, actual)
+								}),
 							}),
 						})),
 					},
@@ -462,6 +474,28 @@ func TestAccEntryResourceMissingFields(t *testing.T) {
 			},
 		},
 	})
+}
+
+func checkJSONEqual(expected string, actual string) error {
+	var expectedJSON any
+
+	err := json.Unmarshal([]byte(expected), &expectedJSON)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errInvalidExpectedJSON, err)
+	}
+
+	var actualJSON any
+
+	err = json.Unmarshal([]byte(actual), &actualJSON)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errInvalidActualJSON, err)
+	}
+
+	if !reflect.DeepEqual(expectedJSON, actualJSON) {
+		return fmt.Errorf("%w: expected %s, got %s", errJSONNotEqual, expected, actual)
+	}
+
+	return nil
 }
 
 //nolint:ireturn

--- a/internal/provider/resource_entry_test.go
+++ b/internal/provider/resource_entry_test.go
@@ -207,7 +207,7 @@ func TestAccEntryResourceCreate(t *testing.T) {
 								"en-AU": knownvalue.StringExact(`"name"`),
 							}),
 							"blurb": knownvalue.MapExact(map[string]knownvalue.Check{
-								"en-AU": knownvalue.StringExact(`{"nodeType":"document","data":{},"content":[]}`),
+								"en-AU": knownvalue.StringExact(`{"content":[],"data":{},"nodeType":"document"}`),
 							}),
 						})),
 					},
@@ -446,6 +446,11 @@ func TestAccEntryResourceMissingFields(t *testing.T) {
 			{
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: configVariables1,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("contentful_entry.test", tfjsonpath.New("fields"), knownvalue.MapExact(map[string]knownvalue.Check{})),
+					},
+				},
 			},
 			{
 				ConfigDirectory: config.TestNameDirectory(),

--- a/internal/provider/resource_entry_test.go
+++ b/internal/provider/resource_entry_test.go
@@ -1,11 +1,7 @@
 package provider_test
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"maps"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -17,12 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-)
-
-var (
-	errInvalidExpectedJSON = errors.New("invalid expected JSON")
-	errInvalidActualJSON   = errors.New("invalid actual JSON")
-	errJSONNotEqual        = errors.New("JSON values are not equal")
 )
 
 func TestAccEntryResourceImport(t *testing.T) {
@@ -195,9 +185,13 @@ func TestAccEntryResourceCreate(t *testing.T) {
 		"space_id":        config.StringVariable("0p38pssr0fi3"),
 		"environment_id":  config.StringVariable("test"),
 		"content_type_id": config.StringVariable("author"),
-		"fields": config.MapVariable(map[string]config.Variable{
-			"name":  config.StringVariable(`{"en-AU":"name"}`),
-			"blurb": config.StringVariable(`{"en-AU":{"nodeType":"document","data":{},"content":[]}}`),
+		"fields": localizedEntryFields(map[string]map[string]string{
+			"name": {
+				"en-AU": `"name"`,
+			},
+			"blurb": {
+				"en-AU": `{"nodeType":"document","data":{},"content":[]}`,
+			},
 		}),
 	}
 
@@ -209,9 +203,11 @@ func TestAccEntryResourceCreate(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("contentful_entry.test", tfjsonpath.New("fields"), knownvalue.MapExact(map[string]knownvalue.Check{
-							"name": knownvalue.StringExact(`{"en-AU":"name"}`),
-							"blurb": knownvalue.StringFunc(func(actual string) error {
-								return checkJSONEqual(`{"en-AU":{"nodeType":"document","data":{},"content":[]}}`, actual)
+							"name": knownvalue.MapExact(map[string]knownvalue.Check{
+								"en-AU": knownvalue.StringExact(`"name"`),
+							}),
+							"blurb": knownvalue.MapExact(map[string]knownvalue.Check{
+								"en-AU": knownvalue.StringExact(`{"nodeType":"document","data":{},"content":[]}`),
 							}),
 						})),
 					},
@@ -235,8 +231,10 @@ func TestAccEntryResourceCreateWithID(t *testing.T) {
 		"environment_id":  config.StringVariable("test"),
 		"entry_id":        config.StringVariable(entryID),
 		"content_type_id": config.StringVariable("author"),
-		"fields": config.MapVariable(map[string]config.Variable{
-			"name": config.StringVariable(`{"en-AU":"name"}`),
+		"fields": localizedEntryFields(map[string]map[string]string{
+			"name": {
+				"en-AU": `"name"`,
+			},
 		}),
 	}
 
@@ -261,8 +259,10 @@ func TestAccEntryResourceUpdate(t *testing.T) {
 		"space_id":        config.StringVariable("0p38pssr0fi3"),
 		"environment_id":  config.StringVariable("test"),
 		"content_type_id": config.StringVariable("author"),
-		"fields": config.MapVariable(map[string]config.Variable{
-			"name": config.StringVariable(`{"en-AU":"name"}`),
+		"fields": localizedEntryFields(map[string]map[string]string{
+			"name": {
+				"en-AU": `"name"`,
+			},
 		}),
 	}
 
@@ -270,8 +270,10 @@ func TestAccEntryResourceUpdate(t *testing.T) {
 		"space_id":        config.StringVariable("0p38pssr0fi3"),
 		"environment_id":  config.StringVariable("test"),
 		"content_type_id": config.StringVariable("author"),
-		"fields": config.MapVariable(map[string]config.Variable{
-			"name": config.StringVariable(`{"en-AU":"name (updated)"}`),
+		"fields": localizedEntryFields(map[string]map[string]string{
+			"name": {
+				"en-AU": `"name (updated)"`,
+			},
 		}),
 	}
 
@@ -317,8 +319,10 @@ func TestAccEntryResourceDeleted(t *testing.T) {
 		"space_id":        config.StringVariable("0p38pssr0fi3"),
 		"environment_id":  config.StringVariable("test"),
 		"content_type_id": config.StringVariable("author"),
-		"entry_fields": config.MapVariable(map[string]config.Variable{
-			"name": config.StringVariable(`{"en-AU":"name"}`),
+		"entry_fields": localizedEntryFields(map[string]map[string]string{
+			"name": {
+				"en-AU": `"name"`,
+			},
 		}),
 	}
 
@@ -424,13 +428,17 @@ func TestAccEntryResourceMissingFields(t *testing.T) {
 	configVariables1 := maps.Clone(configVariables)
 
 	configVariables2 := maps.Clone(configVariables)
-	configVariables2["entry_fields"] = config.MapVariable(map[string]config.Variable{
-		"b": config.StringVariable(`{"en-AU":"b"}`),
+	configVariables2["entry_fields"] = localizedEntryFields(map[string]map[string]string{
+		"b": {
+			"en-AU": `"b"`,
+		},
 	})
 
 	configVariables3 := maps.Clone(configVariables)
-	configVariables3["entry_fields"] = config.MapVariable(map[string]config.Variable{
-		"c": config.StringVariable(`{"en-AU":[]}`),
+	configVariables3["entry_fields"] = localizedEntryFields(map[string]map[string]string{
+		"c": {
+			"en-AU": `[]`,
+		},
 	})
 
 	ContentfulProviderMockableResourceTest(t, server, resource.TestCase{
@@ -451,26 +459,20 @@ func TestAccEntryResourceMissingFields(t *testing.T) {
 	})
 }
 
-func checkJSONEqual(expected string, actual string) error {
-	var expectedJSON any
+//nolint:ireturn
+func localizedEntryFields(fields map[string]map[string]string) config.Variable {
+	fieldVariables := make(map[string]config.Variable, len(fields))
 
-	err := json.Unmarshal([]byte(expected), &expectedJSON)
-	if err != nil {
-		return fmt.Errorf("%w: %w", errInvalidExpectedJSON, err)
+	for fieldID, locales := range fields {
+		localeVariables := make(map[string]config.Variable, len(locales))
+		for locale, value := range locales {
+			localeVariables[locale] = config.StringVariable(value)
+		}
+
+		fieldVariables[fieldID] = config.MapVariable(localeVariables)
 	}
 
-	var actualJSON any
-
-	err = json.Unmarshal([]byte(actual), &actualJSON)
-	if err != nil {
-		return fmt.Errorf("%w: %w", errInvalidActualJSON, err)
-	}
-
-	if !reflect.DeepEqual(expectedJSON, actualJSON) {
-		return fmt.Errorf("%w: expected %s, got %s", errJSONNotEqual, expected, actual)
-	}
-
-	return nil
+	return config.MapVariable(fieldVariables)
 }
 
 //nolint:dupl

--- a/internal/provider/testdata/TestAccEntryResourceCreate/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceCreate/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceCreateWithID/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceCreateWithID/main.tf
@@ -15,7 +15,7 @@ variable "content_type_id" {
 }
 
 variable "fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/1/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/1/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/2/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/2/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/3/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/3/main.tf
@@ -11,6 +11,6 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/4/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/4/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/5/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/5/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/6/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/6/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/7/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/7/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/TestAccEntryResourceDeleted/8/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceDeleted/8/main.tf
@@ -11,6 +11,6 @@ variable "content_type_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }

--- a/internal/provider/testdata/TestAccEntryResourceImport/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceImport/main.tf
@@ -17,6 +17,8 @@ resource "contentful_entry" "test" {
 
   content_type_id = "test"
   fields = {
-    "foo" = jsonencode("bar")
+    "foo" = {
+      "en-US" = jsonencode("bar")
+    }
   }
 }

--- a/internal/provider/testdata/TestAccEntryResourceImportNotFound/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceImportNotFound/main.tf
@@ -17,6 +17,8 @@ resource "contentful_entry" "test" {
 
   content_type_id = "test"
   fields = {
-    "foo" = jsonencode("bar")
+    "foo" = {
+      "en-US" = jsonencode("bar")
+    }
   }
 }

--- a/internal/provider/testdata/TestAccEntryResourceImportPropertyOrderDiff/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceImportPropertyOrderDiff/main.tf
@@ -17,6 +17,8 @@ resource "contentful_entry" "test" {
 
   content_type_id = "contentType"
   fields = {
-    "data" = jsonencode({ "en-US" = { "first" = "value1", "second" = "value2" } })
+    "data" = {
+      "en-US" = jsonencode({ "first" = "value1", "second" = "value2" })
+    }
   }
 }

--- a/internal/provider/testdata/TestAccEntryResourceImportWhitespaceDiff/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceImportWhitespaceDiff/main.tf
@@ -17,6 +17,8 @@ resource "contentful_entry" "test" {
 
   content_type_id = "contentType"
   fields = {
-    "name" = jsonencode({ "en-US" = "Test Name" })
+    "name" = {
+      "en-US" = jsonencode("Test Name")
+    }
   }
 }

--- a/internal/provider/testdata/TestAccEntryResourceMetadataConcepts/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceMetadataConcepts/main.tf
@@ -44,9 +44,9 @@ resource "contentful_entry" "test" {
   content_type_id = contentful_content_type.test.content_type_id
 
   fields = {
-    name = jsonencode({
-      "en-AU" = "Test Entry with Taxonomy Concepts"
-    })
+    name = {
+      "en-AU" = jsonencode("Test Entry with Taxonomy Concepts")
+    }
   }
 
   metadata = {

--- a/internal/provider/testdata/TestAccEntryResourceMetadataTags/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceMetadataTags/main.tf
@@ -44,9 +44,9 @@ resource "contentful_entry" "test" {
   content_type_id = contentful_content_type.test.content_type_id
 
   fields = {
-    name = jsonencode({
-      "en-AU" = "Test Entry with Tags"
-    })
+    name = {
+      "en-AU" = jsonencode("Test Entry with Tags")
+    }
   }
 
   metadata = {

--- a/internal/provider/testdata/TestAccEntryResourceMissingFields/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceMissingFields/main.tf
@@ -11,7 +11,7 @@ variable "test_id" {
 }
 
 variable "entry_fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 
@@ -38,7 +38,7 @@ resource "contentful_content_type" "test" {
       id        = "b"
       name      = "B"
       type      = "Symbol"
-      localized = false
+      localized = true
       required  = false
     },
     {

--- a/internal/provider/testdata/TestAccEntryResourceUpdate/main.tf
+++ b/internal/provider/testdata/TestAccEntryResourceUpdate/main.tf
@@ -11,7 +11,7 @@ variable "content_type_id" {
 }
 
 variable "fields" {
-  type    = map(string)
+  type    = map(map(string))
   default = {}
 }
 

--- a/internal/provider/testdata/entry_model.go
+++ b/internal/provider/testdata/entry_model.go
@@ -20,12 +20,20 @@ func EntryModel(spaceID, environmentID, contentTypeID, entryID string) *rapid.Ge
 					rapid.MapOfN(
 						AlphanumericStringOfN(1, 10),
 						rapid.Map(
-							rapid.Custom(func(t *rapid.T) string {
-								value := rapid.String().Draw(t, "value")
-								bytes, _ := json.Marshal(value)
-								return string(bytes)
-							}),
-							jsontypes.NewNormalizedValue,
+							rapid.MapOfN(
+								AlphanumericStringOfN(1, 10),
+								rapid.Map(
+									rapid.Custom(func(t *rapid.T) string {
+										value := rapid.String().Draw(t, "value")
+										bytes, _ := json.Marshal(value)
+										return string(bytes)
+									}),
+									jsontypes.NewNormalizedValue,
+								),
+								0,
+								5,
+							),
+							provider.NewTypedMap,
 						),
 						0,
 						5,


### PR DESCRIPTION
## Summary

- changes contentful_entry.fields from raw field JSON to a field -> locale -> JSON value shape
- converts the nested field shape to and from Contentful's CMA entry fields payload
- adds a v0 to v1 state upgrader for existing raw field state
- adds terraform-provider-contentful-migrate to rewrite safe literal contentful_entry.fields configuration into the new shape
- updates entry fixtures, list-resource expectations, examples, and generated docs

## Validation

- go test ./internal/provider -run 'TestUpgradeEntryResourceStateV0ToV1LocalizesFields|TestEntryModelRoundTrip|TestAccEntryResource|TestAccEntryListResource' -count=1
- go test ./...
- TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -run 'TestAccEntryResource|TestAccEntryListResource' -count=1
- golangci-lint cache clean && golangci-lint run
- go run ./cmd/terraform-provider-contentful-migrate examples/resources/contentful_entry/resource.tf
