### PR TITLE
fix(provider): fail closed during configuration

### DIFF
--- a/internal/provider/contentful_provider.go
+++ b/internal/provider/contentful_provider.go
@@ -42,9 +42,9 @@ type ContentfulProvider struct {
 	// testing.
 	version string
 
-	contentfulURL string
-	httpClient    *http.Client
-	accessToken   string
+	contentfulURLOverride string
+	httpClient            *http.Client
+	accessTokenOverride   string
 }
 
 type ContentfulProviderModel struct {
@@ -58,7 +58,7 @@ type Option func(*ContentfulProvider)
 
 func WithContentfulURL(url string) Option {
 	return func(p *ContentfulProvider) {
-		p.contentfulURL = url
+		p.contentfulURLOverride = url
 	}
 }
 
@@ -70,8 +70,24 @@ func WithHTTPClient(httpClient *http.Client) Option {
 
 func WithAccessToken(accessToken string) Option {
 	return func(p *ContentfulProvider) {
-		p.accessToken = accessToken
+		p.accessTokenOverride = accessToken
 	}
+}
+
+func resolveProviderString(override string, configured types.String, environmentVariable string) types.String {
+	if override != "" {
+		return types.StringValue(override)
+	}
+
+	if !configured.IsNull() {
+		return configured
+	}
+
+	if environmentValue, found := os.LookupEnv(environmentVariable); found {
+		return types.StringValue(environmentValue)
+	}
+
+	return types.StringNull()
 }
 
 func (p *ContentfulProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
@@ -98,16 +114,36 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 		return
 	}
 
-	var contentfulURL string
-	if !data.URL.IsNull() {
-		contentfulURL = data.URL.ValueString()
-	} else if contentfulURLFromEnv, found := os.LookupEnv("CONTENTFUL_URL"); found {
-		contentfulURL = contentfulURLFromEnv
+	contentfulURLValue := resolveProviderString(p.contentfulURLOverride, data.URL, "CONTENTFUL_URL")
+	accessTokenValue := resolveProviderString(
+		p.accessTokenOverride,
+		data.AccessToken,
+		"CONTENTFUL_MANAGEMENT_ACCESS_TOKEN",
+	)
+
+	if contentfulURLValue.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("url"),
+			"Unknown Contentful API URL",
+			"The provider cannot create the Contentful client because the configured API URL is unknown. "+
+				"Apply the source of the value first or use a known URL.",
+		)
 	}
 
-	if p.contentfulURL != "" {
-		contentfulURL = p.contentfulURL
+	if accessTokenValue.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("access_token"),
+			"Unknown Contentful management access token",
+			"The provider cannot create the Contentful client because the configured management access token is unknown. "+
+				"Apply the source of the value first or use a known access token.",
+		)
 	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	contentfulURL := contentfulURLValue.ValueString()
 
 	if contentfulURL == "" {
 		contentfulURL = cm.DefaultServerURL
@@ -117,18 +153,7 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 		resp.Diagnostics.AddAttributeError(path.Root("url"), "Failed to configure client", "No API URL provided")
 	}
 
-	var accessToken string
-	if !data.AccessToken.IsNull() {
-		accessToken = data.AccessToken.ValueString()
-	} else {
-		if accessTokenFromEnv, found := os.LookupEnv("CONTENTFUL_MANAGEMENT_ACCESS_TOKEN"); found {
-			accessToken = accessTokenFromEnv
-		}
-	}
-
-	if p.accessToken != "" {
-		accessToken = p.accessToken
-	}
+	accessToken := accessTokenValue.ValueString()
 
 	if accessToken == "" {
 		resp.Diagnostics.AddAttributeError(path.Root("access_token"), "Failed to configure client", "No access token provided")
@@ -152,7 +177,9 @@ func (p *ContentfulProvider) Configure(ctx context.Context, req provider.Configu
 		cm.WithClient(cm.NewTransportClient(retryableClient.StandardClient(), "terraform-provider-contentful/"+p.version)),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to create Contentful client: %s", err.Error())
+		resp.Diagnostics.AddError("Failed to create Contentful client", err.Error())
+
+		return
 	}
 
 	providerData := ContentfulProviderData{

--- a/internal/provider/contentful_provider_test.go
+++ b/internal/provider/contentful_provider_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
@@ -21,24 +23,37 @@ func makeTestAccProtoV6ProviderFactories(options ...Option) map[string]func() (t
 
 var testAccProtoV6ProviderFactories = makeTestAccProtoV6ProviderFactories()
 
-func providerConfigDynamicValue(config map[string]any) (tfprotov6.DynamicValue, error) {
-	providerConfigTypes := map[string]tftypes.Type{
-		"url":          tftypes.String,
-		"access_token": tftypes.String,
-	}
-	providerConfigObjectType := tftypes.Object{AttributeTypes: providerConfigTypes}
+var providerConfigType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"url":          tftypes.String,
+	"access_token": tftypes.String,
+}}
 
-	providerConfigObjectValue := tftypes.NewValue(providerConfigObjectType, map[string]tftypes.Value{
+func providerConfigValue(config map[string]any) tftypes.Value {
+	return tftypes.NewValue(providerConfigType, map[string]tftypes.Value{
 		"url":          tftypes.NewValue(tftypes.String, config["url"]),
 		"access_token": tftypes.NewValue(tftypes.String, config["access_token"]),
 	})
+}
 
-	value, err := tfprotov6.NewDynamicValue(providerConfigObjectType, providerConfigObjectValue)
+func providerConfigDynamicValue(config map[string]any) (tfprotov6.DynamicValue, error) {
+	value, err := tfprotov6.NewDynamicValue(providerConfigType, providerConfigValue(config))
 	if err != nil {
 		err = fmt.Errorf("failed to create dynamic value: %w", err)
 	}
 
 	return value, err
+}
+
+type providerDiagnosticExpectation struct {
+	summary   string
+	attribute *tftypes.AttributePath
+}
+
+func providerAttributeError(summary, attribute string) providerDiagnosticExpectation {
+	return providerDiagnosticExpectation{
+		summary:   summary,
+		attribute: tftypes.NewAttributePath().WithAttributeName(attribute),
+	}
 }
 
 func TestProtocol6ProviderServerSchemaVersion(t *testing.T) {
@@ -62,48 +77,36 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		config          map[string]any
-		env             map[string]string
-		expectedSuccess bool
+		config              map[string]any
+		env                 map[string]string
+		options             []Option
+		expectedDiagnostics []providerDiagnosticExpectation
 	}{
 		"config: url": {
 			config: map[string]any{
 				"url": "https://api.test.contentful.com",
 			},
-			expectedSuccess: false,
+			expectedDiagnostics: []providerDiagnosticExpectation{
+				providerAttributeError("Failed to configure client", "access_token"),
+			},
 		},
 		"config: access_token": {
 			config: map[string]any{
 				"access_token": "CFPAT-12345",
 			},
-			expectedSuccess: true,
-		},
-		"config: url,access_token": {
-			config: map[string]any{
-				"url":          "https://api.test.contentful.com",
-				"access_token": "CFPAT-12345",
-			},
-			expectedSuccess: true,
 		},
 		"config: url(invalid),access_token": {
 			config: map[string]any{
 				"url":          "url://an invalid url %/",
 				"access_token": "CFPAT-12345",
 			},
-			expectedSuccess: false,
-		},
-		"env: url": {
-			env: map[string]string{
-				"CONTENTFUL_URL": "https://api.test.contentful.com",
-			},
-			expectedSuccess: false,
+			expectedDiagnostics: []providerDiagnosticExpectation{{summary: "Failed to create Contentful client"}},
 		},
 		"env: url,access_token": {
 			env: map[string]string{
 				"CONTENTFUL_URL":                     "https://api.test.contentful.com",
 				"CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "CFPAT-12345",
 			},
-			expectedSuccess: true,
 		},
 		"config: url env: access_token": {
 			config: map[string]any{
@@ -112,17 +115,99 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 			env: map[string]string{
 				"CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "CFPAT-12345",
 			},
-			expectedSuccess: true,
+		},
+		"config takes precedence over env": {
+			config: map[string]any{
+				"url":          "https://api.test.contentful.com",
+				"access_token": "CFPAT-12345",
+			},
+			env: map[string]string{
+				"CONTENTFUL_URL": "url://an invalid url %/",
+			},
+		},
+		"known empty config takes precedence over env": {
+			config: map[string]any{
+				"url":          "",
+				"access_token": "",
+			},
+			env: map[string]string{
+				"CONTENTFUL_URL":                     "url://an invalid url %/",
+				"CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "CFPAT-12345",
+			},
+			expectedDiagnostics: []providerDiagnosticExpectation{
+				providerAttributeError("Failed to configure client", "access_token"),
+			},
+		},
+		"unknown url": {
+			config: map[string]any{
+				"url":          tftypes.UnknownValue,
+				"access_token": "CFPAT-12345",
+			},
+			expectedDiagnostics: []providerDiagnosticExpectation{
+				providerAttributeError("Unknown Contentful API URL", "url"),
+			},
+		},
+		"unknown access_token": {
+			config: map[string]any{
+				"url":          "https://api.test.contentful.com",
+				"access_token": tftypes.UnknownValue,
+			},
+			expectedDiagnostics: []providerDiagnosticExpectation{
+				providerAttributeError("Unknown Contentful management access token", "access_token"),
+			},
+		},
+		"unknown config takes precedence over env": {
+			config: map[string]any{
+				"url":          tftypes.UnknownValue,
+				"access_token": tftypes.UnknownValue,
+			},
+			env: map[string]string{
+				"CONTENTFUL_URL":                     "https://api.test.contentful.com",
+				"CONTENTFUL_MANAGEMENT_ACCESS_TOKEN": "CFPAT-12345",
+			},
+			expectedDiagnostics: []providerDiagnosticExpectation{
+				providerAttributeError("Unknown Contentful API URL", "url"),
+				providerAttributeError("Unknown Contentful management access token", "access_token"),
+			},
+		},
+		"options take precedence over unknown config and env": {
+			config: map[string]any{
+				"url":          tftypes.UnknownValue,
+				"access_token": tftypes.UnknownValue,
+			},
+			env: map[string]string{
+				"CONTENTFUL_URL": "url://an invalid url %/",
+			},
+			options: []Option{
+				WithContentfulURL("https://api.test.contentful.com"),
+				WithAccessToken("CFPAT-override"),
+			},
+		},
+		"invalid url option takes precedence over config and env": {
+			config: map[string]any{
+				"url":          "https://api.test.contentful.com",
+				"access_token": "CFPAT-12345",
+			},
+			env: map[string]string{
+				"CONTENTFUL_URL": "https://api.test.contentful.com",
+			},
+			options: []Option{
+				WithContentfulURL("url://an invalid url %/"),
+			},
+			expectedDiagnostics: []providerDiagnosticExpectation{{summary: "Failed to create Contentful client"}},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Setenv("CONTENTFUL_URL", "")
+			t.Setenv("CONTENTFUL_MANAGEMENT_ACCESS_TOKEN", "")
+
 			for key, value := range test.env {
 				t.Setenv(key, value)
 			}
 
-			providerServer, err := testAccProtoV6ProviderFactories["contentful"]()
+			providerServer, err := makeTestAccProtoV6ProviderFactories(test.options...)["contentful"]()
 			require.NotNil(t, providerServer)
 			require.NoError(t, err)
 
@@ -136,11 +221,53 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 			require.NotNil(t, resp)
 			require.NoError(t, err)
 
-			if test.expectedSuccess {
-				assert.Empty(t, resp.Diagnostics)
-			} else {
-				assert.NotEmpty(t, resp.Diagnostics)
+			require.Len(t, resp.Diagnostics, len(test.expectedDiagnostics))
+
+			for i, diagnostic := range resp.Diagnostics {
+				expected := test.expectedDiagnostics[i]
+
+				assert.Equal(t, expected.summary, diagnostic.Summary)
+				assert.Equal(t, tfprotov6.DiagnosticSeverityError, diagnostic.Severity)
+				assert.Equal(t, expected.attribute, diagnostic.Attribute)
+				assert.NotEmpty(t, diagnostic.Detail)
 			}
+		})
+	}
+}
+
+func TestProviderConfigureErrorsDoNotSetProviderData(t *testing.T) {
+	t.Parallel()
+
+	for name, url := range map[string]any{
+		"unknown configuration": tftypes.UnknownValue,
+		"invalid URL":           "url://an invalid url %/",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			providerImplementation := New("test")
+			schemaResponse := &frameworkprovider.SchemaResponse{}
+			providerImplementation.Schema(t.Context(), frameworkprovider.SchemaRequest{}, schemaResponse)
+			config := tfsdk.Config{
+				Schema: schemaResponse.Schema,
+				Raw: providerConfigValue(map[string]any{
+					"url":          url,
+					"access_token": "CFPAT-12345",
+				}),
+			}
+			response := &frameworkprovider.ConfigureResponse{}
+
+			providerImplementation.Configure(
+				t.Context(),
+				frameworkprovider.ConfigureRequest{Config: config},
+				response,
+			)
+
+			require.True(t, response.Diagnostics.HasError())
+			assert.Nil(t, response.ActionData)
+			assert.Nil(t, response.DataSourceData)
+			assert.Nil(t, response.ListResourceData)
+			assert.Nil(t, response.ResourceData)
 		})
 	}
 }


### PR DESCRIPTION
## What changed

- resolve provider strings through one precedence path: non-empty provider test/client override → Terraform configuration → environment variable
- preserve Terraform value state through resolution, rejecting unknown `url` and `access_token` values with attribute-path diagnostics before converting them to Go strings
- apply the Contentful URL default only after source resolution
- return immediately when Contentful client construction fails so action, data source, list resource, and resource provider data are published atomically
- extend the existing protocol configuration matrix across known, null, empty, and unknown Terraform values; environment fallback; and test-option precedence
- share one typed provider-configuration fixture between protocol and direct Framework tests

## Configuration behavior

- Terraform input variables arrive as provider configuration values. Known values retain precedence over environment variables.
- An explicitly configured unknown value retains that precedence and fails with an actionable diagnostic; it does not silently switch to a lower-precedence environment value.
- Null configuration falls back to `CONTENTFUL_URL` or `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN`. If no URL is supplied, the provider uses the existing Contentful default URL.
- Known empty configuration remains explicit: an empty URL continues to use the existing default, while an empty access token fails as missing.
- Non-empty `WithContentfulURL` and `WithAccessToken` options remain the highest-precedence test/client injection path, including over unknown configuration. Empty options retain their pre-existing meaning of no override.

## Why

Terraform can call provider configuration while values are still unknown. Framework string accessors return a Go zero value for unknown strings, so resolving sources before checking value state could accidentally use a default or report a misleading missing-value error.

The previous client-construction error path also appended a diagnostic but continued publishing provider data. Downstream components could therefore receive a failed or nil client even though configuration had failed.

Authoritative guidance:

- [HashiCorp provider unknown-value guidance](https://developer.hashicorp.com/terraform/plugin/framework/providers#unknown-values)
- [HashiCorp provider configuration tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider-configure)
- [Framework value access guidance](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values)

## Validation

- `go test ./internal/provider -run 'TestProtocol6ProviderServerConfigure|TestProviderConfigureErrorsDoNotSetProviderData' -count=1`
- `go test ./...`
- `TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -count=1`
- `golangci-lint cache clean`
- `golangci-lint run` (`0 issues`)
- `git diff --check origin/main`

Generation was not run because this change does not modify schemas, generated models, or documentation inputs.