### PR TITLE
ref(provider/team): configure a default description

### DIFF
--- a/internal/provider/resource_team_schema.go
+++ b/internal/provider/resource_team_schema.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
@@ -40,6 +41,8 @@ func TeamResourceSchema(ctx context.Context) schema.Schema {
 			"description": schema.StringAttribute{
 				Description: "A description of the team.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
 		},

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -83,3 +83,81 @@ resource "contentful_team" "test" {
 }
 `
 }
+
+func TestAccTeamResourceImportUpdateUsesDefaultDescription(t *testing.T) {
+	t.Parallel()
+
+	server, _ := cmt.NewContentfulManagementServer()
+
+	server.SetTeam("2zuSjSO4A0e6GKBrhJRe2m", "team-id", cm.TeamData{
+		Name:        "Test Team",
+		Description: cm.NewNilString("Existing description"),
+	})
+
+	ContentfulProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "contentful_team" "test" {
+  organization_id = "2zuSjSO4A0e6GKBrhJRe2m"
+
+  name = "Test Team"
+}
+`,
+				ResourceName:       "contentful_team.test",
+				ImportState:        true,
+				ImportStateId:      "2zuSjSO4A0e6GKBrhJRe2m/team-id",
+				ImportStatePersist: true,
+			},
+			{
+				Config: `
+resource "contentful_team" "test" {
+  organization_id = "2zuSjSO4A0e6GKBrhJRe2m"
+
+  name = "Test Team Updated"
+}
+`,
+				Check: resource.TestCheckResourceAttr("contentful_team.test", "description", ""),
+			},
+		},
+	})
+}
+
+func TestAccTeamResourceImportNullDescriptionUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	server, _ := cmt.NewContentfulManagementServer()
+
+	server.SetTeam("2zuSjSO4A0e6GKBrhJRe2m", "team-id", cm.TeamData{
+		Name:        "Test Team",
+		Description: cm.NewNilStringNull(),
+	})
+
+	ContentfulProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "contentful_team" "test" {
+  organization_id = "2zuSjSO4A0e6GKBrhJRe2m"
+
+  name = "Test Team"
+}
+`,
+				ResourceName:       "contentful_team.test",
+				ImportState:        true,
+				ImportStateId:      "2zuSjSO4A0e6GKBrhJRe2m/team-id",
+				ImportStatePersist: true,
+			},
+			{
+				Config: `
+resource "contentful_team" "test" {
+  organization_id = "2zuSjSO4A0e6GKBrhJRe2m"
+
+  name = "Test Team"
+}
+`,
+				Check: resource.TestCheckResourceAttr("contentful_team.test", "description", ""),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Configure contentful_team.description with a default empty string.
- Cover imported teams where description is omitted from configuration.
- Align the import/update test with Terraform default semantics: omitted description resolves to the configured default rather than preserving imported remote text.

## Validation

- TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -run 'TestAccTeamResourceImport(UpdateUsesDefaultDescription|NullDescriptionUsesDefault)$' -count=1
- TF_ACC=1 TF_ACC_MOCKED=1 go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -run '^TestAcc' ./internal/provider/
- go test ./...
- golangci-lint cache clean
- golangci-lint run