### PR TITLE
ci(golangci): update lint binary

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -24,5 +24,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.12.1
+          version: v2.12.2
           skip-cache: true


### PR DESCRIPTION
## Summary
- update the golangci-lint workflow binary from v2.12.1 to v2.12.2

## Verification
- go build ./...
- go test ./...
- golangci-lint cache clean
- golangci-lint run