### PR TITLE
fix(app-installation): reject unresolved request values

### DIFF
--- a/internal/provider/app_installation_model_request.go
+++ b/internal/provider/app_installation_model_request.go
@@ -8,7 +8,6 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func (model *AppInstallationModel) ToXContentfulMarketplaceHeaderValue(ctx context.Context) (cm.OptString, diag.Diagnostics) {
@@ -28,25 +27,8 @@ func (model *AppInstallationModel) ToXContentfulMarketplaceHeaderValue(ctx conte
 	return value, diags
 }
 
-func (model *AppInstallationModel) ToXContentfulMarketplaceHeaderValueElements(ctx context.Context) ([]string, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	if model.Marketplace.IsNull() || model.Marketplace.IsUnknown() {
-		return []string{}, diags
-	}
-
-	marketplaceElements := make([]types.String, len(model.Marketplace.Elements()))
-	diags.Append(model.Marketplace.ElementsAs(ctx, &marketplaceElements, false)...)
-
-	marketplaceStrings := make([]string, 0, len(marketplaceElements))
-
-	for _, element := range marketplaceElements {
-		if !element.IsNull() && !element.IsUnknown() {
-			marketplaceStrings = append(marketplaceStrings, element.ValueString())
-		}
-	}
-
-	return marketplaceStrings, diags
+func (model *AppInstallationModel) ToXContentfulMarketplaceHeaderValueElements(_ context.Context) ([]string, diag.Diagnostics) {
+	return knownOptionalStringSetElements(path.Root("marketplace"), model.Marketplace)
 }
 
 func (model *AppInstallationModel) ToAppInstallationData() (cm.AppInstallationData, diag.Diagnostics) {
@@ -56,7 +38,13 @@ func (model *AppInstallationModel) ToAppInstallationData() (cm.AppInstallationDa
 
 	switch {
 	case model.Parameters.IsUnknown():
-		diags.AddAttributeWarning(path.Root("parameters"), "Failed to update app installation parameters", "Parameters are unknown")
+		diags.AddAttributeError(
+			path.Root("parameters"),
+			"Unexpected unknown app installation parameters",
+			"App installation parameters must be known before they can be sent to Contentful.",
+		)
+
+		return cm.AppInstallationData{}, diags
 	case model.Parameters.IsNull():
 	default:
 		fields.Parameters = []byte(model.Parameters.ValueString())

--- a/internal/provider/app_installation_model_request_test.go
+++ b/internal/provider/app_installation_model_request_test.go
@@ -9,15 +9,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToXContentfulMarketplaceHeaderValue(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		model        AppInstallationModel
-		expectErrors bool
-		expected     cm.OptString
+		model               AppInstallationModel
+		expected            cm.OptString
+		expectedDiagnostics []string
 	}{
 		"absent": {
 			model:    AppInstallationModel{},
@@ -33,7 +34,32 @@ func TestToXContentfulMarketplaceHeaderValue(t *testing.T) {
 			model: AppInstallationModel{
 				Marketplace: types.SetUnknown(types.StringType),
 			},
-			expected: cm.OptString{},
+			expected:            cm.OptString{},
+			expectedDiagnostics: []string{"marketplace"},
+		},
+		"null child": {
+			model: AppInstallationModel{
+				Marketplace: types.SetValueMust(types.StringType, []attr.Value{types.StringNull()}),
+			},
+			expected:            cm.OptString{},
+			expectedDiagnostics: []string{"marketplace[Value(<null>)]"},
+		},
+		"unknown child": {
+			model: AppInstallationModel{
+				Marketplace: types.SetValueMust(types.StringType, []attr.Value{types.StringUnknown()}),
+			},
+			expected:            cm.OptString{},
+			expectedDiagnostics: []string{"marketplace[Value(<unknown>)]"},
+		},
+		"mixed valid and unknown children fails closed": {
+			model: AppInstallationModel{
+				Marketplace: types.SetValueMust(types.StringType, []attr.Value{
+					types.StringValue("foo"),
+					types.StringUnknown(),
+				}),
+			},
+			expected:            cm.OptString{},
+			expectedDiagnostics: []string{"marketplace[Value(<unknown>)]"},
 		},
 		"empty": {
 			model: AppInstallationModel{
@@ -63,8 +89,9 @@ func TestToXContentfulMarketplaceHeaderValue(t *testing.T) {
 
 			assert.Equal(t, test.expected, value)
 
-			if test.expectErrors {
-				assert.NotEmpty(t, diags.Errors())
+			if len(test.expectedDiagnostics) > 0 {
+				require.True(t, diags.HasError())
+				assert.Equal(t, test.expectedDiagnostics, attributeDiagnosticPaths(t, diags))
 			} else {
 				assert.Empty(t, diags.Errors())
 			}
@@ -91,7 +118,7 @@ func TestToAppInstallationData(t *testing.T) {
 			model: AppInstallationModel{
 				Parameters: jsontypes.NewNormalizedUnknown(),
 			},
-			expectWarnings:      true,
+			expectErrors:        true,
 			expectedRequestBody: "{}",
 		},
 		"empty": {
@@ -125,7 +152,9 @@ func TestToAppInstallationData(t *testing.T) {
 			assert.Equal(t, test.expectedRequestBody, string(requestBody))
 
 			if test.expectErrors {
-				assert.NotEmpty(t, diags.Errors())
+				require.True(t, diags.HasError())
+				assert.Equal(t, cm.AppInstallationData{}, req)
+				assert.Equal(t, []string{"parameters"}, attributeDiagnosticPaths(t, diags))
 			} else {
 				assert.Empty(t, diags.Errors())
 			}

--- a/internal/provider/request_string_list.go
+++ b/internal/provider/request_string_list.go
@@ -37,3 +37,60 @@ func knownStringListElements(valuePath path.Path, elements []types.String) ([]st
 
 	return values, diags
 }
+
+func knownOptionalStringSetElements(valuePath path.Path, value types.Set) ([]string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown string set",
+			"The string set must be known before it can be sent to Contentful.",
+		)
+
+		return nil, diags
+	case value.IsNull():
+		return []string{}, diags
+	}
+
+	values := make([]string, 0, len(value.Elements()))
+
+	for _, rawElement := range value.Elements() {
+		elementPath := valuePath.AtSetValue(rawElement)
+		element, ok := rawElement.(types.String)
+
+		if !ok {
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected string set element type",
+				"The set element must be a string before it can be sent to Contentful.",
+			)
+
+			continue
+		}
+
+		switch {
+		case element.IsUnknown():
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected unknown string set element",
+				"The string value must be known before it can be sent to Contentful.",
+			)
+		case element.IsNull():
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected null string set element",
+				"The string value cannot be null when it is sent to Contentful.",
+			)
+		default:
+			values = append(values, element.ValueString())
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return values, diags
+}

--- a/internal/provider/request_string_list_test.go
+++ b/internal/provider/request_string_list_test.go
@@ -4,6 +4,7 @@ package provider
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -50,6 +51,63 @@ func TestKnownStringListElements(t *testing.T) {
 		require.True(t, diags.HasError())
 		assert.Equal(t, []string{"values[1]", "values[2]"}, requestDiagnosticPaths(t, diags))
 	})
+}
+
+func TestKnownOptionalStringSetElements(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		value               types.Set
+		expected            []string
+		expectedDiagnostics []string
+	}{
+		"known": {
+			value: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("first"),
+				types.StringValue("second"),
+			}),
+			expected: []string{"first", "second"},
+		},
+		"known empty": {
+			value:    types.SetValueMust(types.StringType, []attr.Value{}),
+			expected: []string{},
+		},
+		"null container": {
+			value:    types.SetNull(types.StringType),
+			expected: []string{},
+		},
+		"unknown container": {
+			value:               types.SetUnknown(types.StringType),
+			expectedDiagnostics: []string{"values"},
+		},
+		"invalid children fail closed with set value paths": {
+			value: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("first"),
+				types.StringNull(),
+				types.StringUnknown(),
+				types.StringValue("last"),
+			}),
+			expectedDiagnostics: []string{"values[Value(<null>)]", "values[Value(<unknown>)]"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := knownOptionalStringSetElements(path.Root("values"), test.value)
+
+			if len(test.expectedDiagnostics) == 0 {
+				require.False(t, diags.HasError(), diags.Errors())
+				require.NotNil(t, actual)
+				assert.ElementsMatch(t, test.expected, actual)
+
+				return
+			}
+
+			assert.Nil(t, actual)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedDiagnostics, requestDiagnosticPaths(t, diags))
+		})
+	}
 }
 
 func requestDiagnosticPaths(t *testing.T, diags diag.Diagnostics) []string {


### PR DESCRIPTION
## Summary

- reject an unknown marketplace set instead of silently omitting its request header
- reject null or unknown marketplace elements with set-value diagnostic paths and no partial header
- reject unknown normalized JSON parameters instead of warning and sending an omitted parameters field
- preserve null and known-empty omission semantics, deterministic marketplace sorting, and response conversion

## Root cause

The request converters previously treated unresolved Terraform values as though configuration were absent. An unknown marketplace container was silently omitted, null and unknown children were filtered out while retaining other header values, and unknown parameters produced only a warning before Create or Update continued. This could send a request that differed from the planned configuration.

## Request semantics

- null marketplace: omit the header
- known-empty marketplace: omit the header
- known marketplace values: sort and join as before
- unknown marketplace or null/unknown child: emit an attribute error and return no header
- null parameters: omit parameters
- known parameters: send the normalized JSON bytes
- unknown parameters: emit an attribute error and return an empty request

The existing Create and Update diagnostic barriers stop before the Contentful API call. Response conversion is unchanged.

## Validation

- focused App Installation and request string collection tests
- go test ./...
- go generate ./... with a clean generated diff
- golangci-lint cache clean
- golangci-lint run (0 issues)