### PR TITLE
support(provider): write-only secret arguments

### DIFF
--- a/docs/resources/app_signing_secret.md
+++ b/docs/resources/app_signing_secret.md
@@ -34,11 +34,14 @@ resource "random_password" "contentful_app_signing_secret" {
 
 - `app_definition_id` (String) ID of the app definition for which the signing secret is created.
 - `organization_id` (String) ID of the organization that owns the app.
-- `value` (String, Sensitive) The symmetric key shared between Contentful and an app backend. Must be exactly 64 characters long and contain only alphanumeric characters (a-z, A-Z, 0-9).
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
+- `value` (String, Sensitive) The symmetric key shared between Contentful and an app backend. Must be exactly 64 characters long and contain only alphanumeric characters (a-z, A-Z, 0-9).
+- `value_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only alternative to value. The symmetric key shared between Contentful and an app backend. Must be exactly 64 characters long and contain only alphanumeric characters (a-z, A-Z, 0-9).
 
 ### Read-Only
 

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -150,13 +150,11 @@ Required:
 <a id="nestedatt--headers"></a>
 ### Nested Schema for `headers`
 
-Required:
-
-- `value` (String)
-
 Optional:
 
 - `secret` (Boolean)
+- `value` (String)
+- `value_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments))
 
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/write-only-and-ephemeral-secrets.md
+++ b/docs/write-only-and-ephemeral-secrets.md
@@ -1,0 +1,335 @@
+# Write-only arguments and ephemeral secret use cases
+
+This note evaluates where the provider could use Terraform write-only arguments or ephemeral resources to reduce secret persistence in plan and state artifacts.
+
+It is intentionally scoped to potential use cases. It does not propose changing existing resource behavior without a compatibility decision.
+
+## Sources
+
+- Terraform Plugin Framework write-only arguments: <https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments>
+- Terraform Plugin Framework ephemeral resources: <https://developer.hashicorp.com/terraform/plugin/framework/ephemeral-resources>
+- Terraform language ephemeral blocks: <https://developer.hashicorp.com/terraform/language/ephemeral>
+- Contentful Personal Access Tokens: <https://www.contentful.com/help/token-management/personal-access-tokens/>
+- Local Contentful OpenAPI schemas under `internal/contentful-management-go/openapi/schemas/`
+- Local provider schemas under `internal/provider/`
+
+## Current provider surface reviewed
+
+The provider currently registers these managed resources:
+
+- `contentful_app_definition`
+- `contentful_app_signing_secret`
+- `contentful_app_installation`
+- `contentful_content_type`
+- `contentful_delivery_api_key`
+- `contentful_editor_interface`
+- `contentful_environment_alias`
+- `contentful_environment`
+- `contentful_entry`
+- `contentful_extension`
+- `contentful_personal_access_token`
+- `contentful_resource_provider`
+- `contentful_resource_type`
+- `contentful_role`
+- `contentful_space_enablements`
+- `contentful_tag`
+- `contentful_team`
+- `contentful_team_space_membership`
+- `contentful_webhook`
+
+The provider currently registers these data sources:
+
+- `contentful_app_definition`
+- `contentful_environment_status_ready`
+- `contentful_marketplace_app_definition`
+- `contentful_preview_api_key`
+
+The provider currently registers these list resources:
+
+- `contentful_content_type`
+- `contentful_entry`
+
+## Terraform semantics
+
+Write-only arguments are for managed resource attributes that a practitioner can configure but Terraform does not persist to plan or state. Terraform Plugin Framework documentation says write-only arguments are supported in Terraform 1.11 and later, should be used for secrets such as passwords or API keys that do not need to be persisted, and are only available from configuration.
+
+Important constraints:
+
+- Write-only arguments are resource arguments, not data source outputs.
+- Write-only values are not available from prior state during read.
+- Write-only arguments cannot be used with set attributes, set nested attributes, or set nested blocks.
+- A provider should be the terminal consumer of a write-only value: it should use the value in an API call or ignore it.
+
+Ephemeral resources are different. Terraform opens an ephemeral resource during an operation and guarantees its result data is not persisted in plan or state. The language docs describe ephemeral blocks as suitable for sensitive or temporary data that should not persist. The framework docs describe ephemeral resources as external data references whose data is not persisted.
+
+Important constraints:
+
+- Ephemeral results can only be used in ephemeral contexts.
+- Ephemeral resources are not managed resources; they do not have durable Terraform state.
+- An ephemeral resource that creates a remote object must either leave an intentionally unmanaged object behind or clean it up using the ephemeral lifecycle. That is a product decision, not just a schema choice.
+
+## Strong write-only candidate: app signing secret value
+
+### Current provider behavior
+
+`contentful_app_signing_secret.value` is currently a required sensitive string:
+
+```go
+"value": schema.StringAttribute{
+	Description: "The symmetric key shared between Contentful and an app backend. Must be exactly 64 characters long and contain only alphanumeric characters (a-z, A-Z, 0-9).",
+	Required:    true,
+	Sensitive:   true,
+},
+```
+
+Source: `internal/provider/resource_app_signing_secret_schema.go`.
+
+The local Contentful OpenAPI response schema for app signing secrets returns `redactedValue`, not the raw secret:
+
+```yaml
+AppSigningSecretData:
+  type: object
+  properties:
+    redactedValue:
+      type: string
+  required:
+    - redactedValue
+```
+
+Source: `internal/contentful-management-go/openapi/schemas/app-signing-secret/data.yml`.
+
+### Evaluation
+
+This is the cleanest write-only use case.
+
+The secret is supplied by the practitioner and sent to Contentful. Contentful does not return the raw value on read; it returns a redacted value. Keeping the raw value in Terraform state is therefore useful only for Terraform drift comparison, not because the API can verify the value.
+
+A write-only replacement or companion argument would align with Terraform's intended use case for secrets that the provider consumes in an API request.
+
+### Open design choices
+
+- Keep the existing `value` argument for compatibility and add a new `value_wo` argument.
+- Replace `value` with a write-only argument in a breaking release.
+- Add a version/checksum companion argument, such as `value_wo_version`, so users can intentionally trigger updates when the write-only value changes.
+
+The version/checksum choice matters because Terraform cannot diff a write-only value against state.
+
+## Possible write-only candidate: secret webhook header values
+
+### Current provider behavior
+
+Contentful webhook headers are modeled with `key`, `value`, and `secret` in the local OpenAPI schema:
+
+```yaml
+WebhookDefinitionHeader:
+  type: object
+  properties:
+    key:
+      type: string
+    value:
+      type: string
+    secret:
+      type: boolean
+  required:
+    - key
+```
+
+Source: `internal/contentful-management-go/openapi/schemas/webhook-definition/headers.yml`.
+
+The provider currently models webhook headers as a map of nested objects, each containing `value` and `secret`.
+
+On read, the provider preserves the prior configured value when Contentful omits the value for a secret header:
+
+```go
+if existingHeaderValue, existingHeaderValueOk := existingHeaderValue.GetValue(); existingHeaderValueOk {
+	value.Value = existingHeaderValue.Value
+}
+
+if headerValue, ok := header.Value.Get(); ok {
+	value.Value = types.StringValue(headerValue)
+} else if !headerIsSecret {
+	value.Value = types.StringNull()
+}
+```
+
+Source: `internal/provider/webhook_header_value_response.go`.
+
+### Evaluation
+
+Secret webhook headers are a real state-exposure concern. The current state-preservation behavior is pragmatic for diff stability, but it means a secret header value remains in Terraform state if the user configured it.
+
+A write-only path would better match Contentful's secret-header semantics when `secret = true`.
+
+This case is less straightforward than app signing secrets because the secret is nested inside a map attribute. Terraform supports write-only nested attributes, but the schema shape must be checked carefully against framework constraints. The framework explicitly disallows write-only arguments in set attributes, set nested attributes, and set nested blocks. The current schema uses a map nested attribute, which is more promising than a set, but the exact provider framework version and generated schema behavior still need verification before implementation.
+
+### Open design choices
+
+- Add a write-only nested field such as `headers.<name>.value_wo` for secret headers and keep `headers.<name>.value` for non-secret or compatibility behavior.
+- Add a parallel map such as `secret_header_values_wo` to avoid mixing write-only and persisted fields inside the same nested object.
+- Do not change this until the app signing secret case has established the provider's write-only pattern.
+
+The parallel-map option is less elegant but may be easier to validate and document.
+
+## Potential ephemeral resource: create a personal access token
+
+### Current provider behavior
+
+`contentful_personal_access_token` is a managed resource. Its schema exposes:
+
+- `name` as required and replacement-forcing
+- `expires_in` as optional and replacement-forcing
+- `scopes` as required and replacement-forcing
+- `token` as computed and sensitive
+
+The schema description for `token` already documents the one-time nature of the value:
+
+```go
+"token": schema.StringAttribute{
+	Description: "The access token for the Content Management API. This is only available immediately after creation.",
+	Computed:    true,
+	Sensitive:   true,
+},
+```
+
+Source: `internal/provider/resource_personal_access_token_schema.go`.
+
+Contentful's public PAT documentation says the create response contains the generated access token and that this is the only time it is shown. The same documentation says later GET endpoints return name, scope, and metadata, but not the token itself.
+
+### Why this is not a write-only argument
+
+The PAT token value is generated by Contentful. The practitioner does not provide the token value to the provider.
+
+Write-only arguments solve the inverse problem: a practitioner provides a secret value and the provider sends it to the remote API without persisting it. A generated PAT's secret value is a computed result. Terraform write-only arguments cannot represent computed output values, and the framework docs state that write-only argument values are only available in configuration.
+
+Therefore, `contentful_personal_access_token.token` is not a good write-only argument candidate.
+
+### Why an ephemeral PAT resource could make sense
+
+An ephemeral PAT resource could create the PAT during Terraform execution, return the generated token only as ephemeral result data, and avoid storing the token in plan or state.
+
+The one-time retrieval behavior is not a blocker. It is the reason an ephemeral resource may be the right abstraction:
+
+1. Terraform opens the ephemeral resource during the operation.
+2. The provider calls Contentful's create PAT endpoint.
+3. Contentful returns the generated token in that create response.
+4. The provider returns the token as ephemeral result data.
+5. Terraform allows that token only in ephemeral contexts and does not persist it to plan or state.
+
+The provider does not need to retrieve the token later, because an ephemeral resource has no durable state that must be refreshed with the token value on future plans. Future operations that need a token would open the ephemeral resource again and create a new PAT.
+
+### Proposed shape
+
+A possible ephemeral resource could be named one of:
+
+- `contentful_personal_access_token`
+- `contentful_generated_personal_access_token`
+- `contentful_temporary_personal_access_token`
+
+Configuration:
+
+- `name`
+- `scopes`
+- `expires_in`
+
+Result data:
+
+- `id`
+- `token`
+- `expires_at`
+
+Lifecycle:
+
+- Open: create the PAT and return `id`, `token`, and metadata.
+- Renew: probably unsupported unless Contentful adds a token-extension API. If the token can expire during a long operation, users should set `expires_in` long enough for the run.
+- Close: revoke the PAT if an `id` is available.
+
+### Main risk
+
+The close behavior is the hard part.
+
+If close revokes the PAT, the resource is truly temporary and matches Terraform's ephemeral model. If close does not revoke it, each Terraform operation that opens the ephemeral resource can leave behind a real Contentful PAT that is not managed by Terraform state. That is operationally risky unless the PAT is short-lived and explicitly documented as unmanaged after creation.
+
+Because Contentful supports expiry dates for PATs, `expires_in` should probably be required or have a strict maximum for an ephemeral PAT resource. A no-expiry ephemeral PAT would be a poor default because a failed Terraform run could leave a long-lived unmanaged credential behind.
+
+### Useful cases
+
+An ephemeral PAT resource could be useful when a Terraform operation needs a newly minted Contentful CMA token only during the same run, for example:
+
+- Passing a generated CMA token into another provider's ephemeral provider configuration.
+- Sending a token into a write-only argument on another resource.
+- Bootstrapping an external integration that accepts a token during apply and stores it outside Terraform state.
+
+It would not be useful for ordinary managed resources that must persist their arguments in Terraform state. Terraform will reject ephemeral values in non-ephemeral contexts.
+
+## Non-candidates or weak candidates
+
+### Delivery API key access token
+
+`contentful_delivery_api_key.access_token` is computed and sensitive. The local Contentful OpenAPI schema models delivery API key `accessToken` as response data:
+
+```yaml
+ApiKeyData:
+  allOf:
+    - $ref: "./request-data.yml#/ApiKeyRequestData"
+    - type: object
+      properties:
+        accessToken:
+          type: string
+        preview_api_key:
+          $ref: "../links/preview-api-key-link.yml#/PreviewAPIKeyLink"
+      required:
+        - accessToken
+```
+
+Source: `internal/contentful-management-go/openapi/schemas/api-key/data.yml`.
+
+Because Contentful returns this token as normal readable API data, it is weaker as an ephemeral resource candidate. Keeping it as sensitive computed resource state is consistent with normal Terraform behavior, unless the provider adopts a stricter "no API token in state" policy.
+
+### Preview API key data source access token
+
+`contentful_preview_api_key.access_token` is computed and sensitive. The local Contentful OpenAPI schema models preview API key `accessToken` as response data:
+
+```yaml
+PreviewApiKeyData:
+  type: object
+  properties:
+    name:
+      type: string
+    description:
+      type: string
+      nullable: true
+    accessToken:
+      type: string
+    environments:
+      type: array
+      items:
+        $ref: "../links/environment-link.yml#/EnvironmentLink"
+  required:
+    - name
+    - accessToken
+```
+
+Source: `internal/contentful-management-go/openapi/schemas/preview-api-key/data.yml`.
+
+This is a state-exposure concern, but not a Contentful one-time retrieval problem. An ephemeral variant could be justified only by a provider policy that readable API tokens should not be available through normal data sources.
+
+### App definitions, marketplace app definitions, environment readiness, content types, entries, and other configuration resources
+
+These do not show the same one-time secret or practitioner-supplied secret semantics in the reviewed provider schemas. They are not good write-only or ephemeral candidates based on the evidence reviewed here.
+
+## Recommended implementation order
+
+1. Decide the compatibility policy for `contentful_app_signing_secret.value`.
+2. If write-only support is accepted, implement the app signing secret case first.
+3. Validate Terraform Plugin Framework support for write-only nested attributes inside map nested attributes before changing webhook headers.
+4. Treat ephemeral PAT support as a separate feature with an explicit lifecycle decision: revoke on close, require bounded expiry, or do not implement.
+
+## Decisions needed
+
+Before implementation, choose:
+
+1. Should write-only support be compatibility-preserving, with new `*_wo` arguments, or breaking, by changing existing arguments?
+2. Should write-only secrets require a companion trigger/version argument so users can force updates when a write-only value changes?
+3. For ephemeral PATs, should the provider revoke the token on close?
+4. Should an ephemeral PAT require `expires_in` and enforce a maximum TTL?
+5. Should readable API tokens, such as delivery and preview API keys, remain normal sensitive values or get separate ephemeral variants under a stricter no-token-state policy?

--- a/internal/provider/app_signing_secret_model.go
+++ b/internal/provider/app_signing_secret_model.go
@@ -14,7 +14,8 @@ type AppSigningSecretModel struct {
 	IDIdentityModel
 	AppSigningSecretIdentityModel
 
-	Value types.String `tfsdk:"value"`
+	Value   types.String `tfsdk:"value"`
+	ValueWO types.String `tfsdk:"value_wo"`
 
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/provider/app_signing_secret_model_request.go
+++ b/internal/provider/app_signing_secret_model_request.go
@@ -6,6 +6,7 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func (m *AppSigningSecretModel) ToAppSigningSecretRequest(_ context.Context, _ path.Path) (cm.AppSigningSecretRequestData, diag.Diagnostics) {
@@ -16,4 +17,29 @@ func (m *AppSigningSecretModel) ToAppSigningSecretRequest(_ context.Context, _ p
 	}
 
 	return req, diags
+}
+
+func AppSigningSecretModelWithWriteOnlySecrets(plan, config AppSigningSecretModel) (AppSigningSecretModel, WriteOnlySecretValues, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	values := WriteOnlySecretValues{}
+	model := plan
+
+	value, usedWriteOnly, valueDiags := resolveStringSecret(
+		config.Value,
+		config.ValueWO,
+		path.Root("value"),
+		path.Root("value_wo"),
+		true,
+	)
+	diags.Append(valueDiags...)
+
+	model.Value = value
+	model.ValueWO = types.StringNull()
+
+	if usedWriteOnly {
+		values.Add(path.Root("value_wo"), config.ValueWO)
+	}
+
+	return model, values, diags
 }

--- a/internal/provider/app_signing_secret_model_response.go
+++ b/internal/provider/app_signing_secret_model_response.go
@@ -20,6 +20,7 @@ func NewAppSigningSecretResourceModelFromResponse(_ context.Context, res cm.AppS
 			OrganizationID:  types.StringValue(organizationID),
 			AppDefinitionID: types.StringValue(appDefinitionID),
 		},
+		ValueWO: types.StringNull(),
 	}
 
 	return model, diags

--- a/internal/provider/resource_app_signing_secret.go
+++ b/internal/provider/resource_app_signing_secret.go
@@ -17,6 +17,7 @@ var (
 	_ resource.ResourceWithConfigure   = (*appSigningSecretResource)(nil)
 	_ resource.ResourceWithIdentity    = (*appSigningSecretResource)(nil)
 	_ resource.ResourceWithImportState = (*appSigningSecretResource)(nil)
+	_ resource.ResourceWithModifyPlan  = (*appSigningSecretResource)(nil)
 )
 
 //nolint:ireturn
@@ -56,10 +57,31 @@ func (r *appSigningSecretResource) ImportState(ctx context.Context, req resource
 	}, req, resp)
 }
 
-func (r *appSigningSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan AppSigningSecretModel
+func (r *appSigningSecretResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, config AppSigningSecretModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, values, modelDiags := AppSigningSecretModelWithWriteOnlySecrets(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	markWriteOnlySecretChange(ctx, req, resp, values)
+}
+
+func (r *appSigningSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan, config AppSigningSecretModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -80,7 +102,10 @@ func (r *appSigningSecretResource) Create(ctx context.Context, req resource.Crea
 		AppDefinitionID: plan.AppDefinitionID.ValueString(),
 	}
 
-	request, requestDiags := plan.ToAppSigningSecretRequest(ctx, path.Empty())
+	requestModel, writeOnlySecrets, modelDiags := AppSigningSecretModelWithWriteOnlySecrets(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	request, requestDiags := requestModel.ToAppSigningSecretRequest(ctx, path.Empty())
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -103,8 +128,8 @@ func (r *appSigningSecretResource) Create(ctx context.Context, req resource.Crea
 		responseModel, responseModelDiags := NewAppSigningSecretResourceModelFromResponse(ctx, response.Response)
 		resp.Diagnostics.Append(responseModelDiags...)
 
-		if responseModel.Value.IsNull() && !plan.Value.IsUnknown() {
-			responseModel.Value = plan.Value
+		if responseModel.Value.IsNull() && !requestModel.Value.IsUnknown() && !writeOnlyStringConfigured(config.ValueWO) {
+			responseModel.Value = requestModel.Value
 		}
 
 		data = responseModel
@@ -124,6 +149,7 @@ func (r *appSigningSecretResource) Create(ctx context.Context, req resource.Crea
 
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(writeWriteOnlySecretHashes(ctx, resp.Private, writeOnlySecrets)...)
 }
 
 func (r *appSigningSecretResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -200,10 +226,11 @@ func (r *appSigningSecretResource) Read(ctx context.Context, req resource.ReadRe
 }
 
 func (r *appSigningSecretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state, plan AppSigningSecretModel
+	var state, plan, config AppSigningSecretModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -224,7 +251,10 @@ func (r *appSigningSecretResource) Update(ctx context.Context, req resource.Upda
 		AppDefinitionID: plan.AppDefinitionID.ValueString(),
 	}
 
-	request, requestDiags := plan.ToAppSigningSecretRequest(ctx, path.Empty())
+	requestModel, writeOnlySecrets, modelDiags := AppSigningSecretModelWithWriteOnlySecrets(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	request, requestDiags := requestModel.ToAppSigningSecretRequest(ctx, path.Empty())
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -248,10 +278,12 @@ func (r *appSigningSecretResource) Update(ctx context.Context, req resource.Upda
 		resp.Diagnostics.Append(responseModelDiags...)
 
 		if responseModel.Value.IsNull() {
-			if !plan.Value.IsUnknown() {
-				responseModel.Value = plan.Value
-			} else if !state.Value.IsUnknown() {
-				responseModel.Value = state.Value
+			if !writeOnlyStringConfigured(config.ValueWO) {
+				if !requestModel.Value.IsUnknown() {
+					responseModel.Value = requestModel.Value
+				} else if !state.Value.IsUnknown() {
+					responseModel.Value = state.Value
+				}
 			}
 		}
 
@@ -272,6 +304,7 @@ func (r *appSigningSecretResource) Update(ctx context.Context, req resource.Upda
 
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(writeWriteOnlySecretHashes(ctx, resp.Private, writeOnlySecrets)...)
 }
 
 //nolint:dupl

--- a/internal/provider/resource_app_signing_secret_schema.go
+++ b/internal/provider/resource_app_signing_secret_schema.go
@@ -35,8 +35,14 @@ func AppSigningSecretResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"value": schema.StringAttribute{
 				Description: "The symmetric key shared between Contentful and an app backend. Must be exactly 64 characters long and contain only alphanumeric characters (a-z, A-Z, 0-9).",
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
+			},
+			"value_wo": schema.StringAttribute{
+				Description: "Write-only alternative to value. The symmetric key shared between Contentful and an app backend. Must be exactly 64 characters long and contain only alphanumeric characters (a-z, A-Z, 0-9).",
+				Optional:    true,
+				Sensitive:   true,
+				WriteOnly:   true,
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
 		},

--- a/internal/provider/resource_webhook.go
+++ b/internal/provider/resource_webhook.go
@@ -17,6 +17,7 @@ var (
 	_ resource.ResourceWithConfigure   = (*webhookResource)(nil)
 	_ resource.ResourceWithIdentity    = (*webhookResource)(nil)
 	_ resource.ResourceWithImportState = (*webhookResource)(nil)
+	_ resource.ResourceWithModifyPlan  = (*webhookResource)(nil)
 )
 
 //nolint:ireturn
@@ -56,10 +57,31 @@ func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportSt
 	}, req, resp)
 }
 
-func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan WebhookModel
+func (r *webhookResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, config WebhookModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, values, modelDiags := WebhookModelWithWriteOnlySecrets(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	markWriteOnlySecretChange(ctx, req, resp, values)
+}
+
+func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan, config WebhookModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -81,7 +103,10 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 		SpaceID: plan.SpaceID.ValueString(),
 	}
 
-	request, requestDiags := plan.ToWebhookDefinitionData(ctx, path.Empty())
+	requestModel, writeOnlySecrets, modelDiags := WebhookModelWithWriteOnlySecrets(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	request, requestDiags := requestModel.ToWebhookDefinitionData(ctx, path.Empty())
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -101,7 +126,7 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 
 	switch response := response.(type) {
 	case *cm.WebhookDefinitionStatusCode:
-		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, plan.Headers.Elements())
+		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, requestModel.Headers.Elements())
 		resp.Diagnostics.Append(responseModelDiags...)
 
 		data = responseModel
@@ -123,6 +148,7 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	resp.Diagnostics.Append(SetPrivateProviderData(ctx, resp.Private, "version", currentVersion)...)
+	resp.Diagnostics.Append(writeWriteOnlySecretHashes(ctx, resp.Private, writeOnlySecrets)...)
 }
 
 func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -199,9 +225,10 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 }
 
 func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan WebhookModel
+	var plan, config WebhookModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -228,7 +255,10 @@ func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest
 		XContentfulVersion:  currentVersion,
 	}
 
-	request, requestDiags := plan.ToWebhookDefinitionData(ctx, path.Empty())
+	requestModel, writeOnlySecrets, modelDiags := WebhookModelWithWriteOnlySecrets(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	request, requestDiags := requestModel.ToWebhookDefinitionData(ctx, path.Empty())
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -248,7 +278,7 @@ func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	switch response := response.(type) {
 	case *cm.WebhookDefinitionStatusCode:
-		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, plan.Headers.Elements())
+		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, requestModel.Headers.Elements())
 		resp.Diagnostics.Append(responseModelDiags...)
 
 		data = responseModel
@@ -270,6 +300,7 @@ func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identityModel)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	resp.Diagnostics.Append(SetPrivateProviderData(ctx, resp.Private, "version", currentVersion)...)
+	resp.Diagnostics.Append(writeWriteOnlySecretHashes(ctx, resp.Private, writeOnlySecrets)...)
 }
 
 //nolint:dupl

--- a/internal/provider/resource_webhook.go
+++ b/internal/provider/resource_webhook.go
@@ -126,7 +126,7 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 
 	switch response := response.(type) {
 	case *cm.WebhookDefinitionStatusCode:
-		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, requestModel.Headers.Elements())
+		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, requestModel.Headers)
 		resp.Diagnostics.Append(responseModelDiags...)
 
 		data = responseModel
@@ -191,7 +191,7 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	switch response := response.(type) {
 	case *cm.WebhookDefinition:
-		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, *response, state.Headers.Elements())
+		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, *response, state.Headers)
 		resp.Diagnostics.Append(responseModelDiags...)
 
 		data = responseModel
@@ -278,7 +278,7 @@ func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	switch response := response.(type) {
 	case *cm.WebhookDefinitionStatusCode:
-		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, requestModel.Headers.Elements())
+		responseModel, responseModelDiags := NewWebhookResourceModelFromResponse(ctx, response.Response, requestModel.Headers)
 		resp.Diagnostics.Append(responseModelDiags...)
 
 		data = responseModel

--- a/internal/provider/webhook_filters_schema.go
+++ b/internal/provider/webhook_filters_schema.go
@@ -105,7 +105,12 @@ func (v WebhookFilterValue) SchemaAttributes(ctx context.Context) map[string]sch
 func (v WebhookHeaderValue) SchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"value": schema.StringAttribute{
-			Required: true,
+			Optional: true,
+		},
+		"value_wo": schema.StringAttribute{
+			Optional:  true,
+			Sensitive: true,
+			WriteOnly: true,
 		},
 		"secret": schema.BoolAttribute{
 			Optional: true,

--- a/internal/provider/webhook_header_value.go
+++ b/internal/provider/webhook_header_value.go
@@ -5,6 +5,7 @@ import (
 )
 
 type WebhookHeaderValue struct {
-	Value  types.String `tfsdk:"value"`
-	Secret types.Bool   `tfsdk:"secret"`
+	Value   types.String `tfsdk:"value"`
+	ValueWO types.String `tfsdk:"value_wo"`
+	Secret  types.Bool   `tfsdk:"secret"`
 }

--- a/internal/provider/webhook_header_value_request.go
+++ b/internal/provider/webhook_header_value_request.go
@@ -16,7 +16,7 @@ func (v WebhookHeaderValue) ToWebhookDefinitionHeader(_ context.Context, path pa
 	}
 
 	if v.Value.IsNull() || v.Value.IsUnknown() {
-		diags.AddAttributeError(path.AtName("value"), "Value is required", "")
+		diags.AddAttributeError(path.AtName("value"), "One of value or value_wo is required", "")
 	}
 
 	header.Value = cm.NewOptPointerString(v.Value.ValueStringPointer())

--- a/internal/provider/webhook_header_value_response.go
+++ b/internal/provider/webhook_header_value_response.go
@@ -27,6 +27,7 @@ func NewWebhookHeaderValueFromResponse(_ context.Context, _ path.Path, header cm
 	}
 
 	value.Secret = types.BoolValue(headerIsSecret)
+	value.ValueWO = types.StringNull()
 
 	return NewTypedObject(value), diags
 }

--- a/internal/provider/webhook_header_value_test.go
+++ b/internal/provider/webhook_header_value_test.go
@@ -61,16 +61,19 @@ func TestWebhookHeaderValueInvalid(t *testing.T) {
 
 	testcases := map[string]map[string]attr.Value{
 		"invalid": {
-			"value":  types.DynamicNull(),
-			"secret": types.DynamicNull(),
+			"value":    types.DynamicNull(),
+			"value_wo": types.DynamicNull(),
+			"secret":   types.DynamicNull(),
 		},
 		"invalid value": {
-			"value":  types.DynamicNull(),
-			"secret": types.BoolNull(),
+			"value":    types.DynamicNull(),
+			"value_wo": types.StringNull(),
+			"secret":   types.BoolNull(),
 		},
 		"invalid secret": {
-			"value":  types.StringNull(),
-			"secret": types.DynamicNull(),
+			"value":    types.StringNull(),
+			"value_wo": types.StringNull(),
+			"secret":   types.DynamicNull(),
 		},
 	}
 
@@ -97,20 +100,24 @@ func TestWebhookHeaderValueConversion(t *testing.T) {
 	values := []AttrValueWithToObjectValue{
 		NewTypedObject(WebhookHeaderValue{}),
 		DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
-			"value":  types.StringUnknown(),
-			"secret": types.BoolUnknown(),
+			"value":    types.StringUnknown(),
+			"value_wo": types.StringUnknown(),
+			"secret":   types.BoolUnknown(),
 		})),
 		DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
-			"value":  types.StringNull(),
-			"secret": types.BoolNull(),
+			"value":    types.StringNull(),
+			"value_wo": types.StringNull(),
+			"secret":   types.BoolNull(),
 		})),
 		DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
-			"value":  types.StringValue("value"),
-			"secret": types.BoolValue(false),
+			"value":    types.StringValue("value"),
+			"value_wo": types.StringNull(),
+			"secret":   types.BoolValue(false),
 		})),
 		DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
-			"value":  types.StringValue("value"),
-			"secret": types.BoolValue(true),
+			"value":    types.StringValue("value"),
+			"value_wo": types.StringNull(),
+			"secret":   types.BoolValue(true),
 		})),
 	}
 
@@ -170,8 +177,9 @@ func TestWebhookHeaderTypeValueFromObject(t *testing.T) {
 		t.Parallel()
 
 		value, diags := types.ObjectValue(typ.AttributeTypes(), map[string]attr.Value{
-			"value":  types.StringValue("value"),
-			"secret": types.BoolValue(true),
+			"value":    types.StringValue("value"),
+			"value_wo": types.StringNull(),
+			"secret":   types.BoolValue(true),
 		})
 		assert.False(t, diags.HasError())
 

--- a/internal/provider/webhook_headers_response.go
+++ b/internal/provider/webhook_headers_response.go
@@ -8,13 +8,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-func ReadHeaderValueMapFromResponse(ctx context.Context, path path.Path, headers []cm.WebhookDefinitionHeader, existingHeaderValues map[string]TypedObject[WebhookHeaderValue]) (TypedMap[TypedObject[WebhookHeaderValue]], diag.Diagnostics) {
+func ReadHeaderValueMapFromResponse(ctx context.Context, path path.Path, headers []cm.WebhookDefinitionHeader, existingHeaderValues TypedMap[TypedObject[WebhookHeaderValue]]) (TypedMap[TypedObject[WebhookHeaderValue]], diag.Diagnostics) {
 	diags := diag.Diagnostics{}
+
+	if len(headers) == 0 && existingHeaderValues.IsNull() {
+		return NewTypedMapNull[TypedObject[WebhookHeaderValue]](), diags
+	}
 
 	headersValues := make(map[string]TypedObject[WebhookHeaderValue], len(headers))
 
 	for _, header := range headers {
-		existingHeader := existingHeaderValues[header.Key]
+		existingHeader := existingHeaderValues.Elements()[header.Key]
 
 		value, valueDiags := NewWebhookHeaderValueFromResponse(ctx, path.AtMapKey(header.Key), header, existingHeader)
 		diags.Append(valueDiags...)

--- a/internal/provider/webhook_headers_response_test.go
+++ b/internal/provider/webhook_headers_response_test.go
@@ -1,0 +1,26 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadHeaderValueMapFromResponsePreservesNullEmptyHeaders(t *testing.T) {
+	t.Parallel()
+
+	headers, diags := ReadHeaderValueMapFromResponse(
+		context.Background(),
+		path.Root("headers"),
+		[]cm.WebhookDefinitionHeader{},
+		NewTypedMapNull[TypedObject[WebhookHeaderValue]](),
+	)
+
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, headers.IsNull())
+}

--- a/internal/provider/webhook_headers_schema.go
+++ b/internal/provider/webhook_headers_schema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
 //nolint:ireturn
@@ -16,9 +15,5 @@ func WebhookHeadersSchema(ctx context.Context, optional bool) schema.Attribute {
 		},
 		CustomType: TypedMap[TypedObject[WebhookHeaderValue]]{}.CustomType(ctx),
 		Optional:   optional,
-		Computed:   true,
-		PlanModifiers: []planmodifier.Map{
-			UseStateForUnknown(),
-		},
 	}
 }

--- a/internal/provider/webhook_model_request.go
+++ b/internal/provider/webhook_model_request.go
@@ -2,12 +2,15 @@ package provider
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func (model *WebhookModel) ToWebhookDefinitionData(ctx context.Context, path path.Path) (cm.WebhookDefinitionData, diag.Diagnostics) {
@@ -63,4 +66,57 @@ func (model *WebhookModel) ToWebhookDefinitionData(ctx context.Context, path pat
 	req.Transformation = transformation
 
 	return req, diags
+}
+
+func WebhookModelWithWriteOnlySecrets(plan, config WebhookModel) (WebhookModel, WriteOnlySecretValues, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	values := WriteOnlySecretValues{}
+	model := plan
+
+	if plan.Headers.IsNull() || plan.Headers.IsUnknown() {
+		return model, values, diags
+	}
+
+	headers := maps.Clone(plan.Headers.Elements())
+
+	configHeaders := map[string]TypedObject[WebhookHeaderValue]{}
+	if !config.Headers.IsNull() && !config.Headers.IsUnknown() {
+		configHeaders = config.Headers.Elements()
+	}
+
+	headerKeys := slices.Sorted(maps.Keys(headers))
+	for _, key := range headerKeys {
+		header := headers[key].Value()
+		configHeader := WebhookHeaderValue{}
+
+		if configured, ok := configHeaders[key]; ok {
+			configHeader = configured.Value()
+		}
+
+		valuePath := path.Root("headers").AtMapKey(key).AtName("value")
+		valueWOPath := path.Root("headers").AtMapKey(key).AtName("value_wo")
+
+		value, usedWriteOnly, valueDiags := resolveStringSecret(
+			configHeader.Value,
+			configHeader.ValueWO,
+			valuePath,
+			valueWOPath,
+			true,
+		)
+		diags.Append(valueDiags...)
+
+		header.Value = value
+		header.ValueWO = types.StringNull()
+
+		if usedWriteOnly {
+			values.Add(valueWOPath, configHeader.ValueWO)
+		}
+
+		headers[key] = NewTypedObject(header)
+	}
+
+	model.Headers = NewTypedMap(headers)
+
+	return model, values, diags
 }

--- a/internal/provider/webhook_model_request_test.go
+++ b/internal/provider/webhook_model_request_test.go
@@ -78,8 +78,9 @@ func TestWebhookModelToWebhookDefinitionData(t *testing.T) {
 				URL:    types.StringValue("https://example.com/webhook"),
 				Headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
 					"X-Header": DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
-						"value":  types.StringValue("value"),
-						"secret": types.BoolValue(false),
+						"value":    types.StringValue("value"),
+						"value_wo": types.StringNull(),
+						"secret":   types.BoolValue(false),
 					})),
 				}),
 			},

--- a/internal/provider/webhook_model_response.go
+++ b/internal/provider/webhook_model_response.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func NewWebhookResourceModelFromResponse(ctx context.Context, webhookDefinition cm.WebhookDefinition, existingHeaderValues map[string]TypedObject[WebhookHeaderValue]) (WebhookModel, diag.Diagnostics) {
+func NewWebhookResourceModelFromResponse(ctx context.Context, webhookDefinition cm.WebhookDefinition, existingHeaderValues TypedMap[TypedObject[WebhookHeaderValue]]) (WebhookModel, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	spaceID := webhookDefinition.Sys.Space.Sys.ID

--- a/internal/provider/write_only_resource_models_test.go
+++ b/internal/provider/write_only_resource_models_test.go
@@ -1,0 +1,61 @@
+package provider_test
+
+import (
+	"testing"
+
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppSigningSecretModelWithWriteOnlySecret(t *testing.T) {
+	t.Parallel()
+
+	model, values, diags := AppSigningSecretModelWithWriteOnlySecrets(
+		AppSigningSecretModel{},
+		AppSigningSecretModel{
+			ValueWO: types.StringValue("write-only-secret"),
+		},
+	)
+
+	require.False(t, diags.HasError(), diags)
+	assert.Equal(t, "write-only-secret", model.Value.ValueString())
+	assert.True(t, model.ValueWO.IsNull())
+	assert.Len(t, values, 1)
+}
+
+func TestWebhookModelWithWriteOnlyHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	plan := WebhookModel{
+		Headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+			`x-"secret"\key`: NewTypedObject(WebhookHeaderValue{
+				Value:   types.StringNull(),
+				ValueWO: types.StringNull(),
+				Secret:  types.BoolValue(true),
+			}),
+		}),
+	}
+
+	config := WebhookModel{
+		Headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+			`x-"secret"\key`: NewTypedObject(WebhookHeaderValue{
+				Value:   types.StringNull(),
+				ValueWO: types.StringValue("write-only-secret"),
+				Secret:  types.BoolValue(true),
+			}),
+		}),
+	}
+
+	model, values, diags := WebhookModelWithWriteOnlySecrets(plan, config)
+
+	require.False(t, diags.HasError(), diags)
+
+	header := model.Headers.Elements()[`x-"secret"\key`].Value()
+	assert.Equal(t, "write-only-secret", header.Value.ValueString())
+	assert.True(t, header.ValueWO.IsNull())
+	assert.Len(t, values, 1)
+	assert.Equal(t, path.Root("headers").AtMapKey(`x-"secret"\key`).AtName("value_wo").String(), values[0].Path.String())
+}

--- a/internal/provider/write_only_secret.go
+++ b/internal/provider/write_only_secret.go
@@ -1,0 +1,321 @@
+package provider
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	writeOnlySecretHashesPrivateKey = "write_only_secret_hashes" // #nosec G101 -- private state key, not a credential.
+
+	writeOnlySecretArgon2IDMemory      = 64 * 1024
+	writeOnlySecretArgon2IDTime        = 1
+	writeOnlySecretArgon2IDParallelism = 4
+	writeOnlySecretSaltLength          = 16
+	writeOnlySecretKeyLength           = 32
+	writeOnlySecretParameterPartCount  = 3
+)
+
+type privateStateReader interface {
+	GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics)
+}
+
+type privateStateWriter interface {
+	SetKey(ctx context.Context, key string, value []byte) diag.Diagnostics
+}
+
+type WriteOnlySecretValue struct {
+	Path  path.Path
+	Value types.String
+}
+
+type WriteOnlySecretValues []WriteOnlySecretValue
+
+func (v *WriteOnlySecretValues) Add(argumentPath path.Path, value types.String) {
+	*v = append(*v, WriteOnlySecretValue{
+		Path:  argumentPath,
+		Value: value,
+	})
+}
+
+func writeOnlyStringConfigured(value types.String) bool {
+	return !value.IsNull() && !value.IsUnknown()
+}
+
+func resolveStringSecret(legacy, writeOnly types.String, legacyPath, writeOnlyPath path.Path, required bool) (types.String, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	legacyConfigured := writeOnlyStringConfigured(legacy)
+	writeOnlyConfigured := writeOnlyStringConfigured(writeOnly)
+
+	if legacyConfigured && writeOnlyConfigured {
+		diags.AddError(
+			"Conflicting secret arguments",
+			"Only one of "+legacyPath.String()+" and "+writeOnlyPath.String()+" can be configured.",
+		)
+
+		return types.StringNull(), false, diags
+	}
+
+	if writeOnlyConfigured {
+		return types.StringValue(writeOnly.ValueString()), true, diags
+	}
+
+	if legacyConfigured {
+		return legacy, false, diags
+	}
+
+	if required {
+		diags.AddError(
+			"Missing secret argument",
+			"One of "+legacyPath.String()+" or "+writeOnlyPath.String()+" must be configured.",
+		)
+	}
+
+	return types.StringNull(), false, diags
+}
+
+func writeOnlySecretPreimage(argumentPath path.Path, value types.String) []byte {
+	return []byte(argumentPath.String() + "\x00" + value.ValueString())
+}
+
+func writeOnlySecretHash(argumentPath path.Path, value types.String) (string, error) {
+	salt := make([]byte, writeOnlySecretSaltLength)
+
+	_, err := rand.Read(salt)
+	if err != nil {
+		return "", fmt.Errorf("generate write-only secret salt: %w", err)
+	}
+
+	key := argon2.IDKey(
+		writeOnlySecretPreimage(argumentPath, value),
+		salt,
+		writeOnlySecretArgon2IDTime,
+		writeOnlySecretArgon2IDMemory,
+		writeOnlySecretArgon2IDParallelism,
+		writeOnlySecretKeyLength,
+	)
+
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		writeOnlySecretArgon2IDMemory,
+		writeOnlySecretArgon2IDTime,
+		writeOnlySecretArgon2IDParallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(key),
+	), nil
+}
+
+func writeOnlySecretHashMatches(argumentPath path.Path, value types.String, hash string) bool {
+	parts := strings.Split(hash, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false
+	}
+
+	version, hasVersion := strings.CutPrefix(parts[2], "v=")
+	if !hasVersion {
+		return false
+	}
+
+	parsedVersion, err := strconv.Atoi(version)
+	if err != nil || parsedVersion != argon2.Version {
+		return false
+	}
+
+	parameters, hasMemoryParameter := strings.CutPrefix(parts[3], "m=")
+	if !hasMemoryParameter {
+		return false
+	}
+
+	parameterParts := strings.Split(parameters, ",")
+	if len(parameterParts) != writeOnlySecretParameterPartCount {
+		return false
+	}
+
+	memory, err := strconv.ParseUint(parameterParts[0], 10, 32)
+	if err != nil {
+		return false
+	}
+
+	timePart, hasTimeParameter := strings.CutPrefix(parameterParts[1], "t=")
+	if !hasTimeParameter {
+		return false
+	}
+
+	time, err := strconv.ParseUint(timePart, 10, 32)
+	if err != nil {
+		return false
+	}
+
+	parallelismPart, hasParallelismParameter := strings.CutPrefix(parameterParts[2], "p=")
+	if !hasParallelismParameter {
+		return false
+	}
+
+	parallelism, err := strconv.ParseUint(parallelismPart, 10, 8)
+	if err != nil {
+		return false
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false
+	}
+
+	expectedKey, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false
+	}
+
+	if len(expectedKey) != writeOnlySecretKeyLength {
+		return false
+	}
+
+	actualKey := argon2.IDKey(
+		writeOnlySecretPreimage(argumentPath, value),
+		salt,
+		uint32(time),
+		uint32(memory),
+		uint8(parallelism),
+		writeOnlySecretKeyLength,
+	)
+
+	return subtle.ConstantTimeCompare(actualKey, expectedKey) == 1
+}
+
+type writeOnlySecretHashRecord struct {
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+func readWriteOnlySecretHashes(ctx context.Context, private privateStateReader) ([]writeOnlySecretHashRecord, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if private == nil {
+		return nil, diags
+	}
+
+	data, getDiags := private.GetKey(ctx, writeOnlySecretHashesPrivateKey)
+	diags.Append(getDiags...)
+
+	if diags.HasError() || len(data) == 0 {
+		return nil, diags
+	}
+
+	var hashes []writeOnlySecretHashRecord
+
+	err := json.Unmarshal(data, &hashes)
+	if err != nil {
+		diags.AddError("Invalid write-only secret private state", err.Error())
+
+		return nil, diags
+	}
+
+	return hashes, diags
+}
+
+func writeWriteOnlySecretHashes(ctx context.Context, private privateStateWriter, values WriteOnlySecretValues) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if private == nil {
+		return diags
+	}
+
+	if len(values) == 0 {
+		diags.Append(private.SetKey(ctx, writeOnlySecretHashesPrivateKey, nil)...)
+
+		return diags
+	}
+
+	hashes := make([]writeOnlySecretHashRecord, 0, len(values))
+	for _, value := range values {
+		hash, err := writeOnlySecretHash(value.Path, value.Value)
+		if err != nil {
+			diags.AddError("Failed to create write-only secret hash", err.Error())
+
+			return diags
+		}
+
+		hashes = append(hashes, writeOnlySecretHashRecord{
+			Path: value.Path.String(),
+			Hash: hash,
+		})
+	}
+
+	data, err := json.Marshal(hashes)
+	if err != nil {
+		diags.AddError("Invalid write-only secret hashes", err.Error())
+
+		return diags
+	}
+
+	diags.Append(private.SetKey(ctx, writeOnlySecretHashesPrivateKey, data)...)
+
+	return diags
+}
+
+func writeOnlySecretHashesChanged(ctx context.Context, private privateStateReader, configured WriteOnlySecretValues) (bool, diag.Diagnostics) {
+	stored, diags := readWriteOnlySecretHashes(ctx, private)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	if len(stored) != len(configured) {
+		return true, diags
+	}
+
+	remaining := append([]writeOnlySecretHashRecord(nil), stored...)
+
+	for _, value := range configured {
+		matched := false
+
+		for index, record := range remaining {
+			if record.Path != value.Path.String() {
+				continue
+			}
+
+			if !writeOnlySecretHashMatches(value.Path, value.Value, record.Hash) {
+				return true, diags
+			}
+
+			remaining = append(remaining[:index], remaining[index+1:]...)
+			matched = true
+
+			break
+		}
+
+		if !matched {
+			return true, diags
+		}
+	}
+
+	return len(remaining) != 0, diags
+}
+
+func markWriteOnlySecretChange(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse, values WriteOnlySecretValues) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	changed, hashDiags := writeOnlySecretHashesChanged(ctx, req.Private, values)
+	resp.Diagnostics.Append(hashDiags...)
+
+	if resp.Diagnostics.HasError() || !changed {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("id"), types.StringUnknown())...)
+}

--- a/internal/provider/write_only_secret_test.go
+++ b/internal/provider/write_only_secret_test.go
@@ -1,0 +1,92 @@
+package provider //nolint:testpackage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveStringSecretConflicts(t *testing.T) {
+	t.Parallel()
+
+	_, _, diags := resolveStringSecret(
+		types.StringValue("legacy"),
+		types.StringValue("write-only"),
+		path.Root("value"),
+		path.Root("value_wo"),
+		true,
+	)
+
+	assert.True(t, diags.HasError())
+}
+
+func TestWriteOnlySecretHashIncludesPath(t *testing.T) {
+	t.Parallel()
+
+	value := types.StringValue("shared-secret")
+	valuePath := path.Root("value_wo")
+	headerPath := path.Root("headers").AtMapKey(`x-"secret"\key`).AtName("value_wo")
+
+	hash, err := writeOnlySecretHash(valuePath, value)
+	require.NoError(t, err)
+
+	assert.True(t, writeOnlySecretHashMatches(valuePath, value, hash))
+	assert.False(t, writeOnlySecretHashMatches(headerPath, value, hash))
+}
+
+func TestWriteOnlySecretHashesChanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	argumentPath := path.Root("value_wo")
+	value := types.StringValue("current-secret")
+
+	hash, err := writeOnlySecretHash(argumentPath, value)
+	require.NoError(t, err)
+
+	private := fakePrivateState{
+		values: map[string][]byte{
+			writeOnlySecretHashesPrivateKey: mustJSONMarshal(t, []writeOnlySecretHashRecord{{
+				Path: argumentPath.String(),
+				Hash: hash,
+			}}),
+		},
+	}
+
+	changed, diags := writeOnlySecretHashesChanged(ctx, private, WriteOnlySecretValues{{
+		Path:  argumentPath,
+		Value: value,
+	}})
+	require.False(t, diags.HasError(), diags)
+	assert.False(t, changed)
+
+	changed, diags = writeOnlySecretHashesChanged(ctx, private, WriteOnlySecretValues{{
+		Path:  argumentPath,
+		Value: types.StringValue("rotated-secret"),
+	}})
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, changed)
+}
+
+type fakePrivateState struct {
+	values map[string][]byte
+}
+
+func (s fakePrivateState) GetKey(_ context.Context, key string) ([]byte, diag.Diagnostics) {
+	return s.values[key], nil
+}
+
+func mustJSONMarshal(t *testing.T, value any) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	return data
+}


### PR DESCRIPTION
Support write-only alternatives for app signing secret values and webhook header values without deprecating the existing sensitive fields.

The implementation resolves either the existing value or the new _wo field into Contentful API requests, clears write-only values from provider state, and stores Argon2id private-state verifiers keyed by Terraform framework paths so write-only rotations still produce planned updates.

This also documents the evaluated write-only and ephemeral secret use cases.