### PR TITLE
test(provider): improve test coverage

### DIFF
--- a/internal/provider/editor_interface_layout_response_test.go
+++ b/internal/provider/editor_interface_layout_response_test.go
@@ -1,0 +1,52 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditorLayoutGroupItemRejectsFieldItem(t *testing.T) {
+	t.Parallel()
+
+	actual, diags := NewEditorInterfaceEditorLayoutItemGroupValueFromResponse(
+		t.Context(),
+		path.Root("editor_layout"),
+		cm.NewEditorInterfaceEditorLayoutFieldItemEditorInterfaceEditorLayoutItem(cm.EditorInterfaceEditorLayoutFieldItem{FieldId: "title"}),
+	)
+
+	assert.True(t, diags.HasError())
+	assert.True(t, actual.IsNull())
+}
+
+func TestEditorLayoutNestedGroupItemFieldFromFieldItem(t *testing.T) {
+	t.Parallel()
+
+	actual, diags := NewEditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValueFromResponse(
+		t.Context(),
+		path.Root("items"),
+		cm.NewEditorInterfaceEditorLayoutFieldItemEditorInterfaceEditorLayoutItem(cm.EditorInterfaceEditorLayoutFieldItem{FieldId: "title"}),
+	)
+
+	assert.Empty(t, diags)
+	assert.Equal(t, NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValue{
+		FieldID: types.StringValue("title"),
+	}), actual)
+}
+
+func TestEditorLayoutNestedGroupItemFieldRejectsGroupItem(t *testing.T) {
+	t.Parallel()
+
+	actual, diags := NewEditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValueFromResponse(
+		t.Context(),
+		path.Root("items"),
+		cm.NewEditorInterfaceEditorLayoutGroupItemEditorInterfaceEditorLayoutItem(cm.EditorInterfaceEditorLayoutGroupItem{}),
+	)
+
+	assert.True(t, diags.HasError())
+	assert.False(t, actual.IsNull())
+}

--- a/internal/provider/import_state_test.go
+++ b/internal/provider/import_state_test.go
@@ -1,0 +1,101 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	importStatePassthroughPaths          = []path.Path{path.Root("space_id"), path.Root("entry_id")}
+	importStatePassthroughResourceSchema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"space_id": schema.StringAttribute{Optional: true},
+			"entry_id": schema.StringAttribute{Optional: true},
+		},
+	}
+	importStatePassthroughIdentitySchema = identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"space_id": identityschema.StringAttribute{RequiredForImport: true},
+			"entry_id": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
+	importStatePassthroughRawType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+		"entry_id": tftypes.String,
+	}}
+)
+
+func TestImportStatePassthroughMultipartIDFromIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	reqIdentity := importStatePassthroughIdentity(importStateRawValues("space", "entry"))
+	resp := importStatePassthroughResponse()
+
+	provider.ImportStatePassthroughMultipartID(ctx, importStatePassthroughPaths, resource.ImportStateRequest{
+		Identity: reqIdentity,
+	}, resp)
+
+	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+
+	var stateSpaceID, stateEntryID types.String
+	resp.Diagnostics.Append(resp.State.GetAttribute(ctx, path.Root("space_id"), &stateSpaceID)...)
+	resp.Diagnostics.Append(resp.State.GetAttribute(ctx, path.Root("entry_id"), &stateEntryID)...)
+	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+	assert.Equal(t, types.StringValue("space"), stateSpaceID)
+	assert.Equal(t, types.StringValue("entry"), stateEntryID)
+
+	var identitySpaceID, identityEntryID types.String
+	resp.Diagnostics.Append(resp.Identity.GetAttribute(ctx, path.Root("space_id"), &identitySpaceID)...)
+	resp.Diagnostics.Append(resp.Identity.GetAttribute(ctx, path.Root("entry_id"), &identityEntryID)...)
+	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+	assert.Equal(t, types.StringValue("space"), identitySpaceID)
+	assert.Equal(t, types.StringValue("entry"), identityEntryID)
+}
+
+func TestImportStatePassthroughMultipartIDFromIdentityRejectsNullComponent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	reqIdentity := importStatePassthroughIdentity(importStateRawValues("space", nil))
+	resp := importStatePassthroughResponse()
+
+	provider.ImportStatePassthroughMultipartID(ctx, importStatePassthroughPaths, resource.ImportStateRequest{
+		Identity: reqIdentity,
+	}, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+}
+
+func importStatePassthroughIdentity(rawValues map[string]tftypes.Value) *tfsdk.ResourceIdentity {
+	return &tfsdk.ResourceIdentity{
+		Schema: importStatePassthroughIdentitySchema,
+		Raw:    tftypes.NewValue(importStatePassthroughRawType, rawValues),
+	}
+}
+
+func importStatePassthroughResponse() *resource.ImportStateResponse {
+	return &resource.ImportStateResponse{
+		State:    tfsdk.State{Schema: importStatePassthroughResourceSchema, Raw: tftypes.NewValue(importStatePassthroughRawType, importStateRawValues(nil, nil))},
+		Identity: importStatePassthroughIdentity(importStateRawValues(nil, nil)),
+	}
+}
+
+func importStateRawValues(spaceID, entryID any) map[string]tftypes.Value {
+	return map[string]tftypes.Value{
+		"space_id": tftypes.NewValue(tftypes.String, spaceID),
+		"entry_id": tftypes.NewValue(tftypes.String, entryID),
+	}
+}

--- a/internal/provider/resource_team_space_membership_test.go
+++ b/internal/provider/resource_team_space_membership_test.go
@@ -1,12 +1,20 @@
 package provider_test
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+var (
+	errUnexpectedImportStateCount = errors.New("unexpected import state count")
+	errUnexpectedImportedAttr     = errors.New("unexpected imported attribute")
 )
 
 func TestAccTeamSpaceMembershipResource(t *testing.T) {
@@ -20,19 +28,11 @@ func TestAccTeamSpaceMembershipResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ConfigDirectory: config.TestNameDirectory(),
-				ConfigVariables: config.Variables{
-					"space_id": config.StringVariable("space-id"),
-					"team_id":  config.StringVariable("team-id"),
-					"admin":    config.BoolVariable(true),
-				},
+				ConfigVariables: teamSpaceMembershipConfigVariables("space-id", "team-id", true),
 			},
 			{
 				ConfigDirectory: config.TestNameDirectory(),
-				ConfigVariables: config.Variables{
-					"space_id": config.StringVariable("space-id"),
-					"team_id":  config.StringVariable("team-id"),
-					"admin":    config.BoolVariable(false),
-				},
+				ConfigVariables: teamSpaceMembershipConfigVariables("space-id", "team-id", false),
 			},
 		},
 	})
@@ -53,13 +53,47 @@ func TestAccTeamSpaceMembershipResourceImport(t *testing.T) {
 	ContentfulProviderMockedResourceTest(t, server, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
-				ConfigDirectory: config.TestNameDirectory(),
-				ConfigVariables: config.Variables{
-					"space_id": config.StringVariable("space-id"),
-					"team_id":  config.StringVariable("team-id"),
-					"admin":    config.BoolVariable(true),
-				},
+				ConfigDirectory:  config.TestNameDirectory(),
+				ResourceName:     "contentful_team_space_membership.test",
+				ImportState:      true,
+				ImportStateId:    "space-id/team-space-membership-id",
+				ConfigVariables:  teamSpaceMembershipConfigVariables("space-id", "team-id", true),
+				ImportStateCheck: testAccTeamSpaceMembershipImportCheck(),
 			},
 		},
 	})
+}
+
+func testAccTeamSpaceMembershipImportCheck() resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		if len(states) != 1 {
+			return fmt.Errorf("%w: expected 1 imported resource, got %d", errUnexpectedImportStateCount, len(states))
+		}
+
+		attributes := states[0].Attributes
+		expectedAttributes := map[string]string{
+			"id":                       "space-id/team-space-membership-id",
+			"space_id":                 "space-id",
+			"team_space_membership_id": "team-space-membership-id",
+			"team_id":                  "team-id",
+			"admin":                    "true",
+			"roles.#":                  "0",
+		}
+
+		for name, expected := range expectedAttributes {
+			if actual := attributes[name]; actual != expected {
+				return fmt.Errorf("%w: expected %q to be %q, got %q", errUnexpectedImportedAttr, name, expected, actual)
+			}
+		}
+
+		return nil
+	}
+}
+
+func teamSpaceMembershipConfigVariables(spaceID, teamID string, admin bool) config.Variables {
+	return config.Variables{
+		"space_id": config.StringVariable(spaceID),
+		"team_id":  config.StringVariable(teamID),
+		"admin":    config.BoolVariable(admin),
+	}
 }

--- a/internal/provider/role_model_response_actions_test.go
+++ b/internal/provider/role_model_response_actions_test.go
@@ -1,0 +1,43 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoleActionsFromResponse(t *testing.T) {
+	t.Parallel()
+
+	assertRoleActionsFromResponse(t, cm.NewStringRolePermissionsItem("read"), NewPermissionActionsListValueFromResponse, false)
+	assertRoleActionsFromResponse(t, cm.RolePermissionsItem{}, NewPermissionActionsListValueFromResponse, true)
+	assertRoleActionsFromResponse(t, cm.NewStringRolePoliciesItemActions("read"), NewPolicyActionsListValueFromResponse, false)
+	assertRoleActionsFromResponse(t, cm.RolePoliciesItemActions{}, NewPolicyActionsListValueFromResponse, true)
+}
+
+func assertRoleActionsFromResponse[T any](
+	t *testing.T,
+	input T,
+	convert func(context.Context, path.Path, T) (TypedList[types.String], diag.Diagnostics),
+	expectError bool,
+) {
+	t.Helper()
+
+	actual, diags := convert(t.Context(), path.Root("actions"), input)
+
+	if expectError {
+		assert.True(t, diags.HasError())
+		assert.True(t, actual.IsUnknown())
+
+		return
+	}
+
+	assert.Empty(t, diags)
+	assert.Equal(t, NewTypedList([]types.String{types.StringValue("read")}), actual)
+}

--- a/internal/provider/team_space_membership_model_request_test.go
+++ b/internal/provider/team_space_membership_model_request_test.go
@@ -1,0 +1,35 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeamSpaceMembershipModelToRequestSkipsNullAndUnknownRoles(t *testing.T) {
+	t.Parallel()
+
+	model := provider.TeamSpaceMembershipModel{
+		Admin: types.BoolValue(true),
+		Roles: []types.String{
+			types.StringValue("role-a"),
+			types.StringNull(),
+			types.StringUnknown(),
+			types.StringValue("role-b"),
+		},
+	}
+
+	request, diags := model.ToTeamSpaceMembershipData(t.Context(), path.Empty())
+	require.False(t, diags.HasError(), diags.Errors())
+
+	assert.True(t, request.Admin)
+	assert.Equal(t, []cm.RoleLink{
+		{Sys: cm.RoleLinkSys{Type: cm.RoleLinkSysTypeLink, LinkType: cm.RoleLinkSysLinkTypeRole, ID: "role-a"}},
+		{Sys: cm.RoleLinkSys{Type: cm.RoleLinkSysTypeLink, LinkType: cm.RoleLinkSysLinkTypeRole, ID: "role-b"}},
+	}, request.Roles)
+}

--- a/internal/provider/typed_framework_test.go
+++ b/internal/provider/typed_framework_test.go
@@ -1,0 +1,40 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type typedElementType interface {
+	WithElementType(typ attr.Type) attr.TypeWithElementType
+	ElementTypeWithContext(ctx context.Context) attr.Type
+}
+
+type terraform5PathStepper interface {
+	ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error)
+}
+
+func assertStringElementType(t *testing.T, typ typedElementType) {
+	t.Helper()
+
+	assert.True(t, typ.WithElementType(types.StringType).ElementType().Equal(types.StringType))
+	assert.True(t, typ.ElementTypeWithContext(t.Context()).Equal(types.StringType))
+}
+
+func assertAttributePathStepType(t *testing.T, typ terraform5PathStepper, step tftypes.AttributePathStep, expected attr.Type) {
+	t.Helper()
+
+	stepType, err := typ.ApplyTerraform5AttributePathStep(step)
+	require.NoError(t, err)
+
+	stepAttrType, ok := stepType.(attr.Type)
+	require.True(t, ok)
+
+	assert.True(t, stepAttrType.Equal(expected))
+}

--- a/internal/provider/typed_list_type_test.go
+++ b/internal/provider/typed_list_type_test.go
@@ -105,3 +105,14 @@ func TestTypedListTypeValueFromTerraform(t *testing.T) {
 		})
 	}
 }
+
+func TestTypedListTypeFrameworkMethods(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	listType := TypedList[types.String]{}.CustomType(ctx)
+
+	assert.IsType(t, TypedList[types.String]{}, listType.ValueType(ctx))
+	assertStringElementType(t, listType)
+	assertAttributePathStepType(t, listType, tftypes.ElementKeyInt(0), types.StringType)
+}

--- a/internal/provider/typed_map_type_test.go
+++ b/internal/provider/typed_map_type_test.go
@@ -1,0 +1,22 @@
+package provider_test
+
+import (
+	"testing"
+
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypedMapTypeFrameworkMethods(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mapType := TypedMap[types.String]{}.CustomType(ctx)
+
+	assert.IsType(t, TypedMap[types.String]{}, mapType.ValueType(ctx))
+	assert.Equal(t, "TypedMap[basetypes.StringValue]", mapType.String())
+	assertStringElementType(t, mapType)
+	assertAttributePathStepType(t, mapType, tftypes.ElementKeyString("key"), types.StringType)
+}

--- a/internal/provider/typed_object_type_test.go
+++ b/internal/provider/typed_object_type_test.go
@@ -1,0 +1,27 @@
+package provider_test
+
+import (
+	"testing"
+
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypedObjectTypeFrameworkMethods(t *testing.T) {
+	t.Parallel()
+
+	type typedObjectTypeTestModel struct {
+		Name types.String `tfsdk:"name"`
+	}
+
+	ctx := t.Context()
+	objectType := TypedObject[typedObjectTypeTestModel]{}.CustomType(ctx)
+	attributeTypes := map[string]attr.Type{"name": types.StringType}
+
+	assert.IsType(t, TypedObject[typedObjectTypeTestModel]{}, objectType.ValueType(ctx))
+	assert.True(t, objectType.WithAttributeTypes(attributeTypes).AttributeTypes()["name"].Equal(types.StringType))
+	assertAttributePathStepType(t, objectType, tftypes.AttributeName("name"), types.StringType)
+}

--- a/internal/provider/use_state_for_unknown_test.go
+++ b/internal/provider/use_state_for_unknown_test.go
@@ -1,0 +1,58 @@
+package provider_test
+
+import (
+	"testing"
+
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUseStateForUnknownPlanModifyList(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	stateValue := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("existing"),
+	})
+	resp := &planmodifier.ListResponse{}
+
+	UseStateForUnknown().PlanModifyList(ctx, planmodifier.ListRequest{
+		State:       priorNonNullState(),
+		ConfigValue: types.ListNull(types.StringType),
+		PlanValue:   types.ListUnknown(types.StringType),
+		StateValue:  stateValue,
+	}, resp)
+
+	assert.True(t, resp.PlanValue.Equal(stateValue))
+}
+
+func TestUseStateForUnknownPlanModifyObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	attributeTypes := map[string]attr.Type{"name": types.StringType}
+	stateValue := types.ObjectValueMust(attributeTypes, map[string]attr.Value{
+		"name": types.StringValue("existing"),
+	})
+	resp := &planmodifier.ObjectResponse{}
+
+	UseStateForUnknown().PlanModifyObject(ctx, planmodifier.ObjectRequest{
+		State:       priorNonNullState(),
+		ConfigValue: types.ObjectNull(attributeTypes),
+		PlanValue:   types.ObjectUnknown(attributeTypes),
+		StateValue:  stateValue,
+	}, resp)
+
+	assert.True(t, resp.PlanValue.Equal(stateValue))
+}
+
+func priorNonNullState() tfsdk.State {
+	return tfsdk.State{
+		Raw: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}, map[string]tftypes.Value{}),
+	}
+}


### PR DESCRIPTION
## Summary

- exercise team space membership import with an effective `ImportStateCheck` instead of ignored config state checks
- add focused unit coverage for import-state identity handling, role/editor-interface conversion helpers, typed framework methods, and `UseStateForUnknown` behavior
- reduce test volume with shared import-state fixtures, a typed-framework path-step helper, and a generic role-action assertion helper
- remove superfluous coverage-only assertions for static description/string/diagnostic formatting helpers
- keep coverage improvements targeted at business/helper logic rather than duplicating CRUD lifecycle acceptance tests

## Self-review

- verified the branch is based on `main` and no app-key support files are in the PR diff
- searched for other `ImportState` steps with `ConfigStateChecks`; none remain
- confirmed the reviewed team space membership import assertions execute via `ImportStateCheck`
- accepted a 0.1 percentage-point coverage decrease from removing the diagnostic error-string wrapper test; import, role action conversion, team membership conversion, and typed framework paths remain covered

## Validation

- `GOCACHE=$PWD/.cache/go-build GOMODCACHE=$PWD/.cache/go-mod go test -count=1 ./internal/provider ./internal/contentful-management-go/...`
- `GOCACHE=$PWD/.cache/go-build GOMODCACHE=$PWD/.cache/go-mod TF_ACC=1 TF_ACC_MOCKED=1 go test -count=1 ./internal/provider -coverpkg=./internal/provider -coverprofile=/tmp/provider-mocked-refactored.out`
- mocked provider coverage: `87.8%`
- `golangci-lint cache clean && golangci-lint run`
