### PR TITLE
fix(ci): skip live acceptance without secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,8 @@ jobs:
     concurrency:
       group: testacc
       queue: max
+    env:
+      CONTENTFUL_MANAGEMENT_ACCESS_TOKEN_AVAILABLE: ${{ secrets.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -104,12 +106,14 @@ jobs:
       - run: go mod download
 
       - run: go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -run '^TestAcc' ./internal/provider/
+        if: env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN_AVAILABLE == 'true'
         env:
           TF_ACC: "1"
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN }}
         timeout-minutes: 10
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN_AVAILABLE == 'true'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: testacc-${{ matrix.terraform }}


### PR DESCRIPTION
## Summary

- run live acceptance whenever `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` is available, including Dependabot pull requests
- skip only the secret-dependent live test and coverage upload when the token is unavailable
- preserve the matrix-qualified `testacc (1.14.*)` check required by the repository ruleset

## Why

GitHub withholds repository secrets from fork pull request workflows. The live acceptance test then fails because `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` is unavailable, which reports an infrastructure limitation as if the proposed provider change had failed acceptance testing.

The workflow now derives a boolean availability flag from the secret and keeps the secret value scoped to the live test step. This allows configured Dependabot secrets and repository secrets to run full acceptance while cross-repository runs without a token skip only the guarded steps. Mocked acceptance and all other CI remain unchanged.

## Validation

- parsed `.github/workflows/test.yml` with `yq`
- `git diff --check`
- confirmed recent Dependabot PR #577 passed `testacc (1.14.*)` and that the required Dependabot secrets are configured
- confirmed the branch differs from `main` by one workflow file and four added lines