### PR TITLE
fix(entry): reject unresolved request values

### DIFF
--- a/internal/provider/entry_model_request.go
+++ b/internal/provider/entry_model_request.go
@@ -6,6 +6,7 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
 func (m EntryModel) ToEntryRequest(ctx context.Context) (cm.EntryRequest, diag.Diagnostics) {
@@ -17,6 +18,10 @@ func (m EntryModel) ToEntryRequest(ctx context.Context) (cm.EntryRequest, diag.D
 	metadata, metadataDiags := entryModelToOptEntryMetadata(ctx, m)
 	diags.Append(metadataDiags...)
 
+	if diags.HasError() {
+		return cm.EntryRequest{}, diags
+	}
+
 	return cm.EntryRequest{
 		Fields:   fields,
 		Metadata: metadata,
@@ -24,8 +29,26 @@ func (m EntryModel) ToEntryRequest(ctx context.Context) (cm.EntryRequest, diag.D
 }
 
 func entryModelToOptEntryFields(_ context.Context, model EntryModel) (cm.OptEntryFields, diag.Diagnostics) {
-	if model.Fields.IsNull() || model.Fields.IsUnknown() {
-		return cm.OptEntryFields{}, nil
+	if model.Fields.IsUnknown() {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(
+			path.Root("fields"),
+			"Unexpected unknown entry fields",
+			"Entry fields must be known before they can be sent to Contentful.",
+		)
+
+		return cm.OptEntryFields{}, diags
+	}
+
+	if model.Fields.IsNull() {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(
+			path.Root("fields"),
+			"Unexpected null entry fields",
+			"Entry fields are required.",
+		)
+
+		return cm.OptEntryFields{}, diags
 	}
 
 	diags := diag.Diagnostics{}
@@ -35,10 +58,26 @@ func entryModelToOptEntryFields(_ context.Context, model EntryModel) (cm.OptEntr
 	attrs := model.Fields.Elements()
 	for k, v := range attrs {
 		if v.IsNull() {
+			// Terraform null omits the field. A configured JSON null remains a
+			// known jsontypes.Normalized value and is sent as JSON null.
+			continue
+		}
+
+		if v.IsUnknown() {
+			diags.AddAttributeError(
+				path.Root("fields").AtMapKey(k),
+				"Unexpected unknown entry field",
+				"Entry field values must be known before they can be sent to Contentful.",
+			)
+
 			continue
 		}
 
 		fields[k] = jx.Raw(v.ValueString())
+	}
+
+	if diags.HasError() {
+		return cm.OptEntryFields{}, diags
 	}
 
 	return cm.NewOptEntryFields(fields), diags
@@ -55,10 +94,14 @@ func entryModelToOptEntryMetadata(_ context.Context, model EntryModel) (cm.OptEn
 
 	modelConcepts := model.Metadata.Value().Concepts
 	if !modelConcepts.IsNull() && !modelConcepts.IsUnknown() {
-		concepts := make([]cm.TaxonomyConceptLink, 0, len(modelConcepts.Elements()))
+		conceptValues, conceptDiags := knownStringListElements(
+			path.Root("metadata").AtName("concepts"),
+			modelConcepts.Elements(),
+		)
+		diags.Append(conceptDiags...)
 
-		for _, concept := range modelConcepts.Elements() {
-			conceptValue := concept.ValueString()
+		concepts := make([]cm.TaxonomyConceptLink, 0, len(conceptValues))
+		for _, conceptValue := range conceptValues {
 			concepts = append(concepts, cm.NewTaxonomyConceptLink(conceptValue))
 		}
 
@@ -67,14 +110,22 @@ func entryModelToOptEntryMetadata(_ context.Context, model EntryModel) (cm.OptEn
 
 	modelTags := model.Metadata.Value().Tags
 	if !modelTags.IsNull() && !modelTags.IsUnknown() {
-		tags := make([]cm.TagLink, 0, len(modelTags.Elements()))
+		tagValues, tagDiags := knownStringListElements(
+			path.Root("metadata").AtName("tags"),
+			modelTags.Elements(),
+		)
+		diags.Append(tagDiags...)
 
-		for _, tag := range modelTags.Elements() {
-			tagValue := tag.ValueString()
+		tags := make([]cm.TagLink, 0, len(tagValues))
+		for _, tagValue := range tagValues {
 			tags = append(tags, cm.NewTagLink(tagValue))
 		}
 
 		metadata.Tags = tags
+	}
+
+	if diags.HasError() {
+		return cm.OptEntryMetadata{}, diags
 	}
 
 	return cm.NewOptEntryMetadata(metadata), diags

--- a/internal/provider/entry_model_request_internal_test.go
+++ b/internal/provider/entry_model_request_internal_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryModelToOptEntryFieldsRejectsUnresolvedContainer(t *testing.T) {
+	t.Parallel()
+
+	for name, fields := range map[string]TypedMap[jsontypes.Normalized]{
+		"null":    NewTypedMapNull[jsontypes.Normalized](),
+		"unknown": NewTypedMapUnknown[jsontypes.Normalized](),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result, diags := entryModelToOptEntryFields(t.Context(), EntryModel{Fields: fields})
+
+			assert.Equal(t, cm.OptEntryFields{}, result)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{"fields"}, requestDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestEntryModelToOptEntryFieldsChildSemantics(t *testing.T) {
+	t.Parallel()
+
+	result, diags := entryModelToOptEntryFields(t.Context(), EntryModel{
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"terraform_null": jsontypes.NewNormalizedNull(),
+			"json_null":      NewNormalizedJSONTypesNormalizedValue([]byte("null")),
+		}),
+	})
+
+	require.False(t, diags.HasError(), diags.Errors())
+
+	fields, ok := result.Get()
+	require.True(t, ok)
+	assert.NotContains(t, fields, "terraform_null")
+	assert.JSONEq(t, "null", string(fields["json_null"]))
+}
+
+func TestEntryModelToOptEntryFieldsRejectsUnknownChild(t *testing.T) {
+	t.Parallel()
+
+	result, diags := entryModelToOptEntryFields(t.Context(), EntryModel{
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"known":   NewNormalizedJSONTypesNormalizedValue([]byte(`"value"`)),
+			"unknown": jsontypes.NewNormalizedUnknown(),
+		}),
+	})
+
+	assert.Equal(t, cm.OptEntryFields{}, result)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{`fields["unknown"]`}, requestDiagnosticPaths(t, diags))
+}

--- a/internal/provider/entry_model_request_test.go
+++ b/internal/provider/entry_model_request_test.go
@@ -1,0 +1,172 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryRequestDistinguishesTerraformNullFromJSONNull(t *testing.T) {
+	t.Parallel()
+
+	model := EntryModel{
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"terraform_null": jsontypes.NewNormalizedNull(),
+			"json_null":      NewNormalizedJSONTypesNormalizedValue([]byte("null")),
+			"value":          NewNormalizedJSONTypesNormalizedValue([]byte(`{"en-US":"value"}`)),
+		}),
+		Metadata: NewTypedObjectNull[EntryMetadataValue](),
+	}
+
+	request, diags := model.ToEntryRequest(t.Context())
+	require.False(t, diags.HasError(), diags.Errors())
+
+	fields, ok := request.Fields.Get()
+	require.True(t, ok)
+	assert.NotContains(t, fields, "terraform_null")
+	assert.JSONEq(t, "null", string(fields["json_null"]))
+	assert.JSONEq(t, `{"en-US":"value"}`, string(fields["value"]))
+}
+
+func TestEntryRequestUnknownFieldFailsWithoutPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	model := EntryModel{
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"known":   NewNormalizedJSONTypesNormalizedValue([]byte(`"value"`)),
+			"unknown": jsontypes.NewNormalizedUnknown(),
+		}),
+		Metadata: knownEntryMetadata(),
+	}
+
+	request, diags := model.ToEntryRequest(t.Context())
+	assert.Equal(t, cm.EntryRequest{}, request)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{`fields["unknown"]`}, attributeDiagnosticPaths(t, diags))
+}
+
+func TestEntryRequestUnresolvedFieldsContainerFailsWithoutPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	for name, fields := range map[string]TypedMap[jsontypes.Normalized]{
+		"null":    NewTypedMapNull[jsontypes.Normalized](),
+		"unknown": NewTypedMapUnknown[jsontypes.Normalized](),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := EntryModel{
+				Fields:   fields,
+				Metadata: knownEntryMetadata(),
+			}
+
+			request, diags := model.ToEntryRequest(t.Context())
+			assert.Equal(t, cm.EntryRequest{}, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{"fields"}, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestEntryRequestOmitsUnresolvedOptionalComputedMetadataContainer(t *testing.T) {
+	t.Parallel()
+
+	for name, metadata := range map[string]TypedObject[EntryMetadataValue]{
+		"null":    NewTypedObjectNull[EntryMetadataValue](),
+		"unknown": NewTypedObjectUnknown[EntryMetadataValue](),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := EntryModel{
+				Fields:   NewTypedMap(map[string]jsontypes.Normalized{}),
+				Metadata: metadata,
+			}
+
+			request, diags := model.ToEntryRequest(t.Context())
+			require.False(t, diags.HasError(), diags.Errors())
+			assert.Equal(t, cm.OptEntryMetadata{}, request.Metadata)
+			fields, ok := request.Fields.Get()
+			require.True(t, ok)
+			assert.Empty(t, fields)
+		})
+	}
+}
+
+func TestEntryRequestInvalidMetadataChildrenFailWithoutPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	for name, metadata := range map[string]TypedObject[EntryMetadataValue]{
+		"null concept": NewTypedObject(EntryMetadataValue{
+			Concepts: NewTypedList([]types.String{types.StringValue("concept"), types.StringNull()}),
+			Tags:     NewTypedList([]types.String{types.StringValue("tag")}),
+		}),
+		"unknown concept": NewTypedObject(EntryMetadataValue{
+			Concepts: NewTypedList([]types.String{types.StringValue("concept"), types.StringUnknown()}),
+			Tags:     NewTypedList([]types.String{types.StringValue("tag")}),
+		}),
+		"null tag": NewTypedObject(EntryMetadataValue{
+			Concepts: NewTypedList([]types.String{types.StringValue("concept")}),
+			Tags:     NewTypedList([]types.String{types.StringValue("tag"), types.StringNull()}),
+		}),
+		"unknown tag": NewTypedObject(EntryMetadataValue{
+			Concepts: NewTypedList([]types.String{types.StringValue("concept")}),
+			Tags:     NewTypedList([]types.String{types.StringValue("tag"), types.StringUnknown()}),
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := EntryModel{
+				Fields: NewTypedMap(map[string]jsontypes.Normalized{
+					"known": NewNormalizedJSONTypesNormalizedValue([]byte(`"value"`)),
+				}),
+				Metadata: metadata,
+			}
+
+			request, diags := model.ToEntryRequest(t.Context())
+			assert.Equal(t, cm.EntryRequest{}, request)
+			require.True(t, diags.HasError())
+
+			expectedPath := "metadata.concepts[1]"
+			if name == "null tag" || name == "unknown tag" {
+				expectedPath = "metadata.tags[1]"
+			}
+
+			assert.Equal(t, []string{expectedPath}, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestEntryRequestKnownMetadata(t *testing.T) {
+	t.Parallel()
+
+	model := EntryModel{
+		Fields: NewTypedMap(map[string]jsontypes.Normalized{
+			"known": NewNormalizedJSONTypesNormalizedValue([]byte(`"value"`)),
+		}),
+		Metadata: knownEntryMetadata(),
+	}
+
+	request, diags := model.ToEntryRequest(t.Context())
+	require.False(t, diags.HasError(), diags.Errors())
+
+	metadata, ok := request.Metadata.Get()
+	require.True(t, ok)
+	require.Len(t, metadata.Concepts, 1)
+	assert.Equal(t, "concept", metadata.Concepts[0].Sys.ID)
+	require.Len(t, metadata.Tags, 1)
+	assert.Equal(t, "tag", metadata.Tags[0].Sys.ID)
+}
+
+func knownEntryMetadata() TypedObject[EntryMetadataValue] {
+	return NewTypedObject(EntryMetadataValue{
+		Concepts: NewTypedList([]types.String{types.StringValue("concept")}),
+		Tags:     NewTypedList([]types.String{types.StringValue("tag")}),
+	})
+}

--- a/internal/provider/testdata/entry_model.go
+++ b/internal/provider/testdata/entry_model.go
@@ -15,23 +15,21 @@ func EntryModel(spaceID, environmentID, contentTypeID, entryID string) *rapid.Ge
 			IDIdentityModel:    provider.NewIDIdentityModelFromMultipartID(spaceID, environmentID, entryID),
 			EntryIdentityModel: provider.NewEntryIdentityModel(spaceID, environmentID, entryID),
 			ContentTypeID:      types.StringValue(contentTypeID),
-			Fields: RandomZeroable(
-				rapid.Map(
-					rapid.MapOfN(
-						AlphanumericStringOfN(1, 10),
-						rapid.Map(
-							rapid.Custom(func(t *rapid.T) string {
-								value := rapid.String().Draw(t, "value")
-								bytes, _ := json.Marshal(value)
-								return string(bytes)
-							}),
-							jsontypes.NewNormalizedValue,
-						),
-						0,
-						5,
+			Fields: rapid.Map(
+				rapid.MapOfN(
+					AlphanumericStringOfN(1, 10),
+					rapid.Map(
+						rapid.Custom(func(t *rapid.T) string {
+							value := rapid.String().Draw(t, "value")
+							bytes, _ := json.Marshal(value)
+							return string(bytes)
+						}),
+						jsontypes.NewNormalizedValue,
 					),
-					provider.NewTypedMap,
+					0,
+					5,
 				),
+				provider.NewTypedMap,
 			).Draw(t, "fields"),
 			Metadata: RandomZeroable(
 				rapid.Map(


### PR DESCRIPTION
Stacked on #599; review and merge that pull request first.

## Summary
- reject null or unknown values for the required Entry `fields` map at the exact `fields` path
- reject unknown Entry field children at exact map-key paths while preserving Terraform-null omission and known JSON null
- reject null or unknown concept and tag children at exact list indices while preserving optional-computed metadata-container omission
- return no partial Entry request after any field or metadata conversion error and keep round-trip generators within the required-field schema

## Validation
- `go test ./internal/provider -run 'TestEntry(ModelToOptEntryFields|Request|ModelRoundTrip)' -count=1`\n- `go test ./...`\n- `go generate ./...` (no generated diff)\n- `golangci-lint cache clean`\n- `golangci-lint run`