### PR TITLE
refactor(webhook): consolidate response filter decoding

### DIFF
--- a/internal/provider/webhook_filters_response.go
+++ b/internal/provider/webhook_filters_response.go
@@ -28,6 +28,10 @@ func ReadWebhookFiltersListValueFromResponse(ctx context.Context, path path.Path
 		filtersElements[index] = filtersElement
 	}
 
+	if diags.HasError() {
+		return NewTypedListNull[TypedObject[WebhookFilterValue]](), diags
+	}
+
 	filtersList := NewTypedList(filtersElements)
 
 	return filtersList, diags
@@ -36,7 +40,12 @@ func ReadWebhookFiltersListValueFromResponse(ctx context.Context, path path.Path
 func ReadWebhookFilterValueFromResponse(ctx context.Context, path path.Path, input cm.WebhookDefinitionFilter) (TypedObject[WebhookFilterValue], diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	value := WebhookFilterValue{}
+	value := WebhookFilterValue{
+		Not:    NewTypedObjectNull[WebhookFilterNotValue](),
+		Equals: NewTypedObjectNull[WebhookFilterEqualsValue](),
+		In:     NewTypedObjectNull[WebhookFilterInValue](),
+		Regexp: NewTypedObjectNull[WebhookFilterRegexpValue](),
+	}
 
 	if filterNot, ok := input.Not.Get(); ok {
 		filterNotValue, filterNotValueDiags := ReadWebhookFilterNotValueFromResponse(ctx, path.AtName("not"), filterNot)
@@ -66,13 +75,21 @@ func ReadWebhookFilterValueFromResponse(ctx context.Context, path path.Path, inp
 		value.Regexp = filterRegexpValue
 	}
 
+	if diags.HasError() {
+		return NewTypedObjectNull[WebhookFilterValue](), diags
+	}
+
 	return NewTypedObject(value), diags
 }
 
 func ReadWebhookFilterNotValueFromResponse(ctx context.Context, path path.Path, input cm.WebhookDefinitionFilterNot) (TypedObject[WebhookFilterNotValue], diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	value := WebhookFilterNotValue{}
+	value := WebhookFilterNotValue{
+		Equals: NewTypedObjectNull[WebhookFilterEqualsValue](),
+		In:     NewTypedObjectNull[WebhookFilterInValue](),
+		Regexp: NewTypedObjectNull[WebhookFilterRegexpValue](),
+	}
 
 	if input.Equals != nil {
 		filterEqualsValue, filterEqualsValueDiags := ReadWebhookFilterEqualsValueFromResponse(ctx, path.AtName("equals"), input.Equals)
@@ -95,12 +112,63 @@ func ReadWebhookFilterNotValueFromResponse(ctx context.Context, path path.Path, 
 		value.Regexp = filterRegexpValue
 	}
 
+	if diags.HasError() {
+		return NewTypedObjectNull[WebhookFilterNotValue](), diags
+	}
+
 	return NewTypedObject(value), diags
 }
 
-func ReadWebhookFilterEqualsValueFromResponse(ctx context.Context, path path.Path, input cm.WebhookDefinitionFilterEquals) (TypedObject[WebhookFilterEqualsValue], diag.Diagnostics) {
+func ReadWebhookFilterEqualsValueFromResponse(ctx context.Context, valuePath path.Path, input cm.WebhookDefinitionFilterEquals) (TypedObject[WebhookFilterEqualsValue], diag.Diagnostics) {
+	return readWebhookBinaryFilterValue(ctx, valuePath, input, func(ctx context.Context, filterPath path.Path, doc, term jx.Raw) (WebhookFilterEqualsValue, diag.Diagnostics) {
+		diags := diag.Diagnostics{}
+
+		valueDoc, valueDocDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, filterPath.AtName("doc"), "doc", doc)
+		diags.Append(valueDocDiags...)
+
+		value, valueDiags := ReadWebhookDefinitionFilterTermString(ctx, filterPath.AtName("value"), term)
+		diags.Append(valueDiags...)
+
+		return WebhookFilterEqualsValue{Doc: valueDoc, Value: value}, diags
+	})
+}
+
+func ReadWebhookFilterInValueFromResponse(ctx context.Context, valuePath path.Path, input cm.WebhookDefinitionFilterIn) (TypedObject[WebhookFilterInValue], diag.Diagnostics) {
+	return readWebhookBinaryFilterValue(ctx, valuePath, input, func(ctx context.Context, filterPath path.Path, doc, term jx.Raw) (WebhookFilterInValue, diag.Diagnostics) {
+		diags := diag.Diagnostics{}
+
+		valueDoc, valueDocDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, filterPath.AtName("doc"), "doc", doc)
+		diags.Append(valueDocDiags...)
+
+		values, valuesDiags := ReadWebhookDefinitionFilterTermStringArray(ctx, filterPath.AtName("values"), term)
+		diags.Append(valuesDiags...)
+
+		return WebhookFilterInValue{Doc: valueDoc, Values: values}, diags
+	})
+}
+
+func ReadWebhookFilterRegexpValueFromResponse(ctx context.Context, valuePath path.Path, input cm.WebhookDefinitionFilterRegexp) (TypedObject[WebhookFilterRegexpValue], diag.Diagnostics) {
+	return readWebhookBinaryFilterValue(ctx, valuePath, input, func(ctx context.Context, filterPath path.Path, doc, term jx.Raw) (WebhookFilterRegexpValue, diag.Diagnostics) {
+		diags := diag.Diagnostics{}
+
+		valueDoc, valueDocDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, filterPath.AtName("doc"), "doc", doc)
+		diags.Append(valueDocDiags...)
+
+		pattern, patternDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, filterPath.AtName("pattern"), "pattern", term)
+		diags.Append(patternDiags...)
+
+		return WebhookFilterRegexpValue{Doc: valueDoc, Pattern: pattern}, diags
+	})
+}
+
+func readWebhookBinaryFilterValue[T any](
+	ctx context.Context,
+	path path.Path,
+	input []jx.Raw,
+	decode func(context.Context, path.Path, jx.Raw, jx.Raw) (T, diag.Diagnostics),
+) (TypedObject[T], diag.Diagnostics) {
 	if input == nil {
-		return NewTypedObjectNull[WebhookFilterEqualsValue](), nil
+		return NewTypedObjectNull[T](), nil
 	}
 
 	//nolint:mnd
@@ -108,82 +176,14 @@ func ReadWebhookFilterEqualsValueFromResponse(ctx context.Context, path path.Pat
 		diags := diag.Diagnostics{}
 		diags.AddAttributeError(path, "failed to decode value", fmt.Sprintf("expected array of length 2, received array of length %d", len(input)))
 
-		return NewTypedObjectNull[WebhookFilterEqualsValue](), diags
+		return NewTypedObjectNull[T](), diags
 	}
 
-	diags := diag.Diagnostics{}
+	value, diags := decode(ctx, path, input[0], input[1])
 
-	value := WebhookFilterEqualsValue{}
-
-	valueDoc, valueDocDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, path.AtName("doc"), "doc", input[0])
-	diags.Append(valueDocDiags...)
-
-	value.Doc = valueDoc
-
-	valueValue, valueValueDiags := ReadWebhookDefinitionFilterTermString(ctx, path.AtName("value"), input[1])
-	diags.Append(valueValueDiags...)
-
-	value.Value = valueValue
-
-	return NewTypedObject(value), diags
-}
-
-func ReadWebhookFilterInValueFromResponse(ctx context.Context, path path.Path, input cm.WebhookDefinitionFilterIn) (TypedObject[WebhookFilterInValue], diag.Diagnostics) {
-	if input == nil {
-		return NewTypedObjectNull[WebhookFilterInValue](), nil
+	if diags.HasError() {
+		return NewTypedObjectNull[T](), diags
 	}
-
-	//nolint:mnd
-	if len(input) != 2 {
-		diags := diag.Diagnostics{}
-		diags.AddAttributeError(path, "failed to decode value", fmt.Sprintf("expected array of length 2, received array of length %d", len(input)))
-
-		return NewTypedObjectNull[WebhookFilterInValue](), diags
-	}
-
-	diags := diag.Diagnostics{}
-
-	value := WebhookFilterInValue{}
-
-	valueDoc, valueDocDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, path.AtName("doc"), "doc", input[0])
-	diags.Append(valueDocDiags...)
-
-	value.Doc = valueDoc
-
-	valueValues, valueValuesDiags := ReadWebhookDefinitionFilterTermStringArray(ctx, path.AtName("values"), input[1])
-	diags.Append(valueValuesDiags...)
-
-	value.Values = valueValues
-
-	return NewTypedObject(value), diags
-}
-
-func ReadWebhookFilterRegexpValueFromResponse(ctx context.Context, path path.Path, input cm.WebhookDefinitionFilterRegexp) (TypedObject[WebhookFilterRegexpValue], diag.Diagnostics) {
-	if input == nil {
-		return NewTypedObjectNull[WebhookFilterRegexpValue](), nil
-	}
-
-	//nolint:mnd
-	if len(input) != 2 {
-		diags := diag.Diagnostics{}
-		diags.AddAttributeError(path, "failed to decode value", fmt.Sprintf("expected array of length 2, received array of length %d", len(input)))
-
-		return NewTypedObjectNull[WebhookFilterRegexpValue](), diags
-	}
-
-	diags := diag.Diagnostics{}
-
-	value := WebhookFilterRegexpValue{}
-
-	valueDoc, valueDocDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, path.AtName("doc"), "doc", input[0])
-	diags.Append(valueDocDiags...)
-
-	value.Doc = valueDoc
-
-	valuePattern, valuePatternDiags := ReadWebhookDefinitionFilterTermStringObject(ctx, path.AtName("pattern"), "pattern", input[1])
-	diags.Append(valuePatternDiags...)
-
-	value.Pattern = valuePattern
 
 	return NewTypedObject(value), diags
 }

--- a/internal/provider/webhook_filters_response_test.go
+++ b/internal/provider/webhook_filters_response_test.go
@@ -3,10 +3,124 @@ package provider_test
 import (
 	"testing"
 
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestReadWebhookFilterValueFromResponsePreservesRepresentableAlternatives(t *testing.T) {
+	t.Parallel()
+
+	filterPath := path.Root("filters").AtListIndex(0)
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		actual, diags := ReadWebhookFilterValueFromResponse(t.Context(), filterPath, cm.WebhookDefinitionFilter{})
+
+		require.False(t, diags.HasError())
+		require.False(t, actual.IsNull())
+		assert.True(t, actual.Value().Not.IsNull())
+		assert.True(t, actual.Value().Equals.IsNull())
+		assert.True(t, actual.Value().In.IsNull())
+		assert.True(t, actual.Value().Regexp.IsNull())
+	})
+
+	t.Run("multiple top-level alternatives", func(t *testing.T) {
+		t.Parallel()
+
+		input := cm.WebhookDefinitionFilter{
+			Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`"Entry"`)},
+			In:     cm.WebhookDefinitionFilterIn{[]byte(`{"doc":"sys.id"}`), []byte(`["entry"]`)},
+		}
+
+		actual, diags := ReadWebhookFilterValueFromResponse(t.Context(), filterPath, input)
+
+		require.False(t, diags.HasError())
+		require.False(t, actual.IsNull())
+		assert.False(t, actual.Value().Equals.IsNull())
+		assert.False(t, actual.Value().In.IsNull())
+		assert.Equal(t, "Entry", actual.Value().Equals.Value().Value.ValueString())
+		assert.Equal(t, []types.String{types.StringValue("entry")}, actual.Value().In.Value().Values.Elements())
+	})
+
+	t.Run("multiple negated alternatives", func(t *testing.T) {
+		t.Parallel()
+
+		input := cm.WebhookDefinitionFilter{
+			Not: cm.NewOptWebhookDefinitionFilterNot(cm.WebhookDefinitionFilterNot{
+				Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`"Entry"`)},
+				In:     cm.WebhookDefinitionFilterIn{[]byte(`{"doc":"sys.id"}`), []byte(`["entry"]`)},
+			}),
+		}
+
+		actual, diags := ReadWebhookFilterValueFromResponse(t.Context(), filterPath, input)
+
+		require.False(t, diags.HasError())
+		require.False(t, actual.IsNull())
+		require.False(t, actual.Value().Not.IsNull())
+		assert.False(t, actual.Value().Not.Value().Equals.IsNull())
+		assert.False(t, actual.Value().Not.Value().In.IsNull())
+	})
+}
+
+func TestReadWebhookFilterValueFromResponseReturnsNullAfterConversionError(t *testing.T) {
+	t.Parallel()
+
+	filterPath := path.Root("filters").AtListIndex(0)
+	tests := map[string]struct {
+		input        cm.WebhookDefinitionFilter
+		expectedPath path.Path
+	}{
+		"malformed binary array": {
+			input: cm.WebhookDefinitionFilter{
+				Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`)},
+			},
+			expectedPath: filterPath.AtName("equals"),
+		},
+		"incompatible term": {
+			input: cm.WebhookDefinitionFilter{
+				Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`123`)},
+			},
+			expectedPath: filterPath.AtName("equals").AtName("value"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := ReadWebhookFilterValueFromResponse(t.Context(), filterPath, test.input)
+
+			require.True(t, diags.HasError())
+			assert.True(t, actual.IsNull())
+			assert.Contains(t, webhookDiagnosticPaths(t, diags), test.expectedPath.String())
+		})
+	}
+}
+
+func TestReadWebhookFiltersListValueFromResponseReturnsNullAfterElementError(t *testing.T) {
+	t.Parallel()
+
+	input := cm.NewOptNilWebhookDefinitionFilterArray([]cm.WebhookDefinitionFilter{
+		{
+			Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`"Entry"`)},
+		},
+		{
+			Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`)},
+		},
+	})
+
+	actual, diags := ReadWebhookFiltersListValueFromResponse(t.Context(), path.Root("filters"), input)
+
+	require.True(t, diags.HasError())
+	assert.True(t, actual.IsNull())
+	assert.Contains(t, webhookDiagnosticPaths(t, diags), "filters[1].equals")
+}
 
 func TestReadWebhookDefinitionFilterTermString(t *testing.T) {
 	t.Parallel()
@@ -48,6 +162,20 @@ func TestReadWebhookDefinitionFilterTermString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func webhookDiagnosticPaths(t *testing.T, diags diag.Diagnostics) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(diags.Errors()))
+	for _, diagnostic := range diags.Errors() {
+		withPath, ok := diagnostic.(diag.DiagnosticWithPath)
+		require.True(t, ok)
+
+		paths = append(paths, withPath.Path().String())
+	}
+
+	return paths
 }
 
 func TestReadWebhookDefinitionFilterTermStringArray(t *testing.T) {
@@ -123,12 +251,19 @@ func TestReadWebhookDefinitionFilterTermStringObject(t *testing.T) {
 			name:       "value",
 			expectNull: true,
 		},
+		"value wrong type": {
+			input:       []byte(`{"value":123}`),
+			name:        "value",
+			expectError: true,
+		},
 		"invalid json": {
 			input:       []byte(`{invalid`),
+			name:        "value",
 			expectError: true,
 		},
 		"wrong type": {
 			input:       []byte(`123`),
+			name:        "value",
 			expectError: true,
 		},
 	}
@@ -146,9 +281,11 @@ func TestReadWebhookDefinitionFilterTermStringObject(t *testing.T) {
 
 			if testcase.expectError {
 				assert.True(t, diags.HasError())
-			} else {
-				assert.False(t, diags.HasError())
+
+				return
 			}
+
+			require.False(t, diags.HasError())
 
 			if testcase.expectNull {
 				assert.True(t, value.IsNull())


### PR DESCRIPTION
## What changed

- share binary response decoding across `equals`, `in`, and `regexp`
- represent absent recognized alternatives explicitly as Terraform null
- return null filter objects and lists when descendant conversion reports an error
- preserve all recognized response alternatives without enforcing semantic union cardinality
- preserve the established behavior where an absent `doc` or `pattern` member becomes Terraform null

## Why

The three binary filter readers duplicated nil handling, two-term structural validation, child decoding, and object construction. They could also return partially decoded aggregate values alongside error diagnostics.

This refactor concentrates that behavior in one decoder and gives the response-conversion interface a consistent invariant: structural conversion errors return diagnostics and a null aggregate. Existing webhook lifecycle methods already stop before identity, state, or private-data publication when those diagnostics contain errors.

## Impact

Response conversion does not duplicate Contentful semantic validation. Zero, one, or multiple recognized alternatives remain representable and are preserved. Unknown operator handling remains the generated client’s responsibility. Missing response-object members retain their established Terraform-null representation.

Structural conversion failures—such as malformed binary arrays or incompatible term types—produce path-aware diagnostics without a partially populated filter object or list.

## Validation

- focused webhook response-conversion tests
- webhook filter round-trip tests
- `go test ./...`
- `TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -count=1`
- `golangci-lint cache clean`
- `golangci-lint run --allow-parallel-runners` (0 issues)
- `git diff --check`

`go generate ./...` is not applicable to this converter-only change. In the isolated `/tmp` worktree, the documentation generator derives the provider name from the worktree directory and cannot render the repository templates under that temporary name; its side effects were discarded.
