### PR TITLE
chore(.github/workflows): use cyspbot-action for dependency updates

### DIFF
--- a/.github/workflows/update-indirect-dependencies.yml
+++ b/.github/workflows/update-indirect-dependencies.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write
 
 jobs:
   update:
@@ -18,11 +18,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: create-github-app-token
-        with:
-          app-id: ${{ vars.CYSPBOT_APP_ID }}
-          private-key: ${{ secrets.CYSPBOT_PRIVATE_KEY }}
+      - id: cyspbot
+        uses: cysp/cyspbot-action@d879d41c65cc2cc85387bc0f483f33f97d9001ae # v0.0.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -35,7 +32,7 @@ jobs:
       - name: create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ steps.create-github-app-token.outputs.token }}
+          token: ${{ steps.cyspbot.outputs.token }}
           commit-message: "chore(deps): bump indirect dependencies"
           title: "chore(deps): bump indirect dependencies"
           branch: "github-action-update-indirect-dependencies"


### PR DESCRIPTION
## Summary
- replace actions/create-github-app-token with cyspbot-action in the indirect dependency update workflow
- switch the workflow to OIDC token minting with id-token: write
- update the PR creation step to consume steps.cyspbot.outputs.token

Context: matches the recent terraform-provider-braze migration.