### PR TITLE
fix(provider): reject invalid request list elements

### DIFF
--- a/docs/research/delivery-api-key-environments.md
+++ b/docs/research/delivery-api-key-environments.md
@@ -1,0 +1,47 @@
+# Delivery API key `environments` behavior
+
+Observed against the Contentful CMA on 2026-07-28 using temporary Delivery API
+keys:
+
+| Request value | Create | Update from `[test]` |
+|---|---|---|
+| property omitted | returns `[master]` | returns `[master]` |
+| `[]` | returns `[master]` | returns `[master]` |
+| explicit environment links | returns those links | returns those links |
+| `null` | HTTP 400 | HTTP 400; existing value is unchanged |
+
+Successful create, update, and subsequent get responses contained an
+`environments` array. The linked Preview API key reflected the same environment
+selection as its Delivery API key.
+
+These are point-in-time observations rather than a published compatibility
+guarantee. In particular, the API could later preserve an empty list or choose a
+default environment with a different identifier.
+
+## Design impact
+
+The provider preserves the request distinction exposed by its generated client:
+
+- A null or unknown Terraform list becomes a nil Go slice, so the request omits
+  `environments`.
+- A known empty Terraform list becomes a non-nil empty Go slice, so the request
+  contains `"environments":[]`.
+- A known populated list becomes the corresponding Environment links.
+- Response conversion preserves the response shape rather than reconstructing or
+  validating a presumed default.
+
+This lets Contentful define the effective environment selection and ensures that
+future valid empty responses or changes to its default are represented faithfully.
+
+## Supporting documentation
+
+- Contentful documents CMA updates as full replacements rather than merges:
+  [Updating content](https://www.contentful.com/developers/docs/references/content-management-api/overview/#updating-content).
+- Contentful's official Ruby SDK defaults an omitted create argument to `[]` and
+  notes that an empty value defaults to master:
+  [`ApiKey`](https://github.com/contentful/contentful-management.rb/blob/master/lib/contentful/management/api_key.rb).
+- The REST examples show `environments` represented as an array of Environment
+  links:
+  [create](https://www.contentful.com/developers/docs/references/content-management-api/api-keys/create-a-delivery-api-key/),
+  [update](https://www.contentful.com/developers/docs/references/content-management-api/api-keys/update-a-delivery-api-key/), and
+  [get](https://www.contentful.com/developers/docs/references/content-management-api/api-keys/get-a-delivery-api-key/).

--- a/internal/provider/environment_links.go
+++ b/internal/provider/environment_links.go
@@ -35,6 +35,10 @@ func ToEnvironmentLinks(_ context.Context, valuePath path.Path, value TypedList[
 func NewEnvironmentIDsListValueFromEnvironmentLinks(_ context.Context, _ path.Path, environmentLinks []cm.EnvironmentLink) (TypedList[types.String], diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
+	if environmentLinks == nil {
+		return NewTypedListNull[types.String](), diags
+	}
+
 	listElementValues := make([]types.String, len(environmentLinks))
 
 	for index, item := range environmentLinks {

--- a/internal/provider/environment_links.go
+++ b/internal/provider/environment_links.go
@@ -9,39 +9,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func ToEnvironmentLinks(ctx context.Context, path path.Path, value TypedList[types.String]) ([]cm.EnvironmentLink, diag.Diagnostics) {
+func ToEnvironmentLinks(_ context.Context, valuePath path.Path, value TypedList[types.String]) ([]cm.EnvironmentLink, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	if value.IsUnknown() {
+	if value.IsNull() || value.IsUnknown() {
 		return nil, diags
 	}
 
-	environmentIDValues := value.Elements()
+	environmentIDs, environmentIDDiags := knownStringListElements(valuePath, value.Elements())
+	diags.Append(environmentIDDiags...)
 
-	environments := make([]cm.EnvironmentLink, 0, len(environmentIDValues))
+	if diags.HasError() {
+		return nil, diags
+	}
 
-	for index, environmentIDValue := range environmentIDValues {
-		path := path.AtListIndex(index)
+	environments := make([]cm.EnvironmentLink, 0, len(environmentIDs))
 
-		if environmentIDValue.IsUnknown() {
-			diags.AddAttributeError(path, "Unexpectedly unknown value", "")
-		}
-
-		environmentsItem, environmentsItemDiags := ToEnvironmentLink(ctx, path, environmentIDValue.ValueString())
-		diags.Append(environmentsItemDiags...)
-
-		environments = append(environments, environmentsItem)
+	for _, environmentID := range environmentIDs {
+		environments = append(environments, cm.NewEnvironmentLink(environmentID))
 	}
 
 	return environments, diags
-}
-
-func ToEnvironmentLink(_ context.Context, _ path.Path, environmentID string) (cm.EnvironmentLink, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	item := cm.NewEnvironmentLink(environmentID)
-
-	return item, diags
 }
 
 func NewEnvironmentIDsListValueFromEnvironmentLinks(_ context.Context, _ path.Path, environmentLinks []cm.EnvironmentLink) (TypedList[types.String], diag.Diagnostics) {

--- a/internal/provider/environment_links_test.go
+++ b/internal/provider/environment_links_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToEnvironmentLinks(t *testing.T) {
@@ -17,10 +18,14 @@ func TestToEnvironmentLinks(t *testing.T) {
 	path := path.Root("test")
 
 	tests := map[string]struct {
-		value         TypedList[types.String]
-		expected      []cm.EnvironmentLink
-		expectedDiags bool
+		value               TypedList[types.String]
+		expected            []cm.EnvironmentLink
+		expectedDiagnostics []string
 	}{
+		"null": {
+			value:    NewTypedListNull[types.String](),
+			expected: nil,
+		},
 		"unknown": {
 			value:    NewTypedListUnknown[types.String](),
 			expected: nil,
@@ -29,10 +34,8 @@ func TestToEnvironmentLinks(t *testing.T) {
 			value: NewTypedList([]types.String{
 				types.StringUnknown(),
 			}),
-			expected: []cm.EnvironmentLink{
-				cm.NewEnvironmentLink(""),
-			},
-			expectedDiags: true,
+			expected:            nil,
+			expectedDiagnostics: []string{"test[0]"},
 		},
 		"known and unknown elements": {
 			value: NewTypedList([]types.String{
@@ -40,12 +43,15 @@ func TestToEnvironmentLinks(t *testing.T) {
 				types.StringUnknown(),
 				types.StringValue("c"),
 			}),
-			expected: []cm.EnvironmentLink{
-				cm.NewEnvironmentLink("a"),
-				cm.NewEnvironmentLink(""),
-				cm.NewEnvironmentLink("c"),
-			},
-			expectedDiags: true,
+			expected:            nil,
+			expectedDiagnostics: []string{"test[1]"},
+		},
+		"null element": {
+			value: NewTypedList([]types.String{
+				types.StringNull(),
+			}),
+			expected:            nil,
+			expectedDiagnostics: []string{"test[0]"},
 		},
 		"empty": {
 			value:    NewTypedList([]types.String{}),
@@ -71,11 +77,51 @@ func TestToEnvironmentLinks(t *testing.T) {
 
 			assert.Equal(t, test.expected, result)
 
-			if test.expectedDiags {
-				assert.NotEmpty(t, diags)
+			if len(test.expectedDiagnostics) > 0 {
+				require.True(t, diags.HasError())
+				assert.Equal(t, test.expectedDiagnostics, attributeDiagnosticPaths(t, diags))
 			} else {
 				assert.Empty(t, diags)
 			}
+		})
+	}
+}
+
+func TestDeliveryAPIKeyEnvironmentRequestEncoding(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		environments TypedList[types.String]
+		expectedJSON string
+	}{
+		"null is omitted": {
+			environments: NewTypedListNull[types.String](),
+			expectedJSON: `{"name":"key","description":null}`,
+		},
+		"unknown is omitted": {
+			environments: NewTypedListUnknown[types.String](),
+			expectedJSON: `{"name":"key","description":null}`,
+		},
+		"known empty is explicit": {
+			environments: NewTypedList([]types.String{}),
+			expectedJSON: `{"name":"key","description":null,"environments":[]}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := DeliveryAPIKeyModel{
+				Name:         types.StringValue("key"),
+				Description:  types.StringNull(),
+				Environments: test.environments,
+			}
+
+			request, diags := model.ToAPIKeyRequestFields(t.Context())
+			require.False(t, diags.HasError(), diags.Errors())
+
+			actualJSON, err := request.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, test.expectedJSON, string(actualJSON))
 		})
 	}
 }

--- a/internal/provider/environment_links_test.go
+++ b/internal/provider/environment_links_test.go
@@ -132,17 +132,124 @@ func TestNewEnvironmentIDsListValueFromEnvironmentLinks(t *testing.T) {
 	ctx := t.Context()
 	path := path.Root("test")
 
-	environmentLinks := []cm.EnvironmentLink{
-		cm.NewEnvironmentLink("env1"),
-		cm.NewEnvironmentLink("env2"),
+	tests := map[string]struct {
+		environmentLinks []cm.EnvironmentLink
+		expected         TypedList[types.String]
+	}{
+		"nil": {
+			environmentLinks: nil,
+			expected:         NewTypedListNull[types.String](),
+		},
+		"empty": {
+			environmentLinks: []cm.EnvironmentLink{},
+			expected:         NewTypedList([]types.String{}),
+		},
+		"known elements": {
+			environmentLinks: []cm.EnvironmentLink{
+				cm.NewEnvironmentLink("env1"),
+				cm.NewEnvironmentLink("env2"),
+			},
+			expected: NewTypedList([]types.String{
+				types.StringValue("env1"),
+				types.StringValue("env2"),
+			}),
+		},
 	}
 
-	expected := NewTypedList([]types.String{
-		types.StringValue("env1"),
-		types.StringValue("env2"),
-	})
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	result, diags := NewEnvironmentIDsListValueFromEnvironmentLinks(ctx, path, environmentLinks)
-	assert.Empty(t, diags)
-	assert.Equal(t, expected, result)
+			result, diags := NewEnvironmentIDsListValueFromEnvironmentLinks(ctx, path, test.environmentLinks)
+			assert.Empty(t, diags)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestEnvironmentLinksRequestResponseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	valuePath := path.Root("test")
+
+	for name, value := range map[string]TypedList[types.String]{
+		"null":  NewTypedListNull[types.String](),
+		"empty": NewTypedList([]types.String{}),
+		"known elements": NewTypedList([]types.String{
+			types.StringValue("env1"),
+			types.StringValue("env2"),
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			environmentLinks, requestDiags := ToEnvironmentLinks(ctx, valuePath, value)
+			require.False(t, requestDiags.HasError(), requestDiags.Errors())
+
+			result, responseDiags := NewEnvironmentIDsListValueFromEnvironmentLinks(ctx, valuePath, environmentLinks)
+			require.False(t, responseDiags.HasError(), responseDiags.Errors())
+
+			assert.Equal(t, value, result)
+		})
+	}
+}
+
+func TestEnvironmentLinksJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	valuePath := path.Root("test")
+
+	for name, test := range map[string]struct {
+		value             TypedList[types.String]
+		environmentsField string
+	}{
+		"null": {
+			value:             NewTypedListNull[types.String](),
+			environmentsField: "",
+		},
+		"empty": {
+			value:             NewTypedList([]types.String{}),
+			environmentsField: `"environments":[]`,
+		},
+		"known elements": {
+			value: NewTypedList([]types.String{
+				types.StringValue("env1"),
+				types.StringValue("env2"),
+			}),
+			environmentsField: `"environments":[`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			environmentLinks, requestDiags := ToEnvironmentLinks(ctx, valuePath, test.value)
+			require.False(t, requestDiags.HasError(), requestDiags.Errors())
+
+			apiKey := cm.ApiKey{
+				Sys:          cm.NewAPIKeySys("space", "key"),
+				Name:         "key",
+				Environments: environmentLinks,
+				AccessToken:  "token",
+			}
+
+			encoded, err := apiKey.MarshalJSON()
+			require.NoError(t, err)
+
+			if test.environmentsField == "" {
+				assert.NotContains(t, string(encoded), `"environments"`)
+			} else {
+				assert.Contains(t, string(encoded), test.environmentsField)
+			}
+
+			var decoded cm.ApiKey
+			require.NoError(t, decoded.UnmarshalJSON(encoded))
+
+			result, responseDiags := NewEnvironmentIDsListValueFromEnvironmentLinks(ctx, valuePath, decoded.Environments)
+			require.False(t, responseDiags.HasError(), responseDiags.Errors())
+
+			assert.Equal(t, test.value, result)
+		})
+	}
 }

--- a/internal/provider/personal_access_token_model_request.go
+++ b/internal/provider/personal_access_token_model_request.go
@@ -5,20 +5,43 @@ import (
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-func (model *PersonalAccessTokenModel) ToPersonalAccessTokenRequestData(ctx context.Context) (cm.PersonalAccessTokenRequestData, diag.Diagnostics) {
+func (model *PersonalAccessTokenModel) ToPersonalAccessTokenRequestData(_ context.Context) (cm.PersonalAccessTokenRequestData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	req := cm.PersonalAccessTokenRequestData{
-		Name: model.Name.ValueString(),
+	if model.Scopes.IsUnknown() {
+		diags.AddAttributeError(
+			path.Root("scopes"),
+			"Unexpected unknown scopes",
+			"Personal access token scopes must be known before they can be sent to Contentful.",
+		)
+
+		return cm.PersonalAccessTokenRequestData{}, diags
 	}
 
-	scopes := make([]string, len(model.Scopes.Elements()))
-	diags.Append(tfsdk.ValueAs(ctx, model.Scopes, &scopes)...)
+	if model.Scopes.IsNull() {
+		diags.AddAttributeError(
+			path.Root("scopes"),
+			"Unexpected null scopes",
+			"Personal access token scopes are required.",
+		)
 
-	req.Scopes = scopes
+		return cm.PersonalAccessTokenRequestData{}, diags
+	}
+
+	scopes, scopeDiags := knownStringListElements(path.Root("scopes"), model.Scopes.Elements())
+	diags.Append(scopeDiags...)
+
+	if diags.HasError() {
+		return cm.PersonalAccessTokenRequestData{}, diags
+	}
+
+	req := cm.PersonalAccessTokenRequestData{
+		Name:   model.Name.ValueString(),
+		Scopes: scopes,
+	}
 
 	if !model.ExpiresIn.IsNull() && !model.ExpiresIn.IsUnknown() {
 		req.ExpiresIn = cm.NewOptNilPointerInt64(model.ExpiresIn.ValueInt64Pointer())

--- a/internal/provider/personal_access_token_model_request_test.go
+++ b/internal/provider/personal_access_token_model_request_test.go
@@ -1,0 +1,90 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersonalAccessTokenModelToRequestScopes(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		scopes              TypedList[types.String]
+		expectedScopes      []string
+		expectedDiagnostics []string
+	}{
+		"known": {
+			scopes: NewTypedList([]types.String{
+				types.StringValue("scope-a"),
+				types.StringValue("scope-b"),
+			}),
+			expectedScopes: []string{"scope-a", "scope-b"},
+		},
+		"known empty": {
+			scopes:         NewTypedList([]types.String{}),
+			expectedScopes: []string{},
+		},
+		"null container": {
+			scopes:              NewTypedListNull[types.String](),
+			expectedDiagnostics: []string{"scopes"},
+		},
+		"unknown container": {
+			scopes:              NewTypedListUnknown[types.String](),
+			expectedDiagnostics: []string{"scopes"},
+		},
+		"invalid children": {
+			scopes: NewTypedList([]types.String{
+				types.StringValue("scope-a"),
+				types.StringNull(),
+				types.StringUnknown(),
+				types.StringValue("scope-b"),
+			}),
+			expectedDiagnostics: []string{"scopes[1]", "scopes[2]"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := PersonalAccessTokenModel{
+				Name:   types.StringValue("token"),
+				Scopes: test.scopes,
+			}
+
+			request, diags := model.ToPersonalAccessTokenRequestData(t.Context())
+
+			if len(test.expectedDiagnostics) == 0 {
+				require.False(t, diags.HasError(), diags.Errors())
+				require.NotNil(t, request.Scopes)
+				assert.Equal(t, test.expectedScopes, request.Scopes)
+				assert.Equal(t, "token", request.Name)
+
+				return
+			}
+
+			assert.Equal(t, cm.PersonalAccessTokenRequestData{}, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedDiagnostics, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func attributeDiagnosticPaths(t *testing.T, diags diag.Diagnostics) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(diags.Errors()))
+
+	for _, diagnostic := range diags.Errors() {
+		withPath, ok := diagnostic.(diag.DiagnosticWithPath)
+		require.True(t, ok)
+
+		paths = append(paths, withPath.Path().String())
+	}
+
+	return paths
+}

--- a/internal/provider/request_string_list.go
+++ b/internal/provider/request_string_list.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func knownStringListElements(valuePath path.Path, elements []types.String) ([]string, diag.Diagnostics) {
+	values := make([]string, 0, len(elements))
+	diags := diag.Diagnostics{}
+
+	for index, element := range elements {
+		elementPath := valuePath.AtListIndex(index)
+
+		switch {
+		case element.IsUnknown():
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected unknown string list element",
+				"The string value must be known before it can be sent to Contentful.",
+			)
+		case element.IsNull():
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected null string list element",
+				"The string value cannot be null when it is sent to Contentful.",
+			)
+		default:
+			values = append(values, element.ValueString())
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return values, diags
+}

--- a/internal/provider/request_string_list_test.go
+++ b/internal/provider/request_string_list_test.go
@@ -1,0 +1,68 @@
+//nolint:testpackage // The package-private request conversion module is intentionally tested through its interface.
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKnownStringListElements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("known", func(t *testing.T) {
+		t.Parallel()
+
+		actual, diags := knownStringListElements(path.Root("values"), []types.String{
+			types.StringValue("first"),
+			types.StringValue("second"),
+		})
+
+		require.False(t, diags.HasError(), diags.Errors())
+		assert.Equal(t, []string{"first", "second"}, actual)
+	})
+
+	t.Run("known empty", func(t *testing.T) {
+		t.Parallel()
+
+		actual, diags := knownStringListElements(path.Root("values"), []types.String{})
+
+		require.False(t, diags.HasError(), diags.Errors())
+		require.NotNil(t, actual)
+		assert.Empty(t, actual)
+	})
+
+	t.Run("invalid elements fail closed with exact paths", func(t *testing.T) {
+		t.Parallel()
+
+		actual, diags := knownStringListElements(path.Root("values"), []types.String{
+			types.StringValue("first"),
+			types.StringNull(),
+			types.StringUnknown(),
+			types.StringValue("last"),
+		})
+
+		assert.Nil(t, actual)
+		require.True(t, diags.HasError())
+		assert.Equal(t, []string{"values[1]", "values[2]"}, requestDiagnosticPaths(t, diags))
+	})
+}
+
+func requestDiagnosticPaths(t *testing.T, diags diag.Diagnostics) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(diags.Errors()))
+
+	for _, diagnostic := range diags.Errors() {
+		withPath, ok := diagnostic.(diag.DiagnosticWithPath)
+		require.True(t, ok)
+
+		paths = append(paths, withPath.Path().String())
+	}
+
+	return paths
+}

--- a/internal/provider/team_space_membership_model_request.go
+++ b/internal/provider/team_space_membership_model_request.go
@@ -8,33 +8,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-func (model *TeamSpaceMembershipModel) ToTeamSpaceMembershipData(_ context.Context, _ path.Path) (cm.TeamSpaceMembershipData, diag.Diagnostics) {
+func (model *TeamSpaceMembershipModel) ToTeamSpaceMembershipData(_ context.Context, modelPath path.Path) (cm.TeamSpaceMembershipData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	fields := cm.TeamSpaceMembershipData{
+	roleIDs, roleIDDiags := knownStringListElements(modelPath.AtName("roles"), model.Roles)
+	diags.Append(roleIDDiags...)
+
+	if diags.HasError() {
+		return cm.TeamSpaceMembershipData{}, diags
+	}
+
+	roles := make([]cm.RoleLink, 0, len(roleIDs))
+
+	for _, roleID := range roleIDs {
+		roles = append(roles, cm.RoleLink{
+			Sys: cm.RoleLinkSys{
+				Type:     cm.RoleLinkSysTypeLink,
+				LinkType: cm.RoleLinkSysLinkTypeRole,
+				ID:       roleID,
+			},
+		})
+	}
+
+	return cm.TeamSpaceMembershipData{
 		Admin: model.Admin.ValueBool(),
-	}
-
-	if model.Roles != nil {
-		roles := make([]cm.RoleLink, 0, len(model.Roles))
-		for _, roleID := range model.Roles {
-			if roleID.IsNull() || roleID.IsUnknown() {
-				continue
-			}
-
-			roleLink := cm.RoleLink{
-				Sys: cm.RoleLinkSys{
-					Type:     cm.RoleLinkSysTypeLink,
-					LinkType: cm.RoleLinkSysLinkTypeRole,
-					ID:       roleID.ValueString(),
-				},
-			}
-
-			roles = append(roles, roleLink)
-		}
-
-		fields.Roles = roles
-	}
-
-	return fields, diags
+		Roles: roles,
+	}, diags
 }

--- a/internal/provider/team_space_membership_model_request_test.go
+++ b/internal/provider/team_space_membership_model_request_test.go
@@ -11,25 +11,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTeamSpaceMembershipModelToRequestSkipsNullAndUnknownRoles(t *testing.T) {
+func TestTeamSpaceMembershipModelToRequestRoles(t *testing.T) {
 	t.Parallel()
 
-	model := provider.TeamSpaceMembershipModel{
-		Admin: types.BoolValue(true),
-		Roles: []types.String{
-			types.StringValue("role-a"),
-			types.StringNull(),
-			types.StringUnknown(),
-			types.StringValue("role-b"),
+	for name, test := range map[string]struct {
+		roles               []types.String
+		expectedRoles       []cm.RoleLink
+		expectedDiagnostics []string
+	}{
+		"known": {
+			roles: []types.String{
+				types.StringValue("role-a"),
+				types.StringValue("role-b"),
+			},
+			expectedRoles: []cm.RoleLink{
+				{Sys: cm.RoleLinkSys{Type: cm.RoleLinkSysTypeLink, LinkType: cm.RoleLinkSysLinkTypeRole, ID: "role-a"}},
+				{Sys: cm.RoleLinkSys{Type: cm.RoleLinkSysTypeLink, LinkType: cm.RoleLinkSysLinkTypeRole, ID: "role-b"}},
+			},
 		},
+		"known empty": {
+			roles:         []types.String{},
+			expectedRoles: []cm.RoleLink{},
+		},
+		"invalid children": {
+			roles: []types.String{
+				types.StringValue("role-a"),
+				types.StringNull(),
+				types.StringUnknown(),
+				types.StringValue("role-b"),
+			},
+			expectedDiagnostics: []string{"roles[1]", "roles[2]"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := provider.TeamSpaceMembershipModel{
+				Admin: types.BoolValue(true),
+				Roles: test.roles,
+			}
+
+			request, diags := model.ToTeamSpaceMembershipData(t.Context(), path.Empty())
+
+			if len(test.expectedDiagnostics) == 0 {
+				require.False(t, diags.HasError(), diags.Errors())
+				assert.True(t, request.Admin)
+				require.NotNil(t, request.Roles)
+				assert.Equal(t, test.expectedRoles, request.Roles)
+
+				return
+			}
+
+			assert.Equal(t, cm.TeamSpaceMembershipData{}, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedDiagnostics, attributeDiagnosticPaths(t, diags))
+		})
 	}
-
-	request, diags := model.ToTeamSpaceMembershipData(t.Context(), path.Empty())
-	require.False(t, diags.HasError(), diags.Errors())
-
-	assert.True(t, request.Admin)
-	assert.Equal(t, []cm.RoleLink{
-		{Sys: cm.RoleLinkSys{Type: cm.RoleLinkSysTypeLink, LinkType: cm.RoleLinkSysLinkTypeRole, ID: "role-a"}},
-		{Sys: cm.RoleLinkSys{Type: cm.RoleLinkSysTypeLink, LinkType: cm.RoleLinkSysLinkTypeRole, ID: "role-b"}},
-	}, request.Roles)
 }


### PR DESCRIPTION
## Summary

- add a package-private, path-aware conversion helper for Terraform string-list elements
- reject null or unknown Personal Access Token scopes and Team Space Membership roles without producing partial requests
- preserve Delivery API Key environment omission versus explicit-empty semantics while rejecting invalid children
- remove the shallow single-use environment-link conversion wrapper

## Why

Terraform framework primitive accessors return zero values for null and unknown values. Existing request conversion could therefore skip invalid Team role IDs or construct Delivery environment links with empty IDs. Reflection-based conversion also did not retain the caller's exact nested diagnostic path.

This change keeps collection-container policy in each resource, validates every string child before primitive access, reports exact list indices, and discards the complete aggregate after any conversion error.

## Impact

Valid known and known-empty requests retain their existing behavior. Invalid null or unknown child values now fail before any Contentful mutation instead of being omitted or represented by empty strings. Unconfigured Delivery API Key environments remain omitted, while an explicitly known empty list remains encoded as `"environments": []`.

## Validation

- focused request-conversion and resource model tests
- `go test ./internal/provider -count=1`
- `go test ./... -count=1`
- `go generate ./...` with no generated changes
- `golangci-lint cache clean`
- `golangci-lint run`