### PR TITLE
fix(provider): make multipart imports transactional

### DIFF
--- a/internal/provider/import_state.go
+++ b/internal/provider/import_state.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+type importAttribute struct {
+	path  path.Path
+	value types.String
+}
 
 func ImportStatePassthroughMultipartID(ctx context.Context, attrPaths []path.Path, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	if req.ID != "" {
@@ -21,30 +28,83 @@ func ImportStatePassthroughMultipartID(ctx context.Context, attrPaths []path.Pat
 			return
 		}
 
+		attributes := make([]importAttribute, 0, len(attrPaths))
 		for i, attrPath := range attrPaths {
-			if resp.Identity != nil {
-				resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, attrPath, attrValues[i])...)
+			if attrValues[i] == "" {
+				resp.Diagnostics.AddAttributeError(attrPath, "Resource Import Passthrough Multipart ID Mismatch", "Import identity components must not be empty.")
+
+				return
 			}
 
-			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attrPath, attrValues[i])...)
+			attributes = append(attributes, importAttribute{path: attrPath, value: types.StringValue(attrValues[i])})
 		}
+
+		resp.Diagnostics.Append(setImportAttributes(ctx, &resp.State, resp.Identity, attributes)...)
 
 		return
 	}
 
-	for _, attrPath := range attrPaths {
-		var identityComponentValue attr.Value
+	if req.Identity == nil {
+		resp.Diagnostics.AddError("Resource Import Passthrough Multipart ID Mismatch", "No import identity was provided.")
 
-		resp.Diagnostics.Append(req.Identity.GetAttribute(ctx, attrPath, &identityComponentValue)...)
-
-		if identityComponentValue.IsUnknown() || identityComponentValue.IsNull() {
-			resp.Diagnostics.AddAttributeError(attrPath, "Resource Import Passthrough Multipart ID Mismatch", "")
-		}
-
-		if resp.Identity != nil {
-			resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, attrPath, identityComponentValue)...)
-		}
-
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attrPath, identityComponentValue)...)
+		return
 	}
+
+	attributes := make([]importAttribute, 0, len(attrPaths))
+	for _, attrPath := range attrPaths {
+		var identityValue types.String
+
+		getDiags := req.Identity.GetAttribute(ctx, attrPath, &identityValue)
+		resp.Diagnostics.Append(getDiags...)
+
+		if getDiags.HasError() {
+			return
+		}
+
+		if identityValue.IsUnknown() || identityValue.IsNull() || identityValue.ValueString() == "" {
+			resp.Diagnostics.AddAttributeError(attrPath, "Resource Import Passthrough Multipart ID Mismatch", "Import identity components must be known, non-null, and non-empty.")
+
+			return
+		}
+
+		attributes = append(attributes, importAttribute{path: attrPath, value: identityValue})
+	}
+
+	resp.Diagnostics.Append(setImportAttributes(ctx, &resp.State, resp.Identity, attributes)...)
+}
+
+func setImportAttributes(
+	ctx context.Context,
+	state *tfsdk.State,
+	identity *tfsdk.ResourceIdentity,
+	attributes []importAttribute,
+) diag.Diagnostics {
+	stagedState := *state
+
+	var stagedIdentity tfsdk.ResourceIdentity
+	if identity != nil {
+		stagedIdentity = *identity
+	}
+
+	diags := diag.Diagnostics{}
+
+	for _, attribute := range attributes {
+		if identity != nil {
+			diags.Append(stagedIdentity.SetAttribute(ctx, attribute.path, attribute.value)...)
+		}
+
+		diags.Append(stagedState.SetAttribute(ctx, attribute.path, attribute.value)...)
+	}
+
+	if diags.HasError() {
+		return diags
+	}
+
+	*state = stagedState
+
+	if identity != nil {
+		*identity = stagedIdentity
+	}
+
+	return diags
 }

--- a/internal/provider/import_state_test.go
+++ b/internal/provider/import_state_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
@@ -35,48 +36,280 @@ var (
 	}}
 )
 
-func TestImportStatePassthroughMultipartIDFromIdentity(t *testing.T) {
+func TestImportStatePassthroughMultipartID(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	assertValues := func(t *testing.T, resp *resource.ImportStateResponse, expectIdentity bool) {
+		t.Helper()
 
-	reqIdentity := importStatePassthroughIdentity(importStateRawValues("space", "entry"))
-	resp := importStatePassthroughResponse()
+		var stateSpaceID, stateEntryID types.String
+		resp.Diagnostics.Append(resp.State.GetAttribute(t.Context(), path.Root("space_id"), &stateSpaceID)...)
+		resp.Diagnostics.Append(resp.State.GetAttribute(t.Context(), path.Root("entry_id"), &stateEntryID)...)
+		require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+		assert.Equal(t, types.StringValue("space"), stateSpaceID)
+		assert.Equal(t, types.StringValue("entry"), stateEntryID)
 
-	provider.ImportStatePassthroughMultipartID(ctx, importStatePassthroughPaths, resource.ImportStateRequest{
-		Identity: reqIdentity,
-	}, resp)
+		if !expectIdentity {
+			assert.Nil(t, resp.Identity)
 
-	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+			return
+		}
 
-	var stateSpaceID, stateEntryID types.String
-	resp.Diagnostics.Append(resp.State.GetAttribute(ctx, path.Root("space_id"), &stateSpaceID)...)
-	resp.Diagnostics.Append(resp.State.GetAttribute(ctx, path.Root("entry_id"), &stateEntryID)...)
-	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
-	assert.Equal(t, types.StringValue("space"), stateSpaceID)
-	assert.Equal(t, types.StringValue("entry"), stateEntryID)
+		var identitySpaceID, identityEntryID types.String
+		resp.Diagnostics.Append(resp.Identity.GetAttribute(t.Context(), path.Root("space_id"), &identitySpaceID)...)
+		resp.Diagnostics.Append(resp.Identity.GetAttribute(t.Context(), path.Root("entry_id"), &identityEntryID)...)
+		require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+		assert.Equal(t, types.StringValue("space"), identitySpaceID)
+		assert.Equal(t, types.StringValue("entry"), identityEntryID)
+	}
 
-	var identitySpaceID, identityEntryID types.String
-	resp.Diagnostics.Append(resp.Identity.GetAttribute(ctx, path.Root("space_id"), &identitySpaceID)...)
-	resp.Diagnostics.Append(resp.Identity.GetAttribute(ctx, path.Root("entry_id"), &identityEntryID)...)
-	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
-	assert.Equal(t, types.StringValue("space"), identitySpaceID)
-	assert.Equal(t, types.StringValue("entry"), identityEntryID)
+	tests := map[string]struct {
+		request        resource.ImportStateRequest
+		expectIdentity bool
+	}{
+		"identity": {
+			request: resource.ImportStateRequest{
+				Identity: importStatePassthroughIdentity(importStateRawValues("space", "entry")),
+			},
+			expectIdentity: true,
+		},
+		"identity without response identity": {
+			request: resource.ImportStateRequest{
+				Identity: importStatePassthroughIdentity(importStateRawValues("space", "entry")),
+			},
+		},
+		"legacy ID": {
+			request:        resource.ImportStateRequest{ID: "space/entry"},
+			expectIdentity: true,
+		},
+		"legacy ID without response identity": {
+			request: resource.ImportStateRequest{ID: "space/entry"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := importStatePassthroughResponse()
+			if !test.expectIdentity {
+				resp.Identity = nil
+			}
+
+			provider.ImportStatePassthroughMultipartID(t.Context(), importStatePassthroughPaths, test.request, resp)
+
+			require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+			assertValues(t, resp, test.expectIdentity)
+		})
+	}
 }
 
-func TestImportStatePassthroughMultipartIDFromIdentityRejectsNullComponent(t *testing.T) {
+func TestImportStatePassthroughMultipartIDFromIdentityRejectsInvalidComponent(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	tests := map[string]any{
+		"null":    nil,
+		"unknown": tftypes.UnknownValue,
+		"empty":   "",
+	}
 
-	reqIdentity := importStatePassthroughIdentity(importStateRawValues("space", nil))
+	for name, component := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			reqIdentity := importStatePassthroughIdentity(importStateRawValues("space", component))
+			resp := importStatePassthroughResponse()
+
+			provider.ImportStatePassthroughMultipartID(t.Context(), importStatePassthroughPaths, resource.ImportStateRequest{
+				Identity: reqIdentity,
+			}, resp)
+
+			assert.True(t, resp.Diagnostics.HasError())
+			assert.Equal(t, []string{"entry_id"}, importDiagnosticPaths(t, resp.Diagnostics))
+			assertImportStatePassthroughUntouched(t, resp)
+		})
+	}
+}
+
+func TestImportStatePassthroughMultipartIDFromIDRejectsEmptyComponent(t *testing.T) {
+	t.Parallel()
+
 	resp := importStatePassthroughResponse()
 
-	provider.ImportStatePassthroughMultipartID(ctx, importStatePassthroughPaths, resource.ImportStateRequest{
+	provider.ImportStatePassthroughMultipartID(
+		t.Context(),
+		importStatePassthroughPaths,
+		resource.ImportStateRequest{ID: "space/"},
+		resp,
+	)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Equal(t, []string{"entry_id"}, importDiagnosticPaths(t, resp.Diagnostics))
+	assertImportStatePassthroughUntouched(t, resp)
+}
+
+func TestImportStatePassthroughMultipartIDFromIdentityRejectsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	rawType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+		"entry_id": tftypes.Bool,
+	}}
+	reqIdentity := &tfsdk.ResourceIdentity{
+		Schema: importStatePassthroughIdentitySchema,
+		Raw: tftypes.NewValue(rawType, map[string]tftypes.Value{
+			"space_id": tftypes.NewValue(tftypes.String, "space"),
+			"entry_id": tftypes.NewValue(tftypes.Bool, true),
+		}),
+	}
+	resp := importStatePassthroughResponse()
+
+	provider.ImportStatePassthroughMultipartID(t.Context(), importStatePassthroughPaths, resource.ImportStateRequest{
 		Identity: reqIdentity,
 	}, resp)
 
 	assert.True(t, resp.Diagnostics.HasError())
+	assert.Equal(t, []string{"entry_id"}, importDiagnosticPaths(t, resp.Diagnostics))
+	assertImportStatePassthroughUntouched(t, resp)
+}
+
+func TestImportStatePassthroughMultipartIDFromIDIsAtomicAfterLateSetterError(t *testing.T) {
+	t.Parallel()
+
+	rawType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+	}}
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+				"space_id": schema.StringAttribute{Optional: true},
+			}},
+			Raw: tftypes.NewValue(rawType, map[string]tftypes.Value{
+				"space_id": tftypes.NewValue(tftypes.String, nil),
+			}),
+		},
+	}
+
+	provider.ImportStatePassthroughMultipartID(
+		t.Context(),
+		[]path.Path{path.Root("space_id"), path.Root("missing")},
+		resource.ImportStateRequest{ID: "space/entry"},
+		resp,
+	)
+
+	require.True(t, resp.Diagnostics.HasError())
+
+	var spaceID types.String
+	require.False(t, resp.State.GetAttribute(t.Context(), path.Root("space_id"), &spaceID).HasError())
+	assert.True(t, spaceID.IsNull())
+}
+
+func TestImportStatePassthroughMultipartIDFromIdentityIsAtomicAfterLateSetterError(t *testing.T) {
+	t.Parallel()
+
+	identityRawType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+		"missing":  tftypes.String,
+	}}
+	identitySchema := identityschema.Schema{Attributes: map[string]identityschema.Attribute{
+		"space_id": identityschema.StringAttribute{RequiredForImport: true},
+		"missing":  identityschema.StringAttribute{RequiredForImport: true},
+	}}
+	reqIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchema,
+		Raw: tftypes.NewValue(identityRawType, map[string]tftypes.Value{
+			"space_id": tftypes.NewValue(tftypes.String, "space"),
+			"missing":  tftypes.NewValue(tftypes.String, "entry"),
+		}),
+	}
+
+	stateRawType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+	}}
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: schema.Schema{Attributes: map[string]schema.Attribute{
+				"space_id": schema.StringAttribute{Optional: true},
+			}},
+			Raw: tftypes.NewValue(stateRawType, map[string]tftypes.Value{
+				"space_id": tftypes.NewValue(tftypes.String, nil),
+			}),
+		},
+		Identity: &tfsdk.ResourceIdentity{
+			Schema: identitySchema,
+			Raw: tftypes.NewValue(identityRawType, map[string]tftypes.Value{
+				"space_id": tftypes.NewValue(tftypes.String, nil),
+				"missing":  tftypes.NewValue(tftypes.String, nil),
+			}),
+		},
+	}
+
+	provider.ImportStatePassthroughMultipartID(
+		t.Context(),
+		[]path.Path{path.Root("space_id"), path.Root("missing")},
+		resource.ImportStateRequest{Identity: reqIdentity},
+		resp,
+	)
+
+	require.True(t, resp.Diagnostics.HasError())
+
+	var stateSpaceID types.String
+	require.False(t, resp.State.GetAttribute(t.Context(), path.Root("space_id"), &stateSpaceID).HasError())
+	assert.True(t, stateSpaceID.IsNull())
+
+	var identitySpaceID, identityMissing types.String
+	require.False(t, resp.Identity.GetAttribute(t.Context(), path.Root("space_id"), &identitySpaceID).HasError())
+	require.False(t, resp.Identity.GetAttribute(t.Context(), path.Root("missing"), &identityMissing).HasError())
+	assert.True(t, identitySpaceID.IsNull())
+	assert.True(t, identityMissing.IsNull())
+}
+
+func TestImportStatePassthroughMultipartIDIsAtomicAfterIdentitySetterError(t *testing.T) {
+	t.Parallel()
+
+	stateRawType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+		"entry_id": tftypes.String,
+	}}
+	identityRawType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"space_id": tftypes.String,
+	}}
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: importStatePassthroughResourceSchema,
+			Raw: tftypes.NewValue(stateRawType, map[string]tftypes.Value{
+				"space_id": tftypes.NewValue(tftypes.String, nil),
+				"entry_id": tftypes.NewValue(tftypes.String, nil),
+			}),
+		},
+		Identity: &tfsdk.ResourceIdentity{
+			Schema: identityschema.Schema{Attributes: map[string]identityschema.Attribute{
+				"space_id": identityschema.StringAttribute{RequiredForImport: true},
+			}},
+			Raw: tftypes.NewValue(identityRawType, map[string]tftypes.Value{
+				"space_id": tftypes.NewValue(tftypes.String, nil),
+			}),
+		},
+	}
+
+	provider.ImportStatePassthroughMultipartID(
+		t.Context(),
+		importStatePassthroughPaths,
+		resource.ImportStateRequest{ID: "space/entry"},
+		resp,
+	)
+
+	require.True(t, resp.Diagnostics.HasError())
+
+	var stateSpaceID, stateEntryID types.String
+	require.False(t, resp.State.GetAttribute(t.Context(), path.Root("space_id"), &stateSpaceID).HasError())
+	require.False(t, resp.State.GetAttribute(t.Context(), path.Root("entry_id"), &stateEntryID).HasError())
+	assert.True(t, stateSpaceID.IsNull())
+	assert.True(t, stateEntryID.IsNull())
+
+	var identitySpaceID types.String
+	require.False(t, resp.Identity.GetAttribute(t.Context(), path.Root("space_id"), &identitySpaceID).HasError())
+	assert.True(t, identitySpaceID.IsNull())
 }
 
 func importStatePassthroughIdentity(rawValues map[string]tftypes.Value) *tfsdk.ResourceIdentity {
@@ -98,4 +331,34 @@ func importStateRawValues(spaceID, entryID any) map[string]tftypes.Value {
 		"space_id": tftypes.NewValue(tftypes.String, spaceID),
 		"entry_id": tftypes.NewValue(tftypes.String, entryID),
 	}
+}
+
+func assertImportStatePassthroughUntouched(t *testing.T, resp *resource.ImportStateResponse) {
+	t.Helper()
+
+	var stateSpaceID, stateEntryID types.String
+	require.False(t, resp.State.GetAttribute(t.Context(), path.Root("space_id"), &stateSpaceID).HasError())
+	require.False(t, resp.State.GetAttribute(t.Context(), path.Root("entry_id"), &stateEntryID).HasError())
+	assert.True(t, stateSpaceID.IsNull())
+	assert.True(t, stateEntryID.IsNull())
+
+	var identitySpaceID, identityEntryID types.String
+	require.False(t, resp.Identity.GetAttribute(t.Context(), path.Root("space_id"), &identitySpaceID).HasError())
+	require.False(t, resp.Identity.GetAttribute(t.Context(), path.Root("entry_id"), &identityEntryID).HasError())
+	assert.True(t, identitySpaceID.IsNull())
+	assert.True(t, identityEntryID.IsNull())
+}
+
+func importDiagnosticPaths(t *testing.T, diags diag.Diagnostics) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(diags.Errors()))
+	for _, diagnostic := range diags.Errors() {
+		withPath, ok := diagnostic.(diag.DiagnosticWithPath)
+		require.True(t, ok)
+
+		paths = append(paths, withPath.Path().String())
+	}
+
+	return paths
 }


### PR DESCRIPTION
## Summary

- validate legacy multipart import ID components before writing state or resource identity
- validate structured resource identity components as known, non-null, and non-empty strings
- stage all state and identity mutations and publish them only when every setter succeeds
- add focused regression coverage for valid imports, invalid components, decode failures, and late setter failures

## Why

The import helper previously wrote each component directly as it was processed. A later validation or setter diagnostic could therefore leave an incomplete state or resource identity. Structured identity values were also accepted without consistently rejecting unknown, null, empty, or undecodable components.

The helper now builds a complete validated component set, applies it to staged copies, and commits both outputs only when no errors occurred. Invalid imports leave the response state and identity untouched.

## Impact

Multipart imports retain their existing accepted syntax. Invalid or partially applicable imports now fail deterministically without publishing partial identity or state.

## Validation

- `go test ./internal/provider -run '^TestImportStatePassthroughMultipartID' -count=1`
- `go test ./...`
- `TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -count=1`
- `golangci-lint cache clean`
- `golangci-lint run` (0 issues)
- `git diff --check origin/main...HEAD`

Generation is not relevant because this PR changes no schemas, templates, or generated sources.