### PR TITLE
chore(github/workflows): update cyspbot app token action

### DIFF
--- a/.github/workflows/update-indirect-dependencies.yml
+++ b/.github/workflows/update-indirect-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: cyspbot
-        uses: chikachow/cyspbot-app-token-action@d879d41c65cc2cc85387bc0f483f33f97d9001ae # v0.0.1
+        uses: chikachow/cyspbot-app-token-action@79392f6f3d8271fafc9d2d5247861dc4a07ff49a # v0.0.3
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Update the indirect dependency workflow to use the latest published `chikachow/cyspbot-app-token-action` release.

The workflow now pins `v0.0.3` by full commit SHA: `79392f6f3d8271fafc9d2d5247861dc4a07ff49a`.

## Validation

- Verified latest release with the GitHub API: `v0.0.3`
- `actionlint -ignore 'SC2006'` across the changed workflows