### PR TITLE
fix(contentful-management-go/testing): match content type lifecycle semantics

### DIFF
--- a/docs/resources/content_type.md
+++ b/docs/resources/content_type.md
@@ -63,7 +63,7 @@ resource "contentful_content_type" "author" {
 
 ### Optional
 
-- `metadata` (Attributes) Metadata for the content type. Once set, metadata properties may not be removed, but the list of taxonomy items may be reduced to the empty list (see [below for nested schema](#nestedatt--metadata))
+- `metadata` (Attributes) Metadata for the content type. Omitting metadata removes annotations but preserves taxonomy items. To remove taxonomy items, configure taxonomy as an empty list (see [below for nested schema](#nestedatt--metadata))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/internal/contentful-management-go/testing/content_type.go
+++ b/internal/contentful-management-go/testing/content_type.go
@@ -3,6 +3,7 @@ package cmtesting
 import (
 	"bytes"
 	"encoding/json"
+	"time"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 )
@@ -95,8 +96,9 @@ func updateContentTypeMetadata(contentType *cm.ContentType, requestedMetadata cm
 	contentType.Metadata.SetTo(metadata)
 }
 
-func publishContentType(contentType *cm.ContentType) {
+func publishContentType(contentType *cm.ContentType, publishedAt time.Time) {
 	contentType.Sys.PublishedVersion.SetTo(contentType.Sys.Version)
+	contentType.Sys.PublishedAt.SetTo(publishedAt)
 
 	contentType.Sys.Version++
 }

--- a/internal/contentful-management-go/testing/content_type.go
+++ b/internal/contentful-management-go/testing/content_type.go
@@ -1,8 +1,27 @@
 package cmtesting
 
 import (
+	"bytes"
+	"encoding/json"
+
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 )
+
+func contentTypeMetadataIsEmpty(metadata cm.ContentTypeMetadata) bool {
+	annotations := bytes.TrimSpace(metadata.Annotations)
+	if len(annotations) == 0 {
+		return metadata.Taxonomy == nil
+	}
+
+	var annotationAssignments map[string]json.RawMessage
+
+	err := json.Unmarshal(annotations, &annotationAssignments)
+	if err != nil {
+		return false
+	}
+
+	return len(annotationAssignments) == 0 && metadata.Taxonomy == nil
+}
 
 func NewContentTypeFromRequestFields(spaceID, environmentID, contentTypeID string, contentTypeFields cm.ContentTypeRequestData) cm.ContentType {
 	contentType := cm.ContentType{
@@ -45,7 +64,35 @@ func UpdateContentTypeFromRequestFields(contentType *cm.ContentType, contentType
 
 	contentType.DisplayField = cm.NewNilString(contentTypeFields.DisplayField)
 
-	contentType.Metadata = contentTypeFields.Metadata
+	updateContentTypeMetadata(contentType, contentTypeFields.Metadata)
+}
+
+func updateContentTypeMetadata(contentType *cm.ContentType, requestedMetadata cm.OptContentTypeMetadata) {
+	existingMetadata, existingMetadataSet := contentType.Metadata.Get()
+	metadata, metadataSet := requestedMetadata.Get()
+
+	if !metadataSet {
+		if !existingMetadataSet {
+			return
+		}
+
+		existingMetadata.Annotations = nil
+		if existingMetadata.Taxonomy == nil {
+			contentType.Metadata.Reset()
+
+			return
+		}
+
+		contentType.Metadata.SetTo(existingMetadata)
+
+		return
+	}
+
+	if metadata.Taxonomy == nil && existingMetadataSet {
+		metadata.Taxonomy = existingMetadata.Taxonomy
+	}
+
+	contentType.Metadata.SetTo(metadata)
 }
 
 func publishContentType(contentType *cm.ContentType) {

--- a/internal/contentful-management-go/testing/editor_interface.go
+++ b/internal/contentful-management-go/testing/editor_interface.go
@@ -15,6 +15,8 @@ func NewEditorInterfaceFromFields(spaceID, environmentID, contentTypeID string, 
 }
 
 func UpdateEditorInterfaceFromFields(editorInterface *cm.EditorInterface, editorInterfaceFields cm.EditorInterfaceData) {
+	editorInterface.Sys.Version++
+
 	convertOptNil(&editorInterface.EditorLayout, &editorInterfaceFields.EditorLayout, func(editorLayout []cm.EditorInterfaceEditorLayoutItem) []cm.EditorInterfaceEditorLayoutItem {
 		return editorLayout
 	})
@@ -36,4 +38,77 @@ func UpdateEditorInterfaceFromFields(editorInterface *cm.EditorInterface, editor
 			return cm.EditorInterfaceSidebarItem(sidebarItem)
 		})
 	})
+}
+
+func NewDefaultEditorInterface(spaceID, environmentID, contentTypeID string, fields []cm.ContentTypeFieldsItem) cm.EditorInterface {
+	controls := make([]cm.EditorInterfaceControlsItem, len(fields))
+	for index, field := range fields {
+		controls[index] = cm.EditorInterfaceControlsItem{FieldId: field.ID}
+	}
+
+	return cm.EditorInterface{
+		Sys: cm.EditorInterfaceSys{
+			Space:       cm.NewSpaceLink(spaceID),
+			Environment: cm.NewEnvironmentLink(environmentID),
+			Type:        cm.EditorInterfaceSysTypeEditorInterface,
+			ID:          "default",
+			ContentType: cm.NewContentTypeLink(contentTypeID),
+			Version:     1,
+		},
+		Controls: cm.NewOptNilEditorInterfaceControlsItemArray(controls),
+	}
+}
+
+func SyncEditorInterfaceWithContentType(editorInterface *cm.EditorInterface, previousFieldIDs []string, fields []cm.ContentTypeFieldsItem) {
+	editorInterface.Sys.Version++
+
+	existingControls, controlsSet := editorInterface.Controls.Get()
+	if !controlsSet {
+		return
+	}
+
+	currentFieldIDs := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		currentFieldIDs[field.ID] = struct{}{}
+	}
+
+	controls := make([]cm.EditorInterfaceControlsItem, 0, len(existingControls)+len(fields))
+
+	controlledFieldIDs := make(map[string]struct{}, len(existingControls))
+	for _, control := range existingControls {
+		if _, fieldExists := currentFieldIDs[control.FieldId]; !fieldExists {
+			continue
+		}
+
+		controls = append(controls, control)
+		controlledFieldIDs[control.FieldId] = struct{}{}
+	}
+
+	previousFieldIDSet := make(map[string]struct{}, len(previousFieldIDs))
+	for _, fieldID := range previousFieldIDs {
+		previousFieldIDSet[fieldID] = struct{}{}
+	}
+
+	for _, field := range fields {
+		if _, wasPublished := previousFieldIDSet[field.ID]; wasPublished {
+			continue
+		}
+
+		if _, alreadyControlled := controlledFieldIDs[field.ID]; alreadyControlled {
+			continue
+		}
+
+		controls = append(controls, cm.EditorInterfaceControlsItem{FieldId: field.ID})
+	}
+
+	editorInterface.Controls.SetTo(controls)
+}
+
+func contentTypeFieldIDs(fields []cm.ContentTypeFieldsItem) []string {
+	fieldIDs := make([]string, len(fields))
+	for index, field := range fields {
+		fieldIDs[index] = field.ID
+	}
+
+	return fieldIDs
 }

--- a/internal/contentful-management-go/testing/error.go
+++ b/internal/contentful-management-go/testing/error.go
@@ -10,6 +10,10 @@ func NewContentfulManagementErrorStatusCodeBadRequest(message *string, details [
 	return NewContentfulManagementErrorStatusCode(http.StatusBadRequest, "BadRequest", message, details)
 }
 
+func NewContentfulManagementErrorStatusCodeInvalidQuery(message *string, details []byte) *cm.ErrorStatusCode {
+	return NewContentfulManagementErrorStatusCode(http.StatusBadRequest, "InvalidQuery", message, details)
+}
+
 func NewContentfulManagementErrorStatusCodeValidationFailed(message *string, details []byte) *cm.ErrorStatusCode {
 	return NewContentfulManagementErrorStatusCode(http.StatusUnprocessableEntity, "ValidationFailed", message, details)
 }

--- a/internal/contentful-management-go/testing/error.go
+++ b/internal/contentful-management-go/testing/error.go
@@ -7,24 +7,26 @@ import (
 )
 
 func NewContentfulManagementErrorStatusCodeBadRequest(message *string, details []byte) *cm.ErrorStatusCode {
+	return NewContentfulManagementErrorStatusCode(http.StatusBadRequest, "BadRequest", message, details)
+}
+
+func NewContentfulManagementErrorStatusCodeValidationFailed(message *string, details []byte) *cm.ErrorStatusCode {
+	return NewContentfulManagementErrorStatusCode(http.StatusUnprocessableEntity, "ValidationFailed", message, details)
+}
+
+func NewContentfulManagementErrorStatusCode(statusCode int, id string, message *string, details []byte) *cm.ErrorStatusCode {
 	return &cm.ErrorStatusCode{
-		StatusCode: http.StatusBadRequest,
-		Response:   cm.NewErrorApplicationJSONError(NewContentfulManagementError("BadRequest", message, details)),
+		StatusCode: statusCode,
+		Response:   cm.NewErrorApplicationJSONError(NewContentfulManagementError(id, message, details)),
 	}
 }
 
 func NewContentfulManagementErrorStatusCodeNotFound(message *string, details []byte) *cm.ErrorStatusCode {
-	return &cm.ErrorStatusCode{
-		StatusCode: http.StatusNotFound,
-		Response:   cm.NewErrorApplicationJSONError(NewContentfulManagementError(cm.ErrorSysIDNotFound, message, details)),
-	}
+	return NewContentfulManagementErrorStatusCode(http.StatusNotFound, cm.ErrorSysIDNotFound, message, details)
 }
 
 func NewContentfulManagementErrorStatusCodeVersionMismatch(message *string, details []byte) *cm.ErrorStatusCode {
-	return &cm.ErrorStatusCode{
-		StatusCode: http.StatusConflict,
-		Response:   cm.NewErrorApplicationJSONError(NewContentfulManagementError(cm.ErrorSysIDVersionMismatch, message, details)),
-	}
+	return NewContentfulManagementErrorStatusCode(http.StatusConflict, cm.ErrorSysIDVersionMismatch, message, details)
 }
 
 func NewContentfulManagementError(id string, message *string, details []byte) cm.Error {

--- a/internal/contentful-management-go/testing/handler.go
+++ b/internal/contentful-management-go/testing/handler.go
@@ -34,8 +34,9 @@ type Handler struct {
 
 	appInstallations cm.SpaceEnvironmentMap[*cm.AppInstallation]
 
-	contentTypes     cm.SpaceEnvironmentMap[*cm.ContentType]
-	editorInterfaces cm.SpaceEnvironmentMap[*cm.EditorInterface]
+	contentTypes                 cm.SpaceEnvironmentMap[*cm.ContentType]
+	publishedContentTypeFieldIDs cm.SpaceEnvironmentMap[[]string]
+	editorInterfaces             cm.SpaceEnvironmentMap[*cm.EditorInterface]
 
 	entries cm.SpaceEnvironmentMap[*cm.Entry]
 
@@ -69,6 +70,7 @@ func NewHandler() *Handler {
 		appSigningSecrets:              make(map[string]*cm.AppSigningSecret),
 		appInstallations:               cm.NewSpaceEnvironmentMap[*cm.AppInstallation](),
 		contentTypes:                   cm.NewSpaceEnvironmentMap[*cm.ContentType](),
+		publishedContentTypeFieldIDs:   cm.NewSpaceEnvironmentMap[[]string](),
 		editorInterfaces:               cm.NewSpaceEnvironmentMap[*cm.EditorInterface](),
 		entries:                        cm.NewSpaceEnvironmentMap[*cm.Entry](),
 		extensions:                     cm.NewSpaceEnvironmentMap[*cm.Extension](),

--- a/internal/contentful-management-go/testing/handler_content_type.go
+++ b/internal/contentful-management-go/testing/handler_content_type.go
@@ -88,11 +88,6 @@ func (ts *Handler) PutContentType(_ context.Context, req *cm.ContentTypeRequestD
 
 	UpdateContentTypeFromRequestFields(contentType, *req)
 
-	editorInterface := ts.editorInterfaces.Get(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
-	if editorInterface != nil {
-		editorInterface.Sys.Version++
-	}
-
 	return &cm.ContentTypeStatusCode{
 		StatusCode: http.StatusOK,
 		Response:   *contentType,
@@ -114,6 +109,8 @@ func (ts *Handler) DeleteContentType(_ context.Context, params cm.DeleteContentT
 	}
 
 	ts.contentTypes.Delete(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
+	ts.publishedContentTypeFieldIDs.Delete(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
+	ts.editorInterfaces.Delete(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
 
 	return &cm.NoContent{}, nil
 }
@@ -133,6 +130,22 @@ func (ts *Handler) ActivateContentType(_ context.Context, params cm.ActivateCont
 	}
 
 	publishContentType(contentType, time.Now().UTC())
+
+	editorInterface := ts.editorInterfaces.Get(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
+	if editorInterface == nil {
+		newEditorInterface := NewDefaultEditorInterface(params.SpaceID, params.EnvironmentID, params.ContentTypeID, contentType.Fields)
+		ts.editorInterfaces.Set(params.SpaceID, params.EnvironmentID, params.ContentTypeID, &newEditorInterface)
+	} else {
+		previousFieldIDs := ts.publishedContentTypeFieldIDs.Get(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
+		SyncEditorInterfaceWithContentType(editorInterface, previousFieldIDs, contentType.Fields)
+	}
+
+	ts.publishedContentTypeFieldIDs.Set(
+		params.SpaceID,
+		params.EnvironmentID,
+		params.ContentTypeID,
+		contentTypeFieldIDs(contentType.Fields),
+	)
 
 	return &cm.ContentTypeStatusCode{
 		StatusCode: http.StatusOK,

--- a/internal/contentful-management-go/testing/handler_content_type.go
+++ b/internal/contentful-management-go/testing/handler_content_type.go
@@ -21,6 +21,16 @@ func (ts *Handler) GetContentTypes(_ context.Context, params cm.GetContentTypesP
 
 	contentTypes := ts.contentTypes.List(params.SpaceID, params.EnvironmentID)
 
+	skip := params.Skip.Or(0)
+	if skip < 0 {
+		return NewContentfulManagementErrorStatusCodeInvalidQuery(new(`The value provided for "skip" is invalid. Please provide a value larger than or equal to 0`), nil), nil
+	}
+
+	limit := params.Limit.Or(100) //nolint:mnd
+	if limit < 0 || limit > 1000 {
+		return NewContentfulManagementErrorStatusCodeInvalidQuery(new(`The value provided for "limit" is invalid. Please provide a value between 0 and 1000`), nil), nil
+	}
+
 	items := make([]cm.ContentType, 0, len(contentTypes))
 	for _, ct := range contentTypes {
 		items = append(items, *ct)
@@ -30,8 +40,6 @@ func (ts *Handler) GetContentTypes(_ context.Context, params cm.GetContentTypesP
 		return cmp.Compare(a.Sys.ID, b.Sys.ID)
 	})
 
-	skip := max(params.Skip.Or(0), 0)
-	limit := max(params.Limit.Or(100), 0) //nolint:mnd
 	start := min(skip, int64(len(items)))
 	end := min(start+limit, int64(len(items)))
 

--- a/internal/contentful-management-go/testing/handler_content_type.go
+++ b/internal/contentful-management-go/testing/handler_content_type.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"slices"
+	"time"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 )
@@ -108,6 +109,10 @@ func (ts *Handler) DeleteContentType(_ context.Context, params cm.DeleteContentT
 		return NewContentfulManagementErrorStatusCodeNotFound(new("ContentType not found"), nil), nil
 	}
 
+	if contentType.Sys.PublishedVersion.IsSet() {
+		return NewContentfulManagementErrorStatusCodeBadRequest(new("Cannot delete published"), nil), nil
+	}
+
 	ts.contentTypes.Delete(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
 
 	return &cm.NoContent{}, nil
@@ -123,7 +128,11 @@ func (ts *Handler) ActivateContentType(_ context.Context, params cm.ActivateCont
 		return NewContentfulManagementErrorStatusCodeNotFound(new("ContentType not found"), nil), nil
 	}
 
-	publishContentType(contentType)
+	if params.XContentfulVersion != contentType.Sys.Version {
+		return NewContentfulManagementErrorStatusCodeVersionMismatch(nil, nil), nil
+	}
+
+	publishContentType(contentType, time.Now().UTC())
 
 	return &cm.ContentTypeStatusCode{
 		StatusCode: http.StatusOK,
@@ -141,7 +150,13 @@ func (ts *Handler) DeactivateContentType(_ context.Context, params cm.Deactivate
 		return NewContentfulManagementErrorStatusCodeNotFound(new("ContentType not found"), nil), nil
 	}
 
-	contentType.Sys.PublishedVersion.Reset()
+	if !contentType.Sys.PublishedVersion.IsSet() {
+		return NewContentfulManagementErrorStatusCodeBadRequest(new("Not published"), nil), nil
+	}
 
-	return &cm.NoContent{}, nil
+	contentType.Sys.PublishedVersion.Reset()
+	contentType.Sys.PublishedAt.Reset()
+	contentType.Sys.Version++
+
+	return contentType, nil
 }

--- a/internal/contentful-management-go/testing/handler_content_type.go
+++ b/internal/contentful-management-go/testing/handler_content_type.go
@@ -66,6 +66,10 @@ func (ts *Handler) PutContentType(_ context.Context, req *cm.ContentTypeRequestD
 		return NewContentfulManagementErrorStatusCodeNotFound(new("Environment not found"), nil), nil
 	}
 
+	if metadata, metadataSet := req.Metadata.Get(); metadataSet && contentTypeMetadataIsEmpty(metadata) {
+		return NewContentfulManagementErrorStatusCodeValidationFailed(new("Validation error"), nil), nil
+	}
+
 	contentType := ts.contentTypes.Get(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
 	if contentType == nil {
 		newContentType := NewContentTypeFromRequestFields(params.SpaceID, params.EnvironmentID, params.ContentTypeID, *req)

--- a/internal/contentful-management-go/testing/handler_content_type_lifecycle_test.go
+++ b/internal/contentful-management-go/testing/handler_content_type_lifecycle_test.go
@@ -61,6 +61,10 @@ func TestDeactivateAndDeleteContentTypeUsesContentfulLifecycle(t *testing.T) {
 
 	_, deleted := deleteResponse.(*cm.NoContent)
 	require.True(t, deleted)
+
+	editorResponse, err := handler.GetEditorInterface(context.Background(), contentTypeEditorInterfaceParams())
+	require.NoError(t, err)
+	requireContentfulError(t, editorResponse, http.StatusNotFound, cm.ErrorSysIDNotFound, "EditorInterface not found")
 }
 
 func contentTypeActivateParams(version int) cm.ActivateContentTypeParams {

--- a/internal/contentful-management-go/testing/handler_content_type_lifecycle_test.go
+++ b/internal/contentful-management-go/testing/handler_content_type_lifecycle_test.go
@@ -1,0 +1,94 @@
+package cmtesting_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivateContentTypeUsesContentfulPublicationVersioning(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+	assert.Equal(t, 1, created.Sys.Version)
+	assert.False(t, created.Sys.PublishedVersion.IsSet())
+	assert.False(t, created.Sys.PublishedAt.IsSet())
+
+	staleResponse, err := handler.ActivateContentType(context.Background(), contentTypeActivateParams(0))
+	require.NoError(t, err)
+	requireContentfulError(t, staleResponse, http.StatusConflict, cm.ErrorSysIDVersionMismatch, "")
+
+	activated := activateContentType(t, handler, created.Sys.Version)
+	assert.Equal(t, 2, activated.Sys.Version)
+	assert.Equal(t, 1, activated.Sys.PublishedVersion.Or(0))
+	assert.True(t, activated.Sys.PublishedAt.IsSet())
+}
+
+func TestDeactivateAndDeleteContentTypeUsesContentfulLifecycle(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+	activated := activateContentType(t, handler, created.Sys.Version)
+
+	deletePublishedResponse, err := handler.DeleteContentType(context.Background(), contentTypeDeleteParams())
+	require.NoError(t, err)
+	requireContentfulError(t, deletePublishedResponse, http.StatusBadRequest, "BadRequest", "Cannot delete published")
+
+	deactivateResponse, err := handler.DeactivateContentType(context.Background(), contentTypeDeactivateParams())
+	require.NoError(t, err)
+
+	deactivated, deactivatedOK := deactivateResponse.(*cm.ContentType)
+	require.True(t, deactivatedOK)
+	assert.Equal(t, activated.Sys.Version+1, deactivated.Sys.Version)
+	assert.False(t, deactivated.Sys.PublishedVersion.IsSet())
+	assert.False(t, deactivated.Sys.PublishedAt.IsSet())
+
+	deactivateAgainResponse, err := handler.DeactivateContentType(context.Background(), contentTypeDeactivateParams())
+	require.NoError(t, err)
+	requireContentfulError(t, deactivateAgainResponse, http.StatusBadRequest, "BadRequest", "Not published")
+
+	deleteResponse, err := handler.DeleteContentType(context.Background(), contentTypeDeleteParams())
+	require.NoError(t, err)
+
+	_, deleted := deleteResponse.(*cm.NoContent)
+	require.True(t, deleted)
+}
+
+func contentTypeActivateParams(version int) cm.ActivateContentTypeParams {
+	return cm.ActivateContentTypeParams{
+		SpaceID:            "space",
+		EnvironmentID:      "environment",
+		ContentTypeID:      "content-type",
+		XContentfulVersion: version,
+	}
+}
+
+func contentTypeDeactivateParams() cm.DeactivateContentTypeParams {
+	return cm.DeactivateContentTypeParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type",
+	}
+}
+
+func contentTypeDeleteParams() cm.DeleteContentTypeParams {
+	return cm.DeleteContentTypeParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type",
+	}
+}
+
+func activateContentType(t *testing.T, handler *cmt.Handler, version int) cm.ContentType {
+	t.Helper()
+
+	response, err := handler.ActivateContentType(context.Background(), contentTypeActivateParams(version))
+	require.NoError(t, err)
+
+	return requireContentTypeStatusCode(t, response, http.StatusOK)
+}

--- a/internal/contentful-management-go/testing/handler_content_type_metadata_test.go
+++ b/internal/contentful-management-go/testing/handler_content_type_metadata_test.go
@@ -1,0 +1,175 @@
+package cmtesting_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
+	"github.com/go-faster/jx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPutContentTypeClearsAnnotationsAndPreservesTaxonomyWhenMetadataOmitted(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	request.Metadata.SetTo(cm.ContentTypeMetadata{
+		Annotations: jx.Raw(`{"ContentType":[]}`),
+		Taxonomy: []cm.ContentTypeMetadataTaxonomyItem{{
+			Sys: cm.ContentTypeMetadataTaxonomyItemSys{
+				Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
+				LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConceptScheme,
+				ID:       "furniture",
+			},
+		}},
+	})
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+
+	request.Metadata.Reset()
+	updated := putContentType(t, handler, &request, created.Sys.Version, http.StatusOK)
+	metadata, metadataOK := updated.Metadata.Get()
+	require.True(t, metadataOK)
+	assert.Nil(t, metadata.Annotations)
+	require.Len(t, metadata.Taxonomy, 1)
+	assert.Equal(t, "furniture", metadata.Taxonomy[0].Sys.ID)
+}
+
+func TestPutContentTypePreservesTaxonomyWhenMetadataOmitsTaxonomy(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	request.Metadata.SetTo(cm.ContentTypeMetadata{
+		Taxonomy: []cm.ContentTypeMetadataTaxonomyItem{{
+			Sys: cm.ContentTypeMetadataTaxonomyItemSys{
+				Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
+				LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConceptScheme,
+				ID:       "furniture",
+			},
+		}},
+	})
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+
+	request.Metadata.SetTo(cm.ContentTypeMetadata{Annotations: jx.Raw(`{"ContentType":[]}`)})
+	updated := putContentType(t, handler, &request, created.Sys.Version, http.StatusOK)
+	metadata, metadataOK := updated.Metadata.Get()
+	require.True(t, metadataOK)
+	assert.JSONEq(t, `{"ContentType":[]}`, string(metadata.Annotations))
+	require.Len(t, metadata.Taxonomy, 1)
+	assert.Equal(t, "furniture", metadata.Taxonomy[0].Sys.ID)
+}
+
+func TestPutContentTypeReplacesMetadataWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	request.Metadata.SetTo(cm.ContentTypeMetadata{
+		Annotations: jx.Raw(`{"ContentType":[]}`),
+		Taxonomy: []cm.ContentTypeMetadataTaxonomyItem{{
+			Sys: cm.ContentTypeMetadataTaxonomyItemSys{
+				Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
+				LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConceptScheme,
+				ID:       "furniture",
+			},
+		}},
+	})
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+
+	request.Metadata.SetTo(cm.ContentTypeMetadata{Taxonomy: []cm.ContentTypeMetadataTaxonomyItem{}})
+	updated := putContentType(t, handler, &request, created.Sys.Version, http.StatusOK)
+	metadata, metadataOK := updated.Metadata.Get()
+	require.True(t, metadataOK)
+	assert.Nil(t, metadata.Annotations)
+	assert.Empty(t, metadata.Taxonomy)
+	assert.NotNil(t, metadata.Taxonomy)
+}
+
+func TestPutContentTypeRejectsEmptyMetadataObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]cm.ContentTypeMetadata{
+		"absent properties": {},
+		"empty annotations": {Annotations: jx.Raw(`{ }`)},
+		"null annotations":  {Annotations: jx.Raw(`null`)},
+	}
+
+	for name, metadata := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := newContentTypeTestHandler()
+			request := newContentTypeRequest()
+			request.Metadata.SetTo(metadata)
+
+			response, err := handler.PutContentType(context.Background(), &request, contentTypePutParams(1))
+			require.NoError(t, err)
+			requireContentfulError(t, response, http.StatusUnprocessableEntity, "ValidationFailed", "Validation error")
+
+			getResponse, err := handler.GetContentType(context.Background(), cm.GetContentTypeParams{
+				SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type",
+			})
+			require.NoError(t, err)
+			requireContentfulError(t, getResponse, http.StatusNotFound, cm.ErrorSysIDNotFound, "ContentType not found")
+		})
+	}
+}
+
+func newContentTypeTestHandler() *cmt.Handler {
+	handler := cmt.NewHandler()
+	handler.RegisterSpaceEnvironment("space", "environment", "ready")
+
+	return handler
+}
+
+func newContentTypeRequest() cm.ContentTypeRequestData {
+	return cm.ContentTypeRequestData{
+		Name:         "Content Type",
+		DisplayField: "title",
+		Fields:       []cm.ContentTypeRequestDataFieldsItem{{ID: "title", Name: "Title", Type: "Symbol"}},
+	}
+}
+
+func contentTypePutParams(version int) cm.PutContentTypeParams {
+	return cm.PutContentTypeParams{
+		SpaceID:            "space",
+		EnvironmentID:      "environment",
+		ContentTypeID:      "content-type",
+		XContentfulVersion: version,
+	}
+}
+
+func putContentType(t *testing.T, handler *cmt.Handler, request *cm.ContentTypeRequestData, version, expectedStatus int) cm.ContentType {
+	t.Helper()
+
+	response, err := handler.PutContentType(context.Background(), request, contentTypePutParams(version))
+	require.NoError(t, err)
+
+	return requireContentTypeStatusCode(t, response, expectedStatus)
+}
+
+func requireContentTypeStatusCode(t *testing.T, response any, expectedStatus int) cm.ContentType {
+	t.Helper()
+
+	statusCode, ok := response.(*cm.ContentTypeStatusCode)
+	require.True(t, ok)
+	assert.Equal(t, expectedStatus, statusCode.StatusCode)
+
+	return statusCode.Response
+}
+
+func requireContentfulError(t *testing.T, response any, expectedStatus int, expectedID, expectedMessage string) {
+	t.Helper()
+
+	statusCode, ok := response.(*cm.ErrorStatusCode)
+	require.True(t, ok)
+	assert.Equal(t, expectedStatus, statusCode.StatusCode)
+	errorResponse, ok := statusCode.Response.GetError()
+	require.True(t, ok)
+	assert.Equal(t, expectedID, errorResponse.Sys.ID)
+	assert.Equal(t, expectedMessage, errorResponse.Message.Or(""))
+}

--- a/internal/contentful-management-go/testing/handler_content_type_test.go
+++ b/internal/contentful-management-go/testing/handler_content_type_test.go
@@ -3,6 +3,7 @@ package cmtesting_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
@@ -55,7 +56,7 @@ func TestGetContentTypesPaginates(t *testing.T) {
 	assert.Equal(t, "Content Type 1", secondPageCollection.Items[0].Name)
 }
 
-func TestGetContentTypesHandlesNegativePaginationParams(t *testing.T) {
+func TestGetContentTypesRejectsInvalidPaginationParams(t *testing.T) {
 	t.Parallel()
 
 	server, err := cmt.NewContentfulManagementServer()
@@ -66,16 +67,37 @@ func TestGetContentTypesHandlesNegativePaginationParams(t *testing.T) {
 		Fields: []cm.ContentTypeRequestDataFieldsItem{},
 	})
 
-	response, err := server.Handler().GetContentTypes(context.Background(), cm.GetContentTypesParams{
-		SpaceID:       "space",
-		EnvironmentID: "environment",
-		Skip:          cm.NewOptInt64(-1),
-		Limit:         cm.NewOptInt64(-1),
-	})
-	require.NoError(t, err)
+	testCases := map[string]struct {
+		params  cm.GetContentTypesParams
+		message string
+	}{
+		"negative skip": {
+			params: cm.GetContentTypesParams{
+				SpaceID: "space", EnvironmentID: "environment", Skip: cm.NewOptInt64(-1),
+			},
+			message: `The value provided for "skip" is invalid. Please provide a value larger than or equal to 0`,
+		},
+		"negative limit": {
+			params: cm.GetContentTypesParams{
+				SpaceID: "space", EnvironmentID: "environment", Limit: cm.NewOptInt64(-1),
+			},
+			message: `The value provided for "limit" is invalid. Please provide a value between 0 and 1000`,
+		},
+		"limit above maximum": {
+			params: cm.GetContentTypesParams{
+				SpaceID: "space", EnvironmentID: "environment", Limit: cm.NewOptInt64(1001),
+			},
+			message: `The value provided for "limit" is invalid. Please provide a value between 0 and 1000`,
+		},
+	}
 
-	collection, collectionOk := response.(*cm.ContentTypeCollection)
-	require.True(t, collectionOk)
-	assert.Equal(t, 1, collection.Total.Or(0))
-	assert.Empty(t, collection.Items)
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response, err := server.Handler().GetContentTypes(context.Background(), testCase.params)
+			require.NoError(t, err)
+			requireContentfulError(t, response, http.StatusBadRequest, "InvalidQuery", testCase.message)
+		})
+	}
 }

--- a/internal/contentful-management-go/testing/handler_editor_interface.go
+++ b/internal/contentful-management-go/testing/handler_editor_interface.go
@@ -32,13 +32,7 @@ func (ts *Handler) PutEditorInterface(_ context.Context, req *cm.EditorInterface
 
 	editorInterface := ts.editorInterfaces.Get(params.SpaceID, params.EnvironmentID, params.ContentTypeID)
 	if editorInterface == nil {
-		newEditorInterface := NewEditorInterfaceFromFields(params.SpaceID, params.EnvironmentID, params.ContentTypeID, *req)
-		ts.editorInterfaces.Set(params.SpaceID, params.EnvironmentID, params.ContentTypeID, &newEditorInterface)
-
-		return &cm.EditorInterfaceStatusCode{
-			StatusCode: http.StatusCreated,
-			Response:   newEditorInterface,
-		}, nil
+		return NewContentfulManagementErrorStatusCodeBadRequest(new("The content type you sent could not be found or was not activated."), nil), nil
 	}
 
 	if params.XContentfulVersion != editorInterface.Sys.Version {

--- a/internal/contentful-management-go/testing/handler_editor_interface_test.go
+++ b/internal/contentful-management-go/testing/handler_editor_interface_test.go
@@ -1,0 +1,177 @@
+package cmtesting_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPutEditorInterfaceRequiresActivatedContentType(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	contentTypeRequest := newContentTypeRequest()
+	putContentType(t, handler, &contentTypeRequest, 1, http.StatusCreated)
+
+	response, err := handler.PutEditorInterface(context.Background(), &cm.EditorInterfaceData{}, cm.PutEditorInterfaceParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type", XContentfulVersion: 1,
+	})
+	require.NoError(t, err)
+	requireContentfulError(
+		t,
+		response,
+		http.StatusBadRequest,
+		"BadRequest",
+		"The content type you sent could not be found or was not activated.",
+	)
+}
+
+func TestPutEditorInterfaceUsesContentfulVersioning(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	contentTypeRequest := newContentTypeRequest()
+	created := putContentType(t, handler, &contentTypeRequest, 1, http.StatusCreated)
+	activateContentType(t, handler, created.Sys.Version)
+
+	editorInterfaceRequest := cm.EditorInterfaceData{
+		Controls: cm.NewOptNilEditorInterfaceDataControlsItemArray([]cm.EditorInterfaceDataControlsItem{{
+			FieldId: "title", WidgetNamespace: cm.NewOptString("builtin"), WidgetId: cm.NewOptString("singleLine"),
+		}}),
+	}
+	response, err := handler.PutEditorInterface(context.Background(), &editorInterfaceRequest, cm.PutEditorInterfaceParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type", XContentfulVersion: 1,
+	})
+	require.NoError(t, err)
+
+	statusCode, statusCodeOK := response.(*cm.EditorInterfaceStatusCode)
+	require.True(t, statusCodeOK)
+	assert.Equal(t, http.StatusOK, statusCode.StatusCode)
+	assert.Equal(t, 2, statusCode.Response.Sys.Version)
+
+	staleResponse, err := handler.PutEditorInterface(context.Background(), &editorInterfaceRequest, cm.PutEditorInterfaceParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type", XContentfulVersion: 1,
+	})
+	require.NoError(t, err)
+	requireContentfulError(t, staleResponse, http.StatusConflict, cm.ErrorSysIDVersionMismatch, "")
+}
+
+func TestActivateContentTypeSynchronizesEditorInterface(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+
+	editorResponse, err := handler.GetEditorInterface(context.Background(), contentTypeEditorInterfaceParams())
+	require.NoError(t, err)
+	requireContentfulError(t, editorResponse, http.StatusNotFound, cm.ErrorSysIDNotFound, "EditorInterface not found")
+
+	activated := activateContentType(t, handler, created.Sys.Version)
+	editorInterface := getEditorInterface(t, handler)
+	assert.Equal(t, 1, editorInterface.Sys.Version)
+	assert.Equal(t, []string{"title"}, editorInterfaceControlFieldIDs(t, editorInterface))
+
+	request.Fields = append(request.Fields, cm.ContentTypeRequestDataFieldsItem{ID: "subtitle", Name: "Subtitle", Type: "Symbol"})
+	draftUpdated := putContentType(t, handler, &request, activated.Sys.Version, http.StatusOK)
+	editorInterface = getEditorInterface(t, handler)
+	assert.Equal(t, 1, editorInterface.Sys.Version, "draft updates must not change the editor interface")
+	assert.Equal(t, []string{"title"}, editorInterfaceControlFieldIDs(t, editorInterface))
+
+	activateContentType(t, handler, draftUpdated.Sys.Version)
+	editorInterface = getEditorInterface(t, handler)
+	assert.Equal(t, 2, editorInterface.Sys.Version)
+	assert.Equal(t, []string{"title", "subtitle"}, editorInterfaceControlFieldIDs(t, editorInterface))
+}
+
+func TestActivateContentTypePreservesClearedEditorInterfaceControls(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+	activated := activateContentType(t, handler, created.Sys.Version)
+
+	response, err := handler.PutEditorInterface(context.Background(), &cm.EditorInterfaceData{}, cm.PutEditorInterfaceParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type", XContentfulVersion: 1,
+	})
+	require.NoError(t, err)
+
+	statusCode, statusCodeOK := response.(*cm.EditorInterfaceStatusCode)
+	require.True(t, statusCodeOK)
+	assert.False(t, statusCode.Response.Controls.IsSet())
+
+	request.Fields = append(request.Fields, cm.ContentTypeRequestDataFieldsItem{ID: "subtitle", Name: "Subtitle", Type: "Symbol"})
+	draftUpdated := putContentType(t, handler, &request, activated.Sys.Version, http.StatusOK)
+	activateContentType(t, handler, draftUpdated.Sys.Version)
+
+	editorInterface := getEditorInterface(t, handler)
+	assert.Equal(t, 3, editorInterface.Sys.Version)
+	assert.False(t, editorInterface.Controls.IsSet())
+}
+
+func TestActivateContentTypeAddsControlsOnlyForNewFields(t *testing.T) {
+	t.Parallel()
+
+	handler := newContentTypeTestHandler()
+	request := newContentTypeRequest()
+	created := putContentType(t, handler, &request, 1, http.StatusCreated)
+	activated := activateContentType(t, handler, created.Sys.Version)
+
+	editorInterfaceRequest := cm.EditorInterfaceData{
+		Controls: cm.NewOptNilEditorInterfaceDataControlsItemArray([]cm.EditorInterfaceDataControlsItem{}),
+	}
+	response, err := handler.PutEditorInterface(context.Background(), &editorInterfaceRequest, cm.PutEditorInterfaceParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type", XContentfulVersion: 1,
+	})
+	require.NoError(t, err)
+
+	statusCode, statusCodeOK := response.(*cm.EditorInterfaceStatusCode)
+	require.True(t, statusCodeOK)
+	assert.Empty(t, editorInterfaceControlFieldIDs(t, &statusCode.Response))
+
+	request.Fields = append(request.Fields, cm.ContentTypeRequestDataFieldsItem{ID: "subtitle", Name: "Subtitle", Type: "Symbol"})
+	draftUpdated := putContentType(t, handler, &request, activated.Sys.Version, http.StatusOK)
+	activateContentType(t, handler, draftUpdated.Sys.Version)
+
+	editorInterface := getEditorInterface(t, handler)
+	assert.Equal(t, 3, editorInterface.Sys.Version)
+	assert.Equal(t, []string{"subtitle"}, editorInterfaceControlFieldIDs(t, editorInterface))
+}
+
+func contentTypeEditorInterfaceParams() cm.GetEditorInterfaceParams {
+	return cm.GetEditorInterfaceParams{
+		SpaceID: "space", EnvironmentID: "environment", ContentTypeID: "content-type",
+	}
+}
+
+func getEditorInterface(t *testing.T, handler *cmt.Handler) *cm.EditorInterface {
+	t.Helper()
+
+	response, err := handler.GetEditorInterface(context.Background(), contentTypeEditorInterfaceParams())
+	require.NoError(t, err)
+
+	editorInterface, ok := response.(*cm.EditorInterface)
+	require.True(t, ok)
+
+	return editorInterface
+}
+
+func editorInterfaceControlFieldIDs(t *testing.T, editorInterface *cm.EditorInterface) []string {
+	t.Helper()
+
+	controls, controlsOK := editorInterface.Controls.Get()
+	require.True(t, controlsOK)
+
+	fieldIDs := make([]string, len(controls))
+	for index, control := range controls {
+		fieldIDs[index] = control.FieldId
+	}
+
+	return fieldIDs
+}

--- a/internal/provider/resource_content_type_schema.go
+++ b/internal/provider/resource_content_type_schema.go
@@ -74,7 +74,7 @@ func ContentTypeResourceSchema(ctx context.Context) schema.Schema {
 			"metadata": schema.SingleNestedAttribute{
 				Attributes:  ContentTypeMetadataValue{}.SchemaAttributes(ctx),
 				CustomType:  NewTypedObjectNull[ContentTypeMetadataValue]().CustomType(ctx),
-				Description: `Metadata for the content type. Once set, metadata properties may not be removed, but the list of taxonomy items may be reduced to the empty list`,
+				Description: `Metadata for the content type. Omitting metadata removes annotations but preserves taxonomy items. To remove taxonomy items, configure taxonomy as an empty list`,
 				Optional:    true,
 			},
 			"timeouts": timeouts.AttributesAll(ctx),

--- a/internal/provider/resource_content_type_test.go
+++ b/internal/provider/resource_content_type_test.go
@@ -208,8 +208,9 @@ func TestAccContentTypeResourceUpdate(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest
 func TestAccContentTypeResourceUpdateMetadata(t *testing.T) {
-	t.Parallel()
+	parallelWhenMocked(t)
 
 	server, _ := cmt.NewContentfulManagementServer()
 
@@ -223,7 +224,7 @@ func TestAccContentTypeResourceUpdateMetadata(t *testing.T) {
 		"test_content_type_id": config.StringVariable(contentTypeID),
 	}
 
-	ContentfulProviderMockedResourceTest(t, server, resource.TestCase{
+	ContentfulProviderMockableResourceTest(t, server, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
 				ConfigDirectory: config.TestStepDirectory(),
@@ -240,6 +241,73 @@ func TestAccContentTypeResourceUpdateMetadata(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("contentful_content_type.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ConfigDirectory: config.TestStepDirectory(),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("contentful_content_type.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ConfigDirectory: config.TestStepDirectory(),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("contentful_content_type.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+//nolint:paralleltest
+func TestAccContentTypeResourceRemoveAnnotationsMetadata(t *testing.T) {
+	parallelWhenMocked(t)
+
+	server, _ := cmt.NewContentfulManagementServer()
+
+	server.RegisterSpaceEnvironment("0p38pssr0fi3", "test")
+
+	contentTypeID := "acctest_" + acctest.RandStringFromCharSet(8, "abcdefghijklmnopqrstuvwxyz")
+
+	configVariables := config.Variables{
+		"space_id":             config.StringVariable("0p38pssr0fi3"),
+		"environment_id":       config.StringVariable("test"),
+		"test_content_type_id": config.StringVariable(contentTypeID),
+	}
+
+	ContentfulProviderMockableResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TestAccContentTypeResourceUpdateMetadata/annotations_only"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("contentful_content_type.test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TestAccContentTypeResourceUpdateMetadata/1"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("contentful_content_type.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TestAccContentTypeResourceUpdateMetadata/1"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("contentful_content_type.test", plancheck.ResourceActionNoop),
 					},
 				},
 			},

--- a/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/3/main.tf
+++ b/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/3/main.tf
@@ -28,4 +28,8 @@ resource "contentful_content_type" "test" {
       }
     }
   ]
+
+  metadata = {
+    taxonomy = []
+  }
 }

--- a/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/3/vars.tf
+++ b/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/3/vars.tf
@@ -1,0 +1,12 @@
+variable "space_id" {
+  type = string
+}
+
+variable "environment_id" {
+  type    = string
+  default = "master"
+}
+
+variable "test_content_type_id" {
+  type = string
+}

--- a/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/4/main.tf
+++ b/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/4/main.tf
@@ -28,4 +28,8 @@ resource "contentful_content_type" "test" {
       }
     }
   ]
+
+  metadata = {
+    taxonomy = []
+  }
 }

--- a/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/4/vars.tf
+++ b/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/4/vars.tf
@@ -1,0 +1,12 @@
+variable "space_id" {
+  type = string
+}
+
+variable "environment_id" {
+  type    = string
+  default = "master"
+}
+
+variable "test_content_type_id" {
+  type = string
+}

--- a/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/annotations_only/main.tf
+++ b/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/annotations_only/main.tf
@@ -52,18 +52,5 @@ resource "contentful_content_type" "test" {
         ]
       }
     })
-    taxonomy = [
-      {
-        taxonomy_concept_scheme = {
-          id = "furniture"
-        }
-      },
-      {
-        taxonomy_concept = {
-          id       = "livingRoomFurniture"
-          required = true
-        }
-      },
-    ]
   }
 }

--- a/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/annotations_only/vars.tf
+++ b/internal/provider/testdata/TestAccContentTypeResourceUpdateMetadata/annotations_only/vars.tf
@@ -1,0 +1,12 @@
+variable "space_id" {
+  type = string
+}
+
+variable "environment_id" {
+  type    = string
+  default = "master"
+}
+
+variable "test_content_type_id" {
+  type = string
+}


### PR DESCRIPTION
## Summary

- align mocked content type metadata, lifecycle, publication, deletion, editor interface, and pagination semantics with the Contentful Management API
- model property-specific metadata updates: omitted metadata clears annotations while preserving taxonomy, and explicit `taxonomy = []` removes taxonomy items
- run metadata removal acceptance coverage against both the mock and the real Contentful service using valid system annotations and verified taxonomy fixtures

## Why

The mock previously treated the metadata object as an all-or-nothing replacement. Real Contentful behavior is property-specific, which could hide drift and allowed the metadata acceptance test to pass without ever exercising production behavior.

The revised behavior was established through disposable probes against the real Contentful Management API before updating the mock and fixtures.

## Impact

Content type acceptance tests now cover both supported removal paths: omitting an annotations-only metadata block removes it entirely, while a populated annotations-and-taxonomy block is cleared with `taxonomy = []`. Both paths converge against the mock and the real CMA.

Two-phase deletion of published content type fields remains intentionally out of scope for a future fidelity pass.

## Validation

- real Contentful acceptance: `TestAccContentTypeResourceUpdateMetadata` and `TestAccContentTypeResourceRemoveAnnotationsMetadata`
- complete mocked provider acceptance suite
- `go test ./... -count=1`
- `golangci-lint run`
- `go generate ./...`
- standards and specification review
- verified all disposable Contentful resources were removed