### PR TITLE
chore(github/workflows): update cyspbot action owner

### DIFF
--- a/.github/workflows/update-indirect-dependencies.yml
+++ b/.github/workflows/update-indirect-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: cyspbot
-        uses: cysp/cyspbot-action@d879d41c65cc2cc85387bc0f483f33f97d9001ae # v0.0.1
+        uses: chikachow/cyspbot-app-token-action@d879d41c65cc2cc85387bc0f483f33f97d9001ae # v0.0.1
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -24,7 +24,7 @@ jobs:
           cache: true
 
       - name: update indirect dependencies
-        run: for x in `go list -f '{{if .Indirect}}{{.Path}}{{end}}' -m all`; do go get -u "$x"; done || true
+        run: for x in $(go list -f '{{if .Indirect}}{{.Path}}{{end}}' -m all); do go get -u "$x"; done || true
 
       - name: go mod tidy
         run: go mod tidy -v


### PR DESCRIPTION
Updates the scheduled dependency workflow to consume the transferred action from `chikachow/cyspbot-app-token-action`.

The action ref remains pinned to the existing `v0.0.1` commit SHA.

Verification:
- `actionlint <workflow>`
- `git diff --check`
