### PR TITLE
fix(role): reject unresolved request values

### DIFF
--- a/internal/provider/role_model_permissions_request.go
+++ b/internal/provider/role_model_permissions_request.go
@@ -7,38 +7,88 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func ToRoleDataPermissions(ctx context.Context, path path.Path, permissions TypedMap[TypedList[types.String]]) (cm.RoleDataPermissions, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	if permissions.IsUnknown() {
+	switch {
+	case permissions.IsUnknown():
+		diags.AddAttributeError(
+			path,
+			"Unexpected unknown permissions",
+			"Permissions must be known before they can be sent to Contentful.",
+		)
+
+		return nil, diags
+	case permissions.IsNull():
+		diags.AddAttributeError(
+			path,
+			"Unexpected null permissions",
+			"Permissions are required.",
+		)
+
 		return nil, diags
 	}
 
 	permissionsValues := permissions.Elements()
 
-	rolePermissionsItems := make(cm.RoleDataPermissions, len(permissions.Elements()))
+	keys := make([]string, 0, len(permissionsValues))
+	for key := range permissionsValues {
+		keys = append(keys, key)
+	}
 
-	for key, permissionsValueElement := range permissionsValues {
-		path := path.AtMapKey(key)
+	slices.Sort(keys)
 
-		permissionsItem, permissionsItemDiags := ToRoleDataPermissionsItem(ctx, path, permissionsValueElement)
+	rolePermissionsItems := make(cm.RoleDataPermissions, len(permissionsValues))
+
+	for _, key := range keys {
+		itemPath := path.AtMapKey(key)
+
+		permissionsItem, permissionsItemDiags := ToRoleDataPermissionsItem(ctx, itemPath, permissionsValues[key])
 		diags.Append(permissionsItemDiags...)
 
-		rolePermissionsItems[key] = permissionsItem
+		if !permissionsItemDiags.HasError() {
+			rolePermissionsItems[key] = permissionsItem
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return rolePermissionsItems, diags
 }
 
-func ToRoleDataPermissionsItem(ctx context.Context, _ path.Path, value TypedList[types.String]) (cm.RoleDataPermissionsItem, diag.Diagnostics) {
+func ToRoleDataPermissionsItem(_ context.Context, path path.Path, value TypedList[types.String]) (cm.RoleDataPermissionsItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	actionStrings := make([]string, len(value.Elements()))
-	diags.Append(tfsdk.ValueAs(ctx, value, &actionStrings)...)
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			path,
+			"Unexpected unknown permission actions",
+			"Permission actions must be known before they can be sent to Contentful.",
+		)
+
+		return cm.RoleDataPermissionsItem{}, diags
+	case value.IsNull():
+		diags.AddAttributeError(
+			path,
+			"Unexpected null permission actions",
+			"Permission actions cannot be null.",
+		)
+
+		return cm.RoleDataPermissionsItem{}, diags
+	}
+
+	actionStrings, actionDiags := knownStringListElements(path, value.Elements())
+	diags.Append(actionDiags...)
+
+	if diags.HasError() {
+		return cm.RoleDataPermissionsItem{}, diags
+	}
 
 	if slices.Contains(actionStrings, "all") {
 		return cm.RoleDataPermissionsItem{

--- a/internal/provider/role_model_policies_request.go
+++ b/internal/provider/role_model_policies_request.go
@@ -9,28 +9,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func ToRoleDataPolicies(ctx context.Context, path path.Path, policies TypedList[TypedObject[RolePolicyValue]]) ([]cm.RoleDataPoliciesItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	if policies.IsUnknown() {
+	switch {
+	case policies.IsUnknown():
+		diags.AddAttributeError(
+			path,
+			"Unexpected unknown policies",
+			"Policies must be known before they can be sent to Contentful.",
+		)
+
+		return nil, diags
+	case policies.IsNull():
+		diags.AddAttributeError(
+			path,
+			"Unexpected null policies",
+			"Policies are required.",
+		)
+
 		return nil, diags
 	}
 
 	policiesValues := policies.Elements()
 
-	rolePoliciesItems := make([]cm.RoleDataPoliciesItem, len(policiesValues))
+	rolePoliciesItems := make([]cm.RoleDataPoliciesItem, 0, len(policiesValues))
 
 	for index, policiesValueElement := range policiesValues {
-		path := path.AtListIndex(index)
+		itemPath := path.AtListIndex(index)
 
-		policiesItem, policiesItemDiags := ToRoleDataPoliciesItem(ctx, path, policiesValueElement)
+		policiesItem, policiesItemDiags := ToRoleDataPoliciesItem(ctx, itemPath, policiesValueElement)
 		diags.Append(policiesItemDiags...)
 
-		rolePoliciesItems[index] = policiesItem
+		if !policiesItemDiags.HasError() {
+			rolePoliciesItems = append(rolePoliciesItems, policiesItem)
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return rolePoliciesItems, diags
@@ -39,13 +59,53 @@ func ToRoleDataPolicies(ctx context.Context, path path.Path, policies TypedList[
 func ToRoleDataPoliciesItem(ctx context.Context, path path.Path, policy TypedObject[RolePolicyValue]) (cm.RoleDataPoliciesItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	effect := policy.Value().Effect.ValueString()
+	policyValue, ok := policy.GetValue()
+	if !ok {
+		if policy.IsUnknown() {
+			diags.AddAttributeError(
+				path,
+				"Unexpected unknown policy",
+				"The policy must be known before it can be sent to Contentful.",
+			)
+		} else {
+			diags.AddAttributeError(
+				path,
+				"Unexpected null policy",
+				"Null policies cannot be sent to Contentful.",
+			)
+		}
 
-	actions, actionsDiags := ToRoleDataPoliciesItemActions(ctx, path.AtName("actions"), policy.Value().Actions)
+		return cm.RoleDataPoliciesItem{}, diags
+	}
+
+	var effect string
+
+	switch {
+	case policyValue.Effect.IsUnknown():
+		diags.AddAttributeError(
+			path.AtName("effect"),
+			"Unexpected unknown policy effect",
+			"The policy effect must be known before it can be sent to Contentful.",
+		)
+	case policyValue.Effect.IsNull():
+		diags.AddAttributeError(
+			path.AtName("effect"),
+			"Unexpected null policy effect",
+			"The policy effect cannot be null.",
+		)
+	default:
+		effect = policyValue.Effect.ValueString()
+	}
+
+	actions, actionsDiags := ToRoleDataPoliciesItemActions(ctx, path.AtName("actions"), policyValue.Actions)
 	diags.Append(actionsDiags...)
 
-	constraint, constraintDiags := ToOptRoleDataPoliciesItemConstraint(ctx, path.AtName("constraint"), policy.Value().Constraint)
+	constraint, constraintDiags := ToOptRoleDataPoliciesItemConstraint(ctx, path.AtName("constraint"), policyValue.Constraint)
 	diags.Append(constraintDiags...)
+
+	if diags.HasError() {
+		return cm.RoleDataPoliciesItem{}, diags
+	}
 
 	return cm.RoleDataPoliciesItem{
 		Effect:     cm.RoleDataPoliciesItemEffect(effect),
@@ -54,11 +114,34 @@ func ToRoleDataPoliciesItem(ctx context.Context, path path.Path, policy TypedObj
 	}, diags
 }
 
-func ToRoleDataPoliciesItemActions(ctx context.Context, _ path.Path, actions TypedList[types.String]) (cm.RoleDataPoliciesItemActions, diag.Diagnostics) {
+func ToRoleDataPoliciesItemActions(_ context.Context, path path.Path, actions TypedList[types.String]) (cm.RoleDataPoliciesItemActions, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	actionsStrings := make([]string, len(actions.Elements()))
-	diags.Append(tfsdk.ValueAs(ctx, actions, &actionsStrings)...)
+	switch {
+	case actions.IsUnknown():
+		diags.AddAttributeError(
+			path,
+			"Unexpected unknown policy actions",
+			"Policy actions must be known before they can be sent to Contentful.",
+		)
+
+		return cm.RoleDataPoliciesItemActions{}, diags
+	case actions.IsNull():
+		diags.AddAttributeError(
+			path,
+			"Unexpected null policy actions",
+			"Policy actions are required.",
+		)
+
+		return cm.RoleDataPoliciesItemActions{}, diags
+	}
+
+	actionsStrings, actionDiags := knownStringListElements(path, actions.Elements())
+	diags.Append(actionDiags...)
+
+	if diags.HasError() {
+		return cm.RoleDataPoliciesItemActions{}, diags
+	}
 
 	if slices.Contains(actionsStrings, "all") {
 		return cm.RoleDataPoliciesItemActions{
@@ -73,10 +156,20 @@ func ToRoleDataPoliciesItemActions(ctx context.Context, _ path.Path, actions Typ
 	}, diags
 }
 
-func ToOptRoleDataPoliciesItemConstraint(_ context.Context, _ path.Path, constraint jsontypes.Normalized) (jx.Raw, diag.Diagnostics) {
+func ToOptRoleDataPoliciesItemConstraint(_ context.Context, path path.Path, constraint jsontypes.Normalized) (jx.Raw, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	if constraint.IsNull() {
+		return nil, diags
+	}
+
+	if constraint.IsUnknown() {
+		diags.AddAttributeError(
+			path,
+			"Unexpected unknown policy constraint",
+			"The policy constraint must be known before it can be sent to Contentful.",
+		)
+
 		return nil, diags
 	}
 

--- a/internal/provider/role_model_request.go
+++ b/internal/provider/role_model_request.go
@@ -11,20 +11,51 @@ import (
 func (model *RoleModel) ToRoleData(ctx context.Context) (cm.RoleData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	request := cm.RoleData{
-		Name:        model.Name.ValueString(),
-		Description: cm.NewOptNilPointerString(model.Description.ValueStringPointer()),
+	var name string
+
+	switch {
+	case model.Name.IsUnknown():
+		diags.AddAttributeError(
+			path.Root("name"),
+			"Unexpected unknown role name",
+			"The role name must be known before it can be sent to Contentful.",
+		)
+	case model.Name.IsNull():
+		diags.AddAttributeError(
+			path.Root("name"),
+			"Unexpected null role name",
+			"The role name is required.",
+		)
+	default:
+		name = model.Name.ValueString()
+	}
+
+	description := cm.NewOptNilStringNull()
+
+	if model.Description.IsUnknown() {
+		diags.AddAttributeError(
+			path.Root("description"),
+			"Unexpected unknown role description",
+			"The role description must be known before it can be sent to Contentful.",
+		)
+	} else if !model.Description.IsNull() {
+		description = cm.NewOptNilString(model.Description.ValueString())
 	}
 
 	permissions, permissionsDiags := ToRoleDataPermissions(ctx, path.Root("permissions"), model.Permissions)
 	diags.Append(permissionsDiags...)
 
-	request.Permissions = permissions
-
 	policies, policiesDiags := ToRoleDataPolicies(ctx, path.Root("policies"), model.Policies)
 	diags.Append(policiesDiags...)
 
-	request.Policies = policies
+	if diags.HasError() {
+		return cm.RoleData{}, diags
+	}
 
-	return request, diags
+	return cm.RoleData{
+		Name:        name,
+		Description: description,
+		Permissions: permissions,
+		Policies:    policies,
+	}, diags
 }

--- a/internal/provider/role_model_request_test.go
+++ b/internal/provider/role_model_request_test.go
@@ -5,7 +5,10 @@ import (
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoleModelRoundTripToRoleData(t *testing.T) {
@@ -70,4 +73,266 @@ func TestRoleModelRoundTripToRoleData(t *testing.T) {
 	}, req.Policies[2])
 
 	assert.Empty(t, diags)
+}
+
+func TestRoleRequestRejectsUnresolvedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		mutate        func(*RoleModel)
+		expectedPaths []string
+	}{
+		"null name": {
+			mutate: func(model *RoleModel) {
+				model.Name = types.StringNull()
+			},
+			expectedPaths: []string{"name"},
+		},
+		"unknown name": {
+			mutate: func(model *RoleModel) {
+				model.Name = types.StringUnknown()
+			},
+			expectedPaths: []string{"name"},
+		},
+		"unknown description": {
+			mutate: func(model *RoleModel) {
+				model.Description = types.StringUnknown()
+			},
+			expectedPaths: []string{"description"},
+		},
+		"null permissions": {
+			mutate: func(model *RoleModel) {
+				model.Permissions = NewTypedMapNull[TypedList[types.String]]()
+			},
+			expectedPaths: []string{"permissions"},
+		},
+		"unknown permissions": {
+			mutate: func(model *RoleModel) {
+				model.Permissions = NewTypedMapUnknown[TypedList[types.String]]()
+			},
+			expectedPaths: []string{"permissions"},
+		},
+		"null permission actions": {
+			mutate: func(model *RoleModel) {
+				model.Permissions = NewTypedMap(map[string]TypedList[types.String]{
+					"Entry": NewTypedListNull[types.String](),
+				})
+			},
+			expectedPaths: []string{`permissions["Entry"]`},
+		},
+		"unknown permission actions": {
+			mutate: func(model *RoleModel) {
+				model.Permissions = NewTypedMap(map[string]TypedList[types.String]{
+					"Entry": NewTypedListUnknown[types.String](),
+				})
+			},
+			expectedPaths: []string{`permissions["Entry"]`},
+		},
+		"null permission action": {
+			mutate: func(model *RoleModel) {
+				model.Permissions = NewTypedMap(map[string]TypedList[types.String]{
+					"Entry": NewTypedList([]types.String{types.StringValue("read"), types.StringNull()}),
+				})
+			},
+			expectedPaths: []string{`permissions["Entry"][1]`},
+		},
+		"unknown permission action": {
+			mutate: func(model *RoleModel) {
+				model.Permissions = NewTypedMap(map[string]TypedList[types.String]{
+					"Entry": NewTypedList([]types.String{types.StringValue("read"), types.StringUnknown()}),
+				})
+			},
+			expectedPaths: []string{`permissions["Entry"][1]`},
+		},
+		"null policies": {
+			mutate: func(model *RoleModel) {
+				model.Policies = NewTypedListNull[TypedObject[RolePolicyValue]]()
+			},
+			expectedPaths: []string{"policies"},
+		},
+		"unknown policies": {
+			mutate: func(model *RoleModel) {
+				model.Policies = NewTypedListUnknown[TypedObject[RolePolicyValue]]()
+			},
+			expectedPaths: []string{"policies"},
+		},
+		"null policy": {
+			mutate: func(model *RoleModel) {
+				model.Policies = NewTypedList([]TypedObject[RolePolicyValue]{NewTypedObjectNull[RolePolicyValue]()})
+			},
+			expectedPaths: []string{"policies[0]"},
+		},
+		"unknown policy": {
+			mutate: func(model *RoleModel) {
+				model.Policies = NewTypedList([]TypedObject[RolePolicyValue]{NewTypedObjectUnknown[RolePolicyValue]()})
+			},
+			expectedPaths: []string{"policies[0]"},
+		},
+		"null policy effect": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedList([]types.String{types.StringValue("read")}),
+					Constraint: jsontypes.NewNormalizedNull(),
+					Effect:     types.StringNull(),
+				})
+			},
+			expectedPaths: []string{"policies[0].effect"},
+		},
+		"unknown policy effect": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedList([]types.String{types.StringValue("read")}),
+					Constraint: jsontypes.NewNormalizedNull(),
+					Effect:     types.StringUnknown(),
+				})
+			},
+			expectedPaths: []string{"policies[0].effect"},
+		},
+		"null policy actions": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedListNull[types.String](),
+					Constraint: jsontypes.NewNormalizedNull(),
+					Effect:     types.StringValue("allow"),
+				})
+			},
+			expectedPaths: []string{"policies[0].actions"},
+		},
+		"unknown policy actions": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedListUnknown[types.String](),
+					Constraint: jsontypes.NewNormalizedNull(),
+					Effect:     types.StringValue("allow"),
+				})
+			},
+			expectedPaths: []string{"policies[0].actions"},
+		},
+		"null policy action": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedList([]types.String{types.StringValue("read"), types.StringNull()}),
+					Constraint: jsontypes.NewNormalizedNull(),
+					Effect:     types.StringValue("allow"),
+				})
+			},
+			expectedPaths: []string{"policies[0].actions[1]"},
+		},
+		"unknown policy action": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedList([]types.String{types.StringValue("read"), types.StringUnknown()}),
+					Constraint: jsontypes.NewNormalizedNull(),
+					Effect:     types.StringValue("allow"),
+				})
+			},
+			expectedPaths: []string{"policies[0].actions[1]"},
+		},
+		"unknown policy constraint": {
+			mutate: func(model *RoleModel) {
+				model.Policies = rolePoliciesWith(RolePolicyValue{
+					Actions:    NewTypedList([]types.String{types.StringValue("read")}),
+					Constraint: jsontypes.NewNormalizedUnknown(),
+					Effect:     types.StringValue("allow"),
+				})
+			},
+			expectedPaths: []string{"policies[0].constraint"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validRoleRequestModel()
+			test.mutate(&model)
+
+			request, diags := model.ToRoleData(t.Context())
+
+			assert.Equal(t, cm.RoleData{}, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedPaths, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestRoleRequestAggregatesParentDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	model := validRoleRequestModel()
+	model.Name = types.StringUnknown()
+	model.Description = types.StringUnknown()
+	model.Permissions = NewTypedMapUnknown[TypedList[types.String]]()
+	model.Policies = NewTypedListUnknown[TypedObject[RolePolicyValue]]()
+
+	request, diags := model.ToRoleData(t.Context())
+
+	assert.Equal(t, cm.RoleData{}, request)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"name", "description", "permissions", "policies"}, attributeDiagnosticPaths(t, diags))
+}
+
+func TestRoleRequestDescriptionStates(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		description types.String
+		expected    cm.OptNilString
+	}{
+		"null": {
+			description: types.StringNull(),
+			expected:    cm.NewOptNilStringNull(),
+		},
+		"empty": {
+			description: types.StringValue(""),
+			expected:    cm.NewOptNilString(""),
+		},
+		"non-empty": {
+			description: types.StringValue("description"),
+			expected:    cm.NewOptNilString("description"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validRoleRequestModel()
+			model.Description = test.description
+
+			request, diags := model.ToRoleData(t.Context())
+
+			require.False(t, diags.HasError(), diags.Errors())
+			assert.Equal(t, test.expected, request.Description)
+		})
+	}
+}
+
+func TestRoleRequestOmitsNullPolicyConstraint(t *testing.T) {
+	t.Parallel()
+
+	model := validRoleRequestModel()
+	request, diags := model.ToRoleData(t.Context())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	require.Len(t, request.Policies, 1)
+	assert.Nil(t, request.Policies[0].Constraint)
+}
+
+func validRoleRequestModel() RoleModel {
+	return RoleModel{
+		Name: types.StringValue("role"),
+		Permissions: NewTypedMap(map[string]TypedList[types.String]{
+			"Entry": NewTypedList([]types.String{types.StringValue("read")}),
+		}),
+		Policies: rolePoliciesWith(RolePolicyValue{
+			Actions:    NewTypedList([]types.String{types.StringValue("read")}),
+			Constraint: jsontypes.NewNormalizedNull(),
+			Effect:     types.StringValue("allow"),
+		}),
+	}
+}
+
+func rolePoliciesWith(policy RolePolicyValue) TypedList[TypedObject[RolePolicyValue]] {
+	return NewTypedList([]TypedObject[RolePolicyValue]{NewTypedObject(policy)})
 }


### PR DESCRIPTION
## Summary

- reject null or unknown required Role names and unknown optional descriptions before API request construction
- preserve known descriptions, including empty strings, and the existing Terraform-null API representation
- reject unresolved permission and policy containers, nested values, and union members at exact Terraform paths
- aggregate independent diagnostics and fail closed with zero RoleData on any error

This is stacked on #599 so it can reuse the focused request string-list conversion seam.

## Validation

- `go test ./internal/provider -run "TestRole(ModelRoundTripToRoleData|Request)"`
- `go test ./...`
- `go generate ./...` (clean)
- `golangci-lint cache clean`
- `golangci-lint run` (0 issues)