### PR TITLE
fix(environment-status): publish converted state atomically

### DIFF
--- a/internal/provider/data_source_environment_status_ready.go
+++ b/internal/provider/data_source_environment_status_ready.go
@@ -44,24 +44,26 @@ func (d *environmentStatusReadyDataSource) Configure(_ context.Context, req data
 }
 
 func (d *environmentStatusReadyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data EnvironmentStatusReadyModel
+	var config EnvironmentStatusReadyModel
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	timeout, timeoutDiagnostics := data.Timeouts.Read(ctx, environmentStatusReadyTimeout)
+	timeout, timeoutDiagnostics := config.Timeouts.Read(ctx, environmentStatusReadyTimeout)
 	resp.Diagnostics.Append(timeoutDiagnostics...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	configuredTimeouts := config.Timeouts
+
 	params := cm.GetEnvironmentParams{
-		SpaceID:       data.SpaceID.ValueString(),
-		EnvironmentID: data.EnvironmentID.ValueString(),
+		SpaceID:       config.SpaceID.ValueString(),
+		EnvironmentID: config.EnvironmentID.ValueString(),
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -81,21 +83,21 @@ func (d *environmentStatusReadyDataSource) Read(ctx context.Context, req datasou
 
 		switch response := response.(type) {
 		case *cm.Environment:
-			responseModel, responseModelDiags := NewEnvironmentStatusReadyModelFromResponse(ctx, *response)
-			resp.Diagnostics.Append(responseModelDiags...)
+			continuePolling, responseDiags := publishEnvironmentStatusReadyResponse(
+				ctx,
+				&resp.State,
+				*response,
+				configuredTimeouts,
+			)
+			resp.Diagnostics.Append(responseDiags...)
 
-			responseModel.Timeouts = data.Timeouts
-			data = responseModel
+			if resp.Diagnostics.HasError() || !continuePolling {
+				return
+			}
 
 		default:
 			resp.Diagnostics.AddError("Failed to read environment", util.ErrorDetailFromContentfulManagementResponse(response, err))
 
-			return
-		}
-
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-
-		if data.Status.ValueString() == environmentStatusReadyValue {
 			return
 		}
 

--- a/internal/provider/data_source_environment_status_ready_test.go
+++ b/internal/provider/data_source_environment_status_ready_test.go
@@ -11,6 +11,8 @@ import (
 	cmt "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go/testing"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type environmentStatusReadyTestHandler struct {
@@ -20,7 +22,7 @@ type environmentStatusReadyTestHandler struct {
 	environmentID string
 
 	readyOnRequest int
-	requestCount   int
+	statuses       []string
 }
 
 func (h *environmentStatusReadyTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -30,12 +32,12 @@ func (h *environmentStatusReadyTestHandler) ServeHTTP(w http.ResponseWriter, r *
 		h.mu.Lock()
 		defer h.mu.Unlock()
 
-		h.requestCount++
-
 		status := "queued"
-		if h.requestCount >= h.readyOnRequest {
+		if len(h.statuses)+1 >= h.readyOnRequest {
 			status = "ready"
 		}
+
+		h.statuses = append(h.statuses, status)
 
 		environment := cm.Environment{
 			Sys:  cm.NewEnvironmentSys(h.spaceID, h.environmentID, status),
@@ -54,6 +56,13 @@ func (h *environmentStatusReadyTestHandler) ServeHTTP(w http.ResponseWriter, r *
 	}
 
 	http.NotFound(w, r)
+}
+
+func (h *environmentStatusReadyTestHandler) StatusesServed() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]string(nil), h.statuses...)
 }
 
 func TestAccEnvironmentStatusReadyDataSource(t *testing.T) {
@@ -114,6 +123,14 @@ func TestAccEnvironmentStatusReadyDataSourcePolling(t *testing.T) {
 			},
 		},
 	})
+
+	statuses := server.StatusesServed()
+	require.GreaterOrEqual(t, len(statuses), 2)
+	assert.Equal(t, []string{"queued", "ready"}, statuses[:2])
+
+	for _, status := range statuses[2:] {
+		assert.Equal(t, "ready", status)
+	}
 }
 
 func TestAccEnvironmentStatusReadyDataSourceNotFound(t *testing.T) {

--- a/internal/provider/environment_status_ready_state.go
+++ b/internal/provider/environment_status_ready_state.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"context"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	datasourcetimeouts "github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+func publishEnvironmentStatusReadyResponse(
+	ctx context.Context,
+	state *tfsdk.State,
+	response cm.Environment,
+	configuredTimeouts datasourcetimeouts.Value,
+) (bool, diag.Diagnostics) {
+	model, diags := NewEnvironmentStatusReadyModelFromResponse(ctx, response)
+
+	return publishEnvironmentStatusReadyConversion(ctx, state, configuredTimeouts, model, diags)
+}
+
+func publishEnvironmentStatusReadyConversion(
+	ctx context.Context,
+	state *tfsdk.State,
+	configuredTimeouts datasourcetimeouts.Value,
+	model EnvironmentStatusReadyModel,
+	diags diag.Diagnostics,
+) (bool, diag.Diagnostics) {
+	if diags.HasError() {
+		return false, diags
+	}
+
+	model.Timeouts = configuredTimeouts
+	diags.Append(state.Set(ctx, &model)...)
+
+	if diags.HasError() {
+		return false, diags
+	}
+
+	return model.Status.ValueString() != environmentStatusReadyValue, diags
+}

--- a/internal/provider/environment_status_ready_state_test.go
+++ b/internal/provider/environment_status_ready_state_test.go
@@ -1,0 +1,196 @@
+//nolint:testpackage
+package provider
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	datasourcetimeouts "github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func environmentStatusReadyTimeoutAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"read": types.StringType,
+	}
+}
+
+func TestPublishEnvironmentStatusReadyConversionErrorDoesNotPublish(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	state := tfsdk.State{Schema: EnvironmentStatusReadyDataSourceSchema(ctx)}
+	current := environmentStatusReadyTestModel(
+		types.StringValue("queued"),
+		datasourcetimeouts.Value{
+			Object: types.ObjectNull(environmentStatusReadyTimeoutAttributeTypes()),
+		},
+	)
+	require.False(t, state.Set(ctx, &current).HasError())
+	before := state.Raw
+	conversionDiags := diag.Diagnostics{
+		diag.NewWarningDiagnostic("Incomplete Contentful response", "conversion warning"),
+		diag.NewErrorDiagnostic("Malformed Contentful response", "conversion failed"),
+	}
+
+	continuePolling, diags := publishEnvironmentStatusReadyConversion(
+		ctx,
+		&state,
+		datasourcetimeouts.Value{Object: types.ObjectUnknown(environmentStatusReadyTimeoutAttributeTypes())},
+		EnvironmentStatusReadyModel{Status: types.StringUnknown()},
+		conversionDiags,
+	)
+
+	require.True(t, diags.HasError())
+	assert.False(t, continuePolling)
+	assert.Equal(t, conversionDiags, diags)
+	assert.True(t, before.Equal(state.Raw))
+}
+
+func TestPublishEnvironmentStatusReadyConversionWarningPublishes(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	state := tfsdk.State{Schema: EnvironmentStatusReadyDataSourceSchema(ctx)}
+	configuredTimeouts := environmentStatusReadyTimeoutValue(types.StringUnknown())
+	conversionDiags := diag.Diagnostics{
+		diag.NewWarningDiagnostic("Incomplete Contentful response", "conversion warning"),
+	}
+
+	continuePolling, diags := publishEnvironmentStatusReadyConversion(
+		ctx,
+		&state,
+		configuredTimeouts,
+		environmentStatusReadyTestModel(types.StringValue("queued"), datasourcetimeouts.Value{}),
+		conversionDiags,
+	)
+
+	require.False(t, diags.HasError())
+	assert.True(t, continuePolling)
+	assert.Equal(t, conversionDiags, diags)
+
+	var published EnvironmentStatusReadyModel
+	require.False(t, state.Get(ctx, &published).HasError())
+	assert.Equal(t, types.StringValue("space/environment"), published.ID)
+	assert.Equal(t, types.StringValue("space"), published.SpaceID)
+	assert.Equal(t, types.StringValue("environment"), published.EnvironmentID)
+	assert.Equal(t, types.StringValue("queued"), published.Status)
+	assert.True(t, configuredTimeouts.Equal(published.Timeouts))
+}
+
+func TestPublishEnvironmentStatusReadyResponsePreservesTimeoutsAndControlsPolling(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		configuredTimeouts datasourcetimeouts.Value
+		status             string
+		continuePolling    bool
+	}{
+		"null timeout and queued": {
+			configuredTimeouts: datasourcetimeouts.Value{
+				Object: types.ObjectNull(environmentStatusReadyTimeoutAttributeTypes()),
+			},
+			status:          "queued",
+			continuePolling: true,
+		},
+		"unknown timeout and ready": {
+			configuredTimeouts: datasourcetimeouts.Value{
+				Object: types.ObjectUnknown(environmentStatusReadyTimeoutAttributeTypes()),
+			},
+			status:          environmentStatusReadyValue,
+			continuePolling: false,
+		},
+		"known timeout and ready": {
+			configuredTimeouts: environmentStatusReadyTimeoutValue(types.StringValue("30m")),
+			status:             environmentStatusReadyValue,
+			continuePolling:    false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			state := tfsdk.State{Schema: EnvironmentStatusReadyDataSourceSchema(ctx)}
+			response := cm.Environment{
+				Sys:  cm.NewEnvironmentSys("space", "environment", test.status),
+				Name: "environment",
+			}
+
+			continuePolling, diags := publishEnvironmentStatusReadyResponse(
+				ctx,
+				&state,
+				response,
+				test.configuredTimeouts,
+			)
+
+			require.False(t, diags.HasError())
+			assert.Equal(t, test.continuePolling, continuePolling)
+
+			var published EnvironmentStatusReadyModel
+			require.False(t, state.Get(ctx, &published).HasError())
+			assert.Equal(t, types.StringValue(test.status), published.Status)
+			assert.True(t, test.configuredTimeouts.Equal(published.Timeouts))
+		})
+	}
+}
+
+func TestPublishEnvironmentStatusReadyStatePublicationErrorStopsPollingAndLeavesStateUntouched(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	state := tfsdk.State{Schema: EnvironmentStatusReadyDataSourceSchema(ctx)}
+	current := environmentStatusReadyTestModel(
+		types.StringValue("queued"),
+		datasourcetimeouts.Value{Object: types.ObjectNull(environmentStatusReadyTimeoutAttributeTypes())},
+	)
+	require.False(t, state.Set(ctx, &current).HasError())
+	before := state.Raw
+	state.Schema = datasourceschema.Schema{}
+	response := cm.Environment{
+		Sys:  cm.NewEnvironmentSys("space", "environment", environmentStatusReadyValue),
+		Name: "environment",
+	}
+
+	continuePolling, diags := publishEnvironmentStatusReadyResponse(
+		ctx,
+		&state,
+		response,
+		environmentStatusReadyTimeoutValue(types.StringNull()),
+	)
+
+	require.True(t, diags.HasError())
+	assert.False(t, continuePolling)
+	assert.True(t, before.Equal(state.Raw))
+}
+
+func environmentStatusReadyTimeoutValue(read types.String) datasourcetimeouts.Value {
+	return datasourcetimeouts.Value{
+		Object: types.ObjectValueMust(
+			environmentStatusReadyTimeoutAttributeTypes(),
+			map[string]attr.Value{"read": read},
+		),
+	}
+}
+
+func environmentStatusReadyTestModel(
+	status types.String,
+	timeouts datasourcetimeouts.Value,
+) EnvironmentStatusReadyModel {
+	return EnvironmentStatusReadyModel{
+		IDIdentityModel: NewIDIdentityModelFromMultipartID("space", "environment"),
+		EnvironmentIdentityModel: EnvironmentIdentityModel{
+			SpaceID:       types.StringValue("space"),
+			EnvironmentID: types.StringValue("environment"),
+		},
+		Status:   status,
+		Timeouts: timeouts,
+	}
+}


### PR DESCRIPTION
## Summary

- treat Environment Status response conversion, timeout restoration, state publication, and readiness evaluation as one fail-closed operation
- stop polling after conversion or state-publication diagnostics, before acting on response readiness
- preserve the configuration-owned timeout value exactly while publishing successfully converted responses
- cover conversion errors and warnings, publication failures, null/unknown/known timeout values, and queued-to-ready polling

## Root cause

The data source appended response-conversion diagnostics but unconditionally copied and published the returned model. A converter that reported an error could therefore expose a partial model to `State.Set` and continue the polling flow.

The initial remediation introduced an injectable response converter to exercise that error path. Because production has only one converter, that seam added a caller-selectable variation used only by tests.

## Impact

Environment Status reads now fail closed through a single response-publication operation. Conversion errors cannot mutate state, state-publication errors cannot be treated as readiness, and polling continues only after a non-ready response has been converted and published successfully. Configuration-owned timeout values retain their exact Terraform null, unknown, or known state.

## Validation

- `go test ./internal/provider -run 'TestPublishEnvironmentStatusReady|TestAccEnvironmentStatusReady' -count=1`
- `go test ./...`
- `TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -count=1`
- `golangci-lint cache clean`
- `golangci-lint run --allow-parallel-runners`
- `git diff --check origin/main...HEAD`
