### PR TITLE
Improve provider configuration diagnostics

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,5 +22,5 @@ provider "contentful" {
 
 ### Optional
 
-- `access_token` (String, Sensitive)
-- `url` (String)
+- `access_token` (String, Sensitive) Contentful Management API access token. Can also be set with the CONTENTFUL_MANAGEMENT_ACCESS_TOKEN environment variable.
+- `url` (String) Contentful Management API base URL. Defaults to the public Contentful Management API. Can also be set with the CONTENTFUL_URL environment variable.

--- a/internal/provider/contentful_provider.go
+++ b/internal/provider/contentful_provider.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -79,11 +81,13 @@ func (p *ContentfulProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 		Description: "Manage Contentful spaces and related configuration with Terraform.",
 		Attributes: map[string]schema.Attribute{
 			"url": schema.StringAttribute{
-				Optional: true,
+				Description: "Contentful Management API base URL. Defaults to the public Contentful Management API. Can also be set with the CONTENTFUL_URL environment variable.",
+				Optional:    true,
 			},
 			"access_token": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
+				Description: "Contentful Management API access token. Can also be set with the CONTENTFUL_MANAGEMENT_ACCESS_TOKEN environment variable.",
+				Optional:    true,
+				Sensitive:   true,
 			},
 		},
 	}
@@ -99,7 +103,7 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	var contentfulURL string
-	if !data.URL.IsNull() {
+	if !data.URL.IsNull() && !data.URL.IsUnknown() {
 		contentfulURL = data.URL.ValueString()
 	} else if contentfulURLFromEnv, found := os.LookupEnv("CONTENTFUL_URL"); found {
 		contentfulURL = contentfulURLFromEnv
@@ -114,11 +118,13 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	if contentfulURL == "" {
-		resp.Diagnostics.AddAttributeError(path.Root("url"), "Failed to configure client", "No API URL provided")
+		resp.Diagnostics.AddAttributeError(path.Root("url"), "Missing Contentful API URL", "Set the url provider attribute or the CONTENTFUL_URL environment variable.")
+	} else {
+		resp.Diagnostics.Append(validateContentfulURL(contentfulURL)...)
 	}
 
 	var accessToken string
-	if !data.AccessToken.IsNull() {
+	if !data.AccessToken.IsNull() && !data.AccessToken.IsUnknown() {
 		accessToken = data.AccessToken.ValueString()
 	} else {
 		if accessTokenFromEnv, found := os.LookupEnv("CONTENTFUL_MANAGEMENT_ACCESS_TOKEN"); found {
@@ -131,7 +137,7 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	if accessToken == "" {
-		resp.Diagnostics.AddAttributeError(path.Root("access_token"), "Failed to configure client", "No access token provided")
+		resp.Diagnostics.AddAttributeError(path.Root("access_token"), "Missing Contentful management access token", "Set the access_token provider attribute or the CONTENTFUL_MANAGEMENT_ACCESS_TOKEN environment variable.")
 	}
 
 	if resp.Diagnostics.HasError() {
@@ -152,7 +158,9 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 		cm.WithClient(util.NewClientWithUserAgent(retryableClient.StandardClient(), "terraform-provider-contentful/"+p.version)),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to create Contentful client: %s", err.Error())
+		resp.Diagnostics.AddError("Failed to create Contentful client", err.Error())
+
+		return
 	}
 
 	providerData := ContentfulProviderData{
@@ -164,6 +172,23 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 	resp.DataSourceData = providerData
 	resp.ListResourceData = providerData
 	resp.ResourceData = providerData
+}
+
+func validateContentfulURL(rawURL string) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		diags.AddAttributeError(path.Root("url"), "Invalid Contentful API URL", "The url provider attribute must be an absolute HTTP or HTTPS URL, such as https://api.contentful.com. It can also be set with the CONTENTFUL_URL environment variable.")
+
+		return diags
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		diags.AddAttributeError(path.Root("url"), "Invalid Contentful API URL", "The url provider attribute must use the http or https scheme.")
+	}
+
+	return diags
 }
 
 func (p *ContentfulProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {

--- a/internal/provider/contentful_provider_test.go
+++ b/internal/provider/contentful_provider_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
@@ -56,21 +57,49 @@ func TestProtocol6ProviderServerSchemaVersion(t *testing.T) {
 	assert.EqualValues(t, 0, resp.Provider.Version)
 }
 
+func TestProtocol6ProviderServerSchemaDocumentsProviderConfiguration(t *testing.T) {
+	t.Parallel()
+
+	providerServer, err := testAccProtoV6ProviderFactories["contentful"]()
+	require.NotNil(t, providerServer)
+	require.NoError(t, err)
+
+	resp, err := providerServer.GetProviderSchema(t.Context(), &tfprotov6.GetProviderSchemaRequest{})
+	require.NotNil(t, resp.Provider)
+	require.NoError(t, err)
+	require.Empty(t, resp.Diagnostics)
+
+	attributes := map[string]*tfprotov6.SchemaAttribute{}
+	for _, attribute := range resp.Provider.Block.Attributes {
+		attributes[attribute.Name] = attribute
+	}
+
+	require.Contains(t, attributes, "url")
+	assert.Contains(t, attributes["url"].Description, "CONTENTFUL_URL")
+	assert.Contains(t, attributes["url"].Description, "public Contentful Management API")
+
+	require.Contains(t, attributes, "access_token")
+	assert.True(t, attributes["access_token"].Sensitive)
+	assert.Contains(t, attributes["access_token"].Description, "CONTENTFUL_MANAGEMENT_ACCESS_TOKEN")
+}
+
 func TestProtocol6ProviderServerConfigure(t *testing.T) {
 	if os.Getenv("TF_ACC") != "" {
 		return
 	}
 
 	tests := map[string]struct {
-		config          map[string]any
-		env             map[string]string
-		expectedSuccess bool
+		config                    map[string]any
+		env                       map[string]string
+		expectedSuccess           bool
+		expectedDiagnosticSummary string
 	}{
 		"config: url": {
 			config: map[string]any{
 				"url": "https://api.test.contentful.com",
 			},
-			expectedSuccess: false,
+			expectedSuccess:           false,
+			expectedDiagnosticSummary: "Missing Contentful management access token",
 		},
 		"config: access_token": {
 			config: map[string]any{
@@ -90,13 +119,31 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 				"url":          "url://an invalid url %/",
 				"access_token": "CFPAT-12345",
 			},
-			expectedSuccess: false,
+			expectedSuccess:           false,
+			expectedDiagnosticSummary: "Invalid Contentful API URL",
+		},
+		"config: url(relative),access_token": {
+			config: map[string]any{
+				"url":          "/relative",
+				"access_token": "CFPAT-12345",
+			},
+			expectedSuccess:           false,
+			expectedDiagnosticSummary: "Invalid Contentful API URL",
+		},
+		"config: url(unsupported-scheme),access_token": {
+			config: map[string]any{
+				"url":          "ftp://api.test.contentful.com",
+				"access_token": "CFPAT-12345",
+			},
+			expectedSuccess:           false,
+			expectedDiagnosticSummary: "Invalid Contentful API URL",
 		},
 		"env: url": {
 			env: map[string]string{
 				"CONTENTFUL_URL": "https://api.test.contentful.com",
 			},
-			expectedSuccess: false,
+			expectedSuccess:           false,
+			expectedDiagnosticSummary: "Missing Contentful management access token",
 		},
 		"env: url,access_token": {
 			env: map[string]string{
@@ -140,7 +187,24 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 				assert.Empty(t, resp.Diagnostics)
 			} else {
 				assert.NotEmpty(t, resp.Diagnostics)
+				assertDiagnosticSummary(t, resp.Diagnostics, test.expectedDiagnosticSummary)
 			}
 		})
 	}
+}
+
+func assertDiagnosticSummary(t *testing.T, diagnostics []*tfprotov6.Diagnostic, expectedSummary string) {
+	t.Helper()
+
+	if expectedSummary == "" {
+		return
+	}
+
+	for _, diagnostic := range diagnostics {
+		if strings.Contains(diagnostic.Summary, expectedSummary) {
+			return
+		}
+	}
+
+	t.Fatalf("expected diagnostic summary %q in %#v", expectedSummary, diagnostics)
 }


### PR DESCRIPTION
## Summary

- document provider `url` and `access_token` configuration, including supported environment variables
- validate configured Contentful API URLs before constructing the client
- return clearer provider diagnostics for missing tokens and invalid URLs
- add protocol-level tests for schema documentation and diagnostic summaries

## Validation

- `go test ./...`
- `golangci-lint cache clean`
- `golangci-lint run`
