### PR TITLE
fix(taxonomy): stop after conversion errors

### DIFF
--- a/internal/provider/resource_taxonomy_concept.go
+++ b/internal/provider/resource_taxonomy_concept.go
@@ -131,6 +131,11 @@ func (r *taxonomyConceptResource) Read(ctx context.Context, req resource.ReadReq
 
 	data, modelDiags := NewTaxonomyConceptModelFromResponse(ctx, *concept)
 	resp.Diagnostics.Append(modelDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	preserveConfiguredLabelMapShape(&data, state)
 
 	data.Timeouts = state.Timeouts
@@ -164,6 +169,13 @@ func (r *taxonomyConceptResource) Update(ctx context.Context, req resource.Updat
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	request, requestDiags := plan.ToRequest(ctx)
+	resp.Diagnostics.Append(requestDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	getParams := cm.GetTaxonomyConceptParams{OrganizationID: plan.OrganizationID.ValueString(), TaxonomyConceptID: plan.ConceptID.ValueString()}
 	currentResponse, err := r.providerData.client.GetTaxonomyConcept(ctx, getParams)
 
@@ -173,9 +185,6 @@ func (r *taxonomyConceptResource) Update(ctx context.Context, req resource.Updat
 
 		return
 	}
-
-	request, requestDiags := plan.ToRequest(ctx)
-	resp.Diagnostics.Append(requestDiags...)
 
 	patch, patchErr := taxonomyPatch(taxonomyConceptRequestFromResponse(*current), request)
 	if patchErr != nil {
@@ -187,6 +196,11 @@ func (r *taxonomyConceptResource) Update(ctx context.Context, req resource.Updat
 	if len(patch) == 0 {
 		data, modelDiags := NewTaxonomyConceptModelFromResponse(ctx, *current)
 		resp.Diagnostics.Append(modelDiags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		preserveConfiguredLabelMapShape(&data, plan)
 
 		data.Timeouts = plan.Timeouts
@@ -215,6 +229,11 @@ func (r *taxonomyConceptResource) Update(ctx context.Context, req resource.Updat
 
 	data, modelDiags := NewTaxonomyConceptModelFromResponse(ctx, *concept)
 	resp.Diagnostics.Append(modelDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	preserveConfiguredLabelMapShape(&data, plan)
 
 	data.Timeouts = plan.Timeouts
@@ -280,6 +299,11 @@ func (r *taxonomyConceptResource) Delete(ctx context.Context, req resource.Delet
 func (r *taxonomyConceptResource) setCreateState(ctx context.Context, prior TaxonomyConceptModel, concept cm.TaxonomyConcept, resp *resource.CreateResponse) {
 	data, modelDiags := NewTaxonomyConceptModelFromResponse(ctx, concept)
 	resp.Diagnostics.Append(modelDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	preserveConfiguredLabelMapShape(&data, prior)
 
 	data.Timeouts = prior.Timeouts

--- a/internal/provider/resource_taxonomy_concept_scheme.go
+++ b/internal/provider/resource_taxonomy_concept_scheme.go
@@ -94,6 +94,10 @@ func (r *taxonomyConceptSchemeResource) Create(ctx context.Context, req resource
 	data, modelDiags := NewTaxonomyConceptSchemeModelFromResponse(ctx, *scheme)
 	resp.Diagnostics.Append(modelDiags...)
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	data.Timeouts = plan.Timeouts
 
 	var identity TaxonomyConceptSchemeIdentityModel
@@ -145,6 +149,10 @@ func (r *taxonomyConceptSchemeResource) Read(ctx context.Context, req resource.R
 	data, modelDiags := NewTaxonomyConceptSchemeModelFromResponse(ctx, *scheme)
 	resp.Diagnostics.Append(modelDiags...)
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	data.Timeouts = state.Timeouts
 
 	var identity TaxonomyConceptSchemeIdentityModel
@@ -176,6 +184,13 @@ func (r *taxonomyConceptSchemeResource) Update(ctx context.Context, req resource
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	request, requestDiags := plan.ToRequest(ctx)
+	resp.Diagnostics.Append(requestDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	getParams := cm.GetTaxonomyConceptSchemeParams{OrganizationID: plan.OrganizationID.ValueString(), TaxonomyConceptSchemeID: plan.ConceptSchemeID.ValueString()}
 	currentResponse, err := r.providerData.client.GetTaxonomyConceptScheme(ctx, getParams)
 
@@ -185,9 +200,6 @@ func (r *taxonomyConceptSchemeResource) Update(ctx context.Context, req resource
 
 		return
 	}
-
-	request, requestDiags := plan.ToRequest(ctx)
-	resp.Diagnostics.Append(requestDiags...)
 
 	patch, patchErr := taxonomyPatch(taxonomyConceptSchemeRequestFromResponse(*current), request)
 	if patchErr != nil {
@@ -199,6 +211,10 @@ func (r *taxonomyConceptSchemeResource) Update(ctx context.Context, req resource
 	if len(patch) == 0 {
 		data, modelDiags := NewTaxonomyConceptSchemeModelFromResponse(ctx, *current)
 		resp.Diagnostics.Append(modelDiags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		data.Timeouts = plan.Timeouts
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -226,6 +242,10 @@ func (r *taxonomyConceptSchemeResource) Update(ctx context.Context, req resource
 
 	data, modelDiags := NewTaxonomyConceptSchemeModelFromResponse(ctx, *scheme)
 	resp.Diagnostics.Append(modelDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	data.Timeouts = plan.Timeouts
 

--- a/internal/provider/resource_taxonomy_conversion_barrier_test.go
+++ b/internal/provider/resource_taxonomy_conversion_barrier_test.go
@@ -1,0 +1,140 @@
+//nolint:testpackage // Resource lifecycle methods are intentionally tested through their package-local implementations.
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaxonomyConceptUpdateRequestConversionErrorStopsBeforeAPIRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	model := taxonomyConceptUpdatePlan()
+	model.AltLabels = types.MapValueMust(types.ListType{ElemType: types.StringType}, map[string]attr.Value{
+		"en-US": types.ListUnknown(types.StringType),
+	})
+
+	assertTaxonomyUpdateRequestConversionErrorStopsBeforeAPIRequest(
+		t,
+		model,
+		TaxonomyConceptResourceSchema(ctx),
+		func(client *cm.Client, request resource.UpdateRequest, response *resource.UpdateResponse) {
+			implementation := taxonomyConceptResource{providerData: ContentfulProviderData{client: client}}
+			implementation.Update(ctx, request, response)
+		},
+	)
+}
+
+func TestTaxonomyConceptSchemeUpdateRequestConversionErrorStopsBeforeAPIRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	model := taxonomyConceptSchemeUpdatePlan()
+	model.TopConceptIDs = types.ListValueMust(types.StringType, []attr.Value{types.StringUnknown()})
+
+	assertTaxonomyUpdateRequestConversionErrorStopsBeforeAPIRequest(
+		t,
+		model,
+		TaxonomyConceptSchemeResourceSchema(ctx),
+		func(client *cm.Client, request resource.UpdateRequest, response *resource.UpdateResponse) {
+			implementation := taxonomyConceptSchemeResource{providerData: ContentfulProviderData{client: client}}
+			implementation.Update(ctx, request, response)
+		},
+	)
+}
+
+func assertTaxonomyUpdateRequestConversionErrorStopsBeforeAPIRequest(
+	t *testing.T,
+	model any,
+	resourceSchema schema.Schema,
+	update func(*cm.Client, resource.UpdateRequest, *resource.UpdateResponse),
+) {
+	t.Helper()
+
+	ctx := t.Context()
+	client, requestCount := taxonomyRequestCountingClient(t)
+
+	plan := tfsdk.Plan{Schema: resourceSchema}
+	require.False(t, plan.Set(ctx, model).HasError())
+
+	response := resource.UpdateResponse{State: tfsdk.State{Schema: resourceSchema}}
+	update(client, resource.UpdateRequest{Plan: plan}, &response)
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.Zero(t, requestCount.Load())
+}
+
+func taxonomyRequestCountingClient(t *testing.T) (*cm.Client, *atomic.Int64) {
+	t.Helper()
+
+	requestCount := &atomic.Int64{}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		http.Error(responseWriter, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}))
+	t.Cleanup(testServer.Close)
+
+	client, err := cm.NewClient(
+		testServer.URL,
+		cm.NewAccessTokenSecuritySource("access-token"),
+		cm.WithClient(testServer.Client()),
+	)
+	require.NoError(t, err)
+
+	return client, requestCount
+}
+
+func taxonomyConceptUpdatePlan() TaxonomyConceptModel {
+	listType := types.ListType{ElemType: types.StringType}
+
+	return TaxonomyConceptModel{
+		IDIdentityModel:              NewIDIdentityModelFromMultipartID("organization", "concept"),
+		TaxonomyConceptIdentityModel: TaxonomyConceptIdentityModel{OrganizationID: types.StringValue("organization"), ConceptID: types.StringValue("concept")},
+		URI:                          types.StringNull(),
+		PrefLabel:                    types.MapValueMust(types.StringType, map[string]attr.Value{"en-US": types.StringValue("Concept")}),
+		AltLabels:                    types.MapNull(listType),
+		HiddenLabels:                 types.MapNull(listType),
+		Notations:                    types.ListNull(types.StringType),
+		Note:                         types.MapNull(types.StringType),
+		ChangeNote:                   types.MapNull(types.StringType),
+		Definition:                   types.MapNull(types.StringType),
+		EditorialNote:                types.MapNull(types.StringType),
+		Example:                      types.MapNull(types.StringType),
+		HistoryNote:                  types.MapNull(types.StringType),
+		ScopeNote:                    types.MapNull(types.StringType),
+		BroaderConceptIDs:            types.ListNull(types.StringType),
+		RelatedConceptIDs:            types.ListNull(types.StringType),
+		ConceptSchemeIDs:             types.SetUnknown(types.StringType),
+		Timeouts:                     TimeoutsNull(),
+	}
+}
+
+func taxonomyConceptSchemeUpdatePlan() TaxonomyConceptSchemeModel {
+	return TaxonomyConceptSchemeModel{
+		IDIdentityModel: NewIDIdentityModelFromMultipartID("organization", "scheme"),
+		TaxonomyConceptSchemeIdentityModel: TaxonomyConceptSchemeIdentityModel{
+			OrganizationID:  types.StringValue("organization"),
+			ConceptSchemeID: types.StringValue("scheme"),
+		},
+		URI:           types.StringNull(),
+		PrefLabel:     types.MapValueMust(types.StringType, map[string]attr.Value{"en-US": types.StringValue("Scheme")}),
+		Definition:    types.MapNull(types.StringType),
+		TopConceptIDs: types.ListNull(types.StringType),
+		ConceptIDs:    types.ListNull(types.StringType),
+		TotalConcepts: types.Int64Unknown(),
+		Timeouts:      TimeoutsNull(),
+	}
+}

--- a/internal/provider/taxonomy_model_conversion_test.go
+++ b/internal/provider/taxonomy_model_conversion_test.go
@@ -242,6 +242,72 @@ func TestTaxonomyCollectionConversions(t *testing.T) {
 	}
 }
 
+func TestTaxonomyRequestConversionsReportUnknownCollectionElements(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*testing.T) diag.Diagnostics{
+		"concept string map": func(t *testing.T) diag.Diagnostics {
+			t.Helper()
+
+			model := taxonomyConceptUpdatePlan()
+			model.PrefLabel = types.MapValueMust(types.StringType, map[string]attr.Value{
+				"en-US": types.StringUnknown(),
+			})
+			_, diags := model.ToRequest(t.Context())
+
+			return diags
+		},
+		"concept string list map": func(t *testing.T) diag.Diagnostics {
+			t.Helper()
+
+			model := taxonomyConceptUpdatePlan()
+			model.AltLabels = types.MapValueMust(types.ListType{ElemType: types.StringType}, map[string]attr.Value{
+				"en-US": types.ListUnknown(types.StringType),
+			})
+			_, diags := model.ToRequest(t.Context())
+
+			return diags
+		},
+		"concept string list": func(t *testing.T) diag.Diagnostics {
+			t.Helper()
+
+			model := taxonomyConceptUpdatePlan()
+			model.Notations = types.ListValueMust(types.StringType, []attr.Value{types.StringUnknown()})
+			_, diags := model.ToRequest(t.Context())
+
+			return diags
+		},
+		"concept scheme string map": func(t *testing.T) diag.Diagnostics {
+			t.Helper()
+
+			model := taxonomyConceptSchemeUpdatePlan()
+			model.PrefLabel = types.MapValueMust(types.StringType, map[string]attr.Value{
+				"en-US": types.StringUnknown(),
+			})
+			_, diags := model.ToRequest(t.Context())
+
+			return diags
+		},
+		"concept scheme string list": func(t *testing.T) diag.Diagnostics {
+			t.Helper()
+
+			model := taxonomyConceptSchemeUpdatePlan()
+			model.TopConceptIDs = types.ListValueMust(types.StringType, []attr.Value{types.StringUnknown()})
+			_, diags := model.ToRequest(t.Context())
+
+			return diags
+		},
+	}
+
+	for name, convert := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.True(t, convert(t).HasError())
+		})
+	}
+}
+
 func TestTaxonomyConceptToRequestAddsPreferredLocalesToLabelMaps(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- convert taxonomy concept and concept scheme update plans before issuing any Contentful API request
- stop update immediately when request conversion reports diagnostics, so partial conversion output cannot reach GET, patch construction, or PATCH
- stop create, read, and update state handling immediately when typed response-to-model conversion reports diagnostics
- cover the `stringMap`, `stringListMap`, and `stringList` request-conversion families through both `ToRequest` interfaces
- add focused lifecycle regressions proving conversion failures stop both resource implementations with zero HTTP requests

## Why

Terraform Plugin Framework conversions can return a value together with error diagnostics. Continuing after those diagnostics risks constructing a request from partial conversion output or publishing partially converted state.

The taxonomy update paths now validate request conversion before remote access. Response conversion diagnostics are treated as defensive state-publication barriers before shape preservation, identity work, or state writes.

## Impact

Invalid or unresolved taxonomy collection values fail closed before any Contentful request. If typed response-to-model conversion reports errors, Terraform identity and state are not published from partial conversion output.

Malformed wire responses remain the responsibility of the Contentful Management API decoder; this change does not claim broader semantic response validation.

## Validation

- focused request-conversion and lifecycle-barrier tests
- `go test ./...`
- `TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -count=1`
- `terraform fmt -check -recursive ./examples`
- `golangci-lint cache clean`
- `golangci-lint run --allow-parallel-runners`
- `git diff --check`
- independent Standards and Spec re-review