### PR TITLE
fix(schema): validate configurable collection children

### DIFF
--- a/internal/provider/resource_app_definition_schema.go
+++ b/internal/provider/resource_app_definition_schema.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func AppDefinitionResourceSchema(ctx context.Context) schema.Schema {
@@ -91,6 +93,9 @@ func AppDefinitionResourceSchema(ctx context.Context) schema.Schema {
 								},
 							},
 							Optional: true,
+							Validators: []validator.List{
+								listvalidator.NoNullValues(),
+							},
 						},
 						"navigation_item": schema.SingleNestedAttribute{
 							Description: "Navigation item configuration for page locations.",
@@ -109,6 +114,9 @@ func AppDefinitionResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Required: true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"parameters": schema.SingleNestedAttribute{
 				Description: "Definitions of configuration parameters.",
@@ -119,6 +127,9 @@ func AppDefinitionResourceSchema(ctx context.Context) schema.Schema {
 							Attributes: AppDefinitionParameterSchemaAttributes(ctx),
 						},
 						Optional: true,
+						Validators: []validator.List{
+							listvalidator.NoNullValues(),
+						},
 					},
 					"instance": schema.ListNestedAttribute{
 						Description: "Instance-level parameter definitions.",
@@ -126,6 +137,9 @@ func AppDefinitionResourceSchema(ctx context.Context) schema.Schema {
 							Attributes: AppDefinitionParameterSchemaAttributes(ctx),
 						},
 						Optional: true,
+						Validators: []validator.List{
+							listvalidator.NoNullValues(),
+						},
 					},
 				},
 				Optional: true,
@@ -167,6 +181,9 @@ func AppDefinitionParameterSchemaAttributes(ctx context.Context) map[string]sche
 			ElementType: jsontypes.NormalizedType{},
 			CustomType:  NewTypedListNull[jsontypes.Normalized]().CustomType(ctx),
 			Optional:    true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 		"labels": schema.SingleNestedAttribute{
 			Description: "Custom labels for Boolean parameter values.",

--- a/internal/provider/resource_app_installation_schema.go
+++ b/internal/provider/resource_app_installation_schema.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -46,6 +48,9 @@ func AppInstallationResourceSchema(ctx context.Context) schema.Schema {
 				Description: "Marketplace information for the app.",
 				ElementType: types.StringType,
 				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.NoNullValues(),
+				},
 			},
 			"parameters": schema.StringAttribute{
 				Description: "App-specific configuration variables. Optional free-form object with values managed by the app. The stringified value cannot be longer than 16kB.",

--- a/internal/provider/resource_collection_validation_test.go
+++ b/internal/provider/resource_collection_validation_test.go
@@ -1,0 +1,244 @@
+package provider_test
+
+import (
+	"testing"
+
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEveryConfigurableResourceCollectionValidatesChildren(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	exemptions := map[string]string{
+		"contentful_entry.fields": "entry field values are JSON and explicit JSON null is meaningful",
+	}
+
+	for _, resourceFactory := range New("test").Resources(ctx) {
+		managedResource := resourceFactory()
+		metadataResponse := resource.MetadataResponse{}
+		managedResource.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "contentful"}, &metadataResponse)
+
+		schemaResponse := resource.SchemaResponse{}
+		managedResource.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
+		require.False(t, schemaResponse.Diagnostics.HasError(), schemaResponse.Diagnostics)
+
+		validateConfigurableCollectionAttributes(t, metadataResponse.TypeName, schemaResponse.Schema.Attributes, exemptions)
+	}
+}
+
+//nolint:cyclop,gocognit
+func validateConfigurableCollectionAttributes(
+	t *testing.T,
+	prefix string,
+	attributes map[string]schema.Attribute,
+	exemptions map[string]string,
+) {
+	t.Helper()
+
+	for name, attribute := range attributes {
+		attributePath := prefix + "." + name
+
+		switch attribute := attribute.(type) {
+		case schema.ListAttribute:
+			if attribute.Required || attribute.Optional {
+				if _, exempt := exemptions[attributePath]; !exempt {
+					t.Run(attributePath, func(t *testing.T) {
+						t.Parallel()
+						validateListChildren(t, attribute)
+					})
+				}
+			}
+		case schema.ListNestedAttribute:
+			if attribute.Required || attribute.Optional {
+				if _, exempt := exemptions[attributePath]; !exempt {
+					t.Run(attributePath, func(t *testing.T) {
+						t.Parallel()
+						validateListChildren(t, attribute)
+					})
+				}
+			}
+
+			validateConfigurableCollectionAttributes(t, attributePath, attribute.NestedObject.Attributes, exemptions)
+		case schema.SetAttribute:
+			if attribute.Required || attribute.Optional {
+				if _, exempt := exemptions[attributePath]; !exempt {
+					t.Run(attributePath, func(t *testing.T) {
+						t.Parallel()
+						validateSetChildren(t, attribute)
+					})
+				}
+			}
+		case schema.SetNestedAttribute:
+			validateConfigurableCollectionAttributes(t, attributePath, attribute.NestedObject.Attributes, exemptions)
+		case schema.MapAttribute:
+			if attribute.Required || attribute.Optional {
+				if _, exempt := exemptions[attributePath]; !exempt {
+					t.Run(attributePath, func(t *testing.T) {
+						t.Parallel()
+						validateMapChildren(t, attribute)
+						validateNestedMapCollectionChildren(t, attribute)
+					})
+				}
+			}
+		case schema.MapNestedAttribute:
+			if attribute.Required || attribute.Optional {
+				if _, exempt := exemptions[attributePath]; !exempt {
+					t.Run(attributePath, func(t *testing.T) {
+						t.Parallel()
+						validateMapChildren(t, attribute)
+					})
+				}
+			}
+
+			validateConfigurableCollectionAttributes(t, attributePath, attribute.NestedObject.Attributes, exemptions)
+		case schema.SingleNestedAttribute:
+			validateConfigurableCollectionAttributes(t, attributePath, attribute.Attributes, exemptions)
+		}
+	}
+}
+
+func validateListChildren(t *testing.T, attribute schema.Attribute) {
+	t.Helper()
+
+	var elementType attr.Type
+
+	var validators []validator.List
+
+	switch attribute := attribute.(type) {
+	case schema.ListAttribute:
+		elementType = attribute.ElementType
+		validators = attribute.Validators
+	case schema.ListNestedAttribute:
+		elementType = attribute.NestedObject.Type()
+		validators = attribute.Validators
+	default:
+		require.FailNowf(t, "unexpected attribute type", "got %T, want a list attribute", attribute)
+	}
+
+	require.NotEmpty(t, validators)
+	assertListDiagnostics(t, validators, types.ListValueMust(elementType, []attr.Value{valueForType(t, elementType, nil)}), true)
+	assertListDiagnostics(t, validators, types.ListUnknown(elementType), false)
+	assertListDiagnostics(t, validators, types.ListValueMust(elementType, []attr.Value{valueForType(t, elementType, tftypes.UnknownValue)}), false)
+}
+
+func validateMapChildren(t *testing.T, attribute schema.Attribute) {
+	t.Helper()
+
+	var elementType attr.Type
+
+	var validators []validator.Map
+
+	switch attribute := attribute.(type) {
+	case schema.MapAttribute:
+		elementType = attribute.ElementType
+		validators = attribute.Validators
+	case schema.MapNestedAttribute:
+		elementType = attribute.NestedObject.Type()
+		validators = attribute.Validators
+	default:
+		require.FailNowf(t, "unexpected attribute type", "got %T, want a map attribute", attribute)
+	}
+
+	require.NotEmpty(t, validators)
+	assertMapDiagnostics(t, validators, types.MapValueMust(elementType, map[string]attr.Value{"key": valueForType(t, elementType, nil)}), true)
+	assertMapDiagnostics(t, validators, types.MapUnknown(elementType), false)
+	assertMapDiagnostics(t, validators, types.MapValueMust(elementType, map[string]attr.Value{"key": valueForType(t, elementType, tftypes.UnknownValue)}), false)
+}
+
+func validateNestedMapCollectionChildren(t *testing.T, attribute schema.MapAttribute) {
+	t.Helper()
+
+	if _, ok := attribute.ElementType.TerraformType(t.Context()).(tftypes.List); !ok {
+		return
+	}
+
+	nullChild := types.MapValueMust(attribute.ElementType, map[string]attr.Value{
+		"key": listValueWithElement(t, attribute.ElementType, nil),
+	})
+	unknownChild := types.MapValueMust(attribute.ElementType, map[string]attr.Value{
+		"key": listValueWithElement(t, attribute.ElementType, tftypes.UnknownValue),
+	})
+
+	assertMapDiagnostics(t, attribute.Validators, nullChild, true)
+	assertMapDiagnostics(t, attribute.Validators, unknownChild, false)
+}
+
+func validateSetChildren(t *testing.T, attribute schema.Attribute) {
+	t.Helper()
+
+	setAttribute, ok := attribute.(schema.SetAttribute)
+	require.True(t, ok)
+	require.NotEmpty(t, setAttribute.Validators)
+
+	assertSetDiagnostics(t, setAttribute.Validators, types.SetValueMust(setAttribute.ElementType, []attr.Value{valueForType(t, setAttribute.ElementType, nil)}), true)
+	assertSetDiagnostics(t, setAttribute.Validators, types.SetUnknown(setAttribute.ElementType), false)
+	assertSetDiagnostics(t, setAttribute.Validators, types.SetValueMust(setAttribute.ElementType, []attr.Value{valueForType(t, setAttribute.ElementType, tftypes.UnknownValue)}), false)
+}
+
+//nolint:ireturn
+func valueForType(t *testing.T, valueType attr.Type, value any) attr.Value {
+	t.Helper()
+
+	result, err := valueType.ValueFromTerraform(t.Context(), tftypes.NewValue(valueType.TerraformType(t.Context()), value))
+	require.NoError(t, err)
+
+	return result
+}
+
+//nolint:ireturn
+func listValueWithElement(t *testing.T, listType attr.Type, element any) attr.Value {
+	t.Helper()
+
+	terraformType, ok := listType.TerraformType(t.Context()).(tftypes.List)
+	require.True(t, ok)
+
+	result, err := listType.ValueFromTerraform(t.Context(), tftypes.NewValue(terraformType, []tftypes.Value{
+		tftypes.NewValue(terraformType.ElementType, element),
+	}))
+	require.NoError(t, err)
+
+	return result
+}
+
+func assertListDiagnostics(t *testing.T, validators []validator.List, value types.List, expectedError bool) {
+	t.Helper()
+
+	response := validator.ListResponse{}
+	for _, valueValidator := range validators {
+		valueValidator.ValidateList(t.Context(), validator.ListRequest{Path: path.Root("value"), ConfigValue: value}, &response)
+	}
+
+	assert.Equal(t, expectedError, response.Diagnostics.HasError(), response.Diagnostics)
+}
+
+func assertMapDiagnostics(t *testing.T, validators []validator.Map, value types.Map, expectedError bool) {
+	t.Helper()
+
+	response := validator.MapResponse{}
+	for _, valueValidator := range validators {
+		valueValidator.ValidateMap(t.Context(), validator.MapRequest{Path: path.Root("value"), ConfigValue: value}, &response)
+	}
+
+	assert.Equal(t, expectedError, response.Diagnostics.HasError(), response.Diagnostics)
+}
+
+func assertSetDiagnostics(t *testing.T, validators []validator.Set, value types.Set, expectedError bool) {
+	t.Helper()
+
+	response := validator.SetResponse{}
+	for _, valueValidator := range validators {
+		valueValidator.ValidateSet(t.Context(), validator.SetRequest{Path: path.Root("value"), ConfigValue: value}, &response)
+	}
+
+	assert.Equal(t, expectedError, response.Diagnostics.HasError(), response.Diagnostics)
+}

--- a/internal/provider/resource_content_type_schema.go
+++ b/internal/provider/resource_content_type_schema.go
@@ -70,6 +70,9 @@ func ContentTypeResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: NewTypedListUnknown[TypedObject[ContentTypeFieldValue]]().CustomType(ctx),
 				Required:   true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"metadata": schema.SingleNestedAttribute{
 				Attributes:  ContentTypeMetadataValue{}.SchemaAttributes(ctx),
@@ -94,6 +97,9 @@ func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) SchemaAttribute
 			ElementType: types.StringType,
 			CustomType:  NewTypedListNull[types.String]().CustomType(ctx),
 			Required:    true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 	}
 }
@@ -153,6 +159,9 @@ func (v ContentTypeFieldItemsValue) SchemaAttributes(ctx context.Context) map[st
 			Optional:    true,
 			Computed:    true,
 			Default:     listdefault.StaticValue(types.ListValueMust(jsontypes.NormalizedType{}, []attr.Value{})),
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 	}
 }
@@ -211,6 +220,9 @@ func (v ContentTypeFieldValue) SchemaAttributes(ctx context.Context) map[string]
 			Optional:    true,
 			Computed:    true,
 			Default:     listdefault.StaticValue(types.ListValueMust(jsontypes.NormalizedType{}, []attr.Value{})),
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 		"allowed_resources": schema.ListNestedAttribute{
 			Description: "For Resource Link fields, defines the allowed resource types that can be linked.",
@@ -220,6 +232,9 @@ func (v ContentTypeFieldValue) SchemaAttributes(ctx context.Context) map[string]
 			},
 			CustomType: NewTypedListNull[TypedObject[ContentTypeFieldAllowedResourceItemValue]]().CustomType(ctx),
 			Optional:   true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 	}
 }
@@ -307,6 +322,7 @@ func (v ContentTypeMetadataValue) SchemaAttributes(ctx context.Context) map[stri
 			Optional:    true,
 			Computed:    true,
 			Validators: []validator.List{
+				listvalidator.NoNullValues(),
 				listvalidator.AtLeastOneOf(
 					path.MatchRelative().AtParent().AtName("annotations"),
 					path.MatchRelative().AtParent().AtName("taxonomy"),

--- a/internal/provider/resource_delivery_api_key_schema.go
+++ b/internal/provider/resource_delivery_api_key_schema.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -49,6 +51,9 @@ func DeliveryAPIKeyResourceSchema(ctx context.Context) schema.Schema {
 				CustomType:  NewTypedListNull[types.String]().CustomType(ctx),
 				Optional:    true,
 				Computed:    true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resource_editor_interface_schema.go
+++ b/internal/provider/resource_editor_interface_schema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -54,6 +55,9 @@ func EditorInterfaceResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: TypedList[TypedObject[EditorInterfaceEditorLayoutItemValue]]{}.CustomType(ctx),
 				Optional:   true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"controls": schema.ListNestedAttribute{
 				Description: "Field-level controls that specify which widget to use for editing each field.",
@@ -63,6 +67,9 @@ func EditorInterfaceResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: TypedList[TypedObject[EditorInterfaceControlValue]]{}.CustomType(ctx),
 				Optional:   true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"group_controls": schema.ListNestedAttribute{
 				Description: "Group-level controls that specify widgets for field groups.",
@@ -72,6 +79,9 @@ func EditorInterfaceResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: TypedList[TypedObject[EditorInterfaceGroupControlValue]]{}.CustomType(ctx),
 				Optional:   true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"sidebar": schema.ListNestedAttribute{
 				Description: "Configuration for sidebar widgets in the editor.",
@@ -81,6 +91,9 @@ func EditorInterfaceResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: TypedList[TypedObject[EditorInterfaceSidebarValue]]{}.CustomType(ctx),
 				Optional:   true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{Create: true, Read: true, Update: true}),
 		},
@@ -156,6 +169,9 @@ func (v EditorInterfaceEditorLayoutItemGroupItemGroupValue) SchemaAttributes(ctx
 			},
 			CustomType: NewTypedListNull[TypedObject[EditorInterfaceEditorLayoutItemGroupItemGroupItemValue]]().CustomType(ctx),
 			Required:   true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 	}
 }
@@ -208,6 +224,9 @@ func (v EditorInterfaceEditorLayoutItemGroupValue) SchemaAttributes(ctx context.
 			},
 			CustomType: NewTypedListNull[TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]]().CustomType(ctx),
 			Required:   true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 	}
 }

--- a/internal/provider/resource_entry_schema.go
+++ b/internal/provider/resource_entry_schema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -100,6 +102,9 @@ func (v EntryMetadataValue) SchemaAttributes(ctx context.Context) map[string]sch
 			PlanModifiers: []planmodifier.List{
 				listplanmodifier.UseStateForUnknown(),
 			},
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 		"tags": schema.ListAttribute{
 			ElementType: types.StringType,
@@ -109,6 +114,9 @@ func (v EntryMetadataValue) SchemaAttributes(ctx context.Context) map[string]sch
 			Default:     listdefault.StaticValue(defaultTagsListValue),
 			PlanModifiers: []planmodifier.List{
 				listplanmodifier.UseStateForUnknown(),
+			},
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
 			},
 		},
 	}

--- a/internal/provider/resource_extension_schema.go
+++ b/internal/provider/resource_extension_schema.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func ExtensionResourceSchema(ctx context.Context) schema.Schema {
@@ -116,6 +118,9 @@ func ExtensionResourceExtensionSchemaAttributes(ctx context.Context) map[string]
 				},
 			},
 			Required: true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 		"sidebar": schema.BoolAttribute{
 			Optional: true,
@@ -129,12 +134,18 @@ func ExtensionResourceExtensionSchemaAttributes(ctx context.Context) map[string]
 						Attributes: AppDefinitionParameterSchemaAttributes(ctx),
 					},
 					Optional: true,
+					Validators: []validator.List{
+						listvalidator.NoNullValues(),
+					},
 				},
 				"instance": schema.ListNestedAttribute{
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: AppDefinitionParameterSchemaAttributes(ctx),
 					},
 					Optional: true,
+					Validators: []validator.List{
+						listvalidator.NoNullValues(),
+					},
 				},
 			},
 			Optional: true,

--- a/internal/provider/resource_personal_access_token_schema.go
+++ b/internal/provider/resource_personal_access_token_schema.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -52,6 +54,9 @@ func PersonalAccessTokenResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.StringType,
 				CustomType:  NewTypedListNull[types.String]().CustomType(ctx),
 				Required:    true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/resource_role_schema.go
+++ b/internal/provider/resource_role_schema.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -48,6 +51,10 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: NewTypedListNull[types.String]().Type(ctx),
 				CustomType:  NewTypedMapNull[TypedList[types.String]]().CustomType(ctx),
 				Required:    true,
+				Validators: []validator.Map{
+					mapvalidator.NoNullValues(),
+					mapvalidator.ValueListsAre(listvalidator.NoNullValues()),
+				},
 			},
 			"policies": schema.ListNestedAttribute{
 				Description: "Policies allow or deny access to resources in fine-grained detail. For example, limit read access to only entries of a specific content type or write access to only certain parts of an entry (e.g. a specific locale).",
@@ -57,6 +64,9 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: TypedList[TypedObject[RolePolicyValue]]{}.CustomType(ctx),
 				Required:   true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
 		},
@@ -70,6 +80,9 @@ func (v RolePolicyValue) SchemaAttributes(ctx context.Context) map[string]schema
 			ElementType: types.StringType,
 			CustomType:  TypedList[types.String]{}.CustomType(ctx),
 			Required:    true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 		"constraint": schema.StringAttribute{
 			Description: "JSON constraint that defines the scope of the policy.",

--- a/internal/provider/resource_taxonomy_schema.go
+++ b/internal/provider/resource_taxonomy_schema.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -36,7 +38,15 @@ func taxonomyIdentityAttributes(entityName string) map[string]schema.Attribute {
 }
 
 func localizedStringAttribute(description string, required bool) schema.MapAttribute {
-	return schema.MapAttribute{Description: description, Required: required, Optional: !required, ElementType: types.StringType}
+	return schema.MapAttribute{
+		Description: description,
+		Required:    required,
+		Optional:    !required,
+		ElementType: types.StringType,
+		Validators: []validator.Map{
+			mapvalidator.NoNullValues(),
+		},
+	}
 }
 
 func optionalComputedStringList(description string) schema.ListAttribute {
@@ -47,6 +57,9 @@ func optionalComputedStringList(description string) schema.ListAttribute {
 		ElementType: types.StringType,
 		PlanModifiers: []planmodifier.List{
 			listplanmodifier.UseStateForUnknown(),
+		},
+		Validators: []validator.List{
+			listvalidator.NoNullValues(),
 		},
 	}
 }
@@ -64,6 +77,10 @@ func TaxonomyConceptResourceSchema(ctx context.Context) schema.Schema {
 		PlanModifiers: []planmodifier.Map{
 			mapplanmodifier.UseStateForUnknown(),
 		},
+		Validators: []validator.Map{
+			mapvalidator.NoNullValues(),
+			mapvalidator.ValueListsAre(listvalidator.NoNullValues()),
+		},
 	}
 	attributes["hidden_labels"] = schema.MapAttribute{
 		Description: "Localized hidden labels.",
@@ -72,6 +89,10 @@ func TaxonomyConceptResourceSchema(ctx context.Context) schema.Schema {
 		ElementType: types.ListType{ElemType: types.StringType},
 		PlanModifiers: []planmodifier.Map{
 			mapplanmodifier.UseStateForUnknown(),
+		},
+		Validators: []validator.Map{
+			mapvalidator.NoNullValues(),
+			mapvalidator.ValueListsAre(listvalidator.NoNullValues()),
 		},
 	}
 

--- a/internal/provider/resource_team_space_membership_schema.go
+++ b/internal/provider/resource_team_space_membership_schema.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -49,6 +51,9 @@ func TeamSpaceMembershipResourceSchema(ctx context.Context) schema.Schema {
 				Description: "List of role IDs assigned to the team in the space.",
 				ElementType: types.StringType,
 				Required:    true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
 		},

--- a/internal/provider/resource_webhook_schema.go
+++ b/internal/provider/resource_webhook_schema.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -54,6 +56,9 @@ func WebhookResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.StringType,
 				CustomType:  TypedList[types.String]{}.CustomType(ctx),
 				Optional:    true,
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+				},
 			},
 			"filters": WebhookFiltersSchema(ctx, true),
 			"http_basic_password": schema.StringAttribute{

--- a/internal/provider/webhook_filters_schema.go
+++ b/internal/provider/webhook_filters_schema.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -20,6 +22,9 @@ func WebhookFiltersSchema(ctx context.Context, optional bool) schema.Attribute {
 		},
 		CustomType: NewTypedListNull[TypedObject[WebhookFilterValue]]().CustomType(ctx),
 		Optional:   optional,
+		Validators: []validator.List{
+			listvalidator.NoNullValues(),
+		},
 	}
 }
 
@@ -43,6 +48,9 @@ func (v WebhookFilterInValue) SchemaAttributes(ctx context.Context) map[string]s
 			ElementType: types.StringType,
 			CustomType:  NewTypedListNull[types.String]().CustomType(ctx),
 			Required:    true,
+			Validators: []validator.List{
+				listvalidator.NoNullValues(),
+			},
 		},
 	}
 }

--- a/internal/provider/webhook_headers_schema.go
+++ b/internal/provider/webhook_headers_schema.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 //nolint:ireturn
@@ -18,6 +20,9 @@ func WebhookHeadersSchema(ctx context.Context, optional bool) schema.Attribute {
 		CustomType: TypedMap[TypedObject[WebhookHeaderValue]]{}.CustomType(ctx),
 		Optional:   optional,
 		Computed:   true,
+		Validators: []validator.Map{
+			mapvalidator.NoNullValues(),
+		},
 		PlanModifiers: []planmodifier.Map{
 			mapplanmodifier.UseStateForUnknown(),
 		},


### PR DESCRIPTION
## Summary

- reject known null children in every practitioner-configurable resource collection
- validate nested list children inside Role and Taxonomy maps
- defer validation for unknown collection containers and children
- add a recursive schema inventory test covering every managed resource

## Why

Terraform distinguishes null values from unknown values. Collection conversion code cannot safely consume known null children, while unknown values must remain valid during planning so Terraform can resolve them later.

The existing schemas applied this constraint inconsistently, allowing invalid known-null children to reach provider conversion logic. This change applies the framework validator contracts at the schema boundary without changing runtime conversion behavior.

`contentful_entry.fields` remains intentionally exempt because its JSON values may explicitly be null. Computed-only collections and list-resource result schemas are outside this configuration-validation boundary.

## Validation

- focused recursive managed-resource schema inventory test
- `go test ./...`
- `TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -count=1`
- documentation generation with explicit `contentful` / `terraform-provider-contentful` names
- `golangci-lint cache clean`
- `golangci-lint run --allow-parallel-runners` (0 issues)
- `git diff --check`
