### PR TITLE
fix(app): reject unresolved request values

### DIFF
--- a/internal/provider/app_definition_model_request.go
+++ b/internal/provider/app_definition_model_request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
-	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
@@ -12,11 +11,14 @@ import (
 func (model *AppDefinitionBaseModel) ToAppDefinitionData(ctx context.Context, path path.Path) (cm.AppDefinitionData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
+	name, nameDiags := appRequestRequiredString(model.Name, path.AtName("name"))
+	diags.Append(nameDiags...)
+
 	fields := cm.AppDefinitionData{
-		Name: model.Name.ValueString(),
+		Name: name,
 	}
 
-	if !model.Src.IsUnknown() {
+	if !model.Src.IsUnknown() && !model.Src.IsNull() {
 		fields.Src = cm.NewOptPointerString(model.Src.ValueStringPointer())
 	}
 
@@ -28,75 +30,67 @@ func (model *AppDefinitionBaseModel) ToAppDefinitionData(ctx context.Context, pa
 		path := path.AtName("locations")
 
 		locations := make([]cm.AppDefinitionDataLocationsItem, 0, len(model.Locations))
-		for _, location := range model.Locations {
-			path := path.AtListIndex(len(locations))
+		for index, location := range model.Locations {
+			requestLocation, locationDiags := location.ToAppDefinitionDataLocationsItem(ctx, path.AtListIndex(index))
+			diags.Append(locationDiags...)
 
-			locationsItem := location.ToAppDefinitionDataLocationsItem(ctx, path)
-
-			locations = append(locations, locationsItem)
+			if !locationDiags.HasError() {
+				locations = append(locations, requestLocation)
+			}
 		}
 
 		fields.Locations = locations
 	}
 
 	if model.Parameters != nil {
-		path := path.AtName("parameters")
+		parameters, parameterDiags := model.Parameters.ToAppDefinitionParameters(ctx, path.AtName("parameters"))
+		diags.Append(parameterDiags...)
 
-		var installationParameters, instanceParameters []cm.AppDefinitionParameter
-
-		if model.Parameters.Installation != nil {
-			path := path.AtName("installation")
-
-			installationParameters = make([]cm.AppDefinitionParameter, 0, len(model.Parameters.Installation))
-
-			for index, element := range model.Parameters.Installation {
-				parameter, parameterDiags := element.ToAppDefinitionParameter(ctx, path.AtListIndex(index))
-				diags.Append(parameterDiags...)
-
-				installationParameters = append(installationParameters, parameter)
-			}
+		if !parameterDiags.HasError() {
+			fields.Parameters.SetTo(parameters)
 		}
+	}
 
-		if model.Parameters.Instance != nil {
-			path := path.AtName("instance")
-
-			instanceParameters = make([]cm.AppDefinitionParameter, 0, len(model.Parameters.Instance))
-
-			for index, element := range model.Parameters.Instance {
-				parameter, parameterDiags := element.ToAppDefinitionParameter(ctx, path.AtListIndex(index))
-				diags.Append(parameterDiags...)
-
-				instanceParameters = append(instanceParameters, parameter)
-			}
-		}
-
-		fields.Parameters.SetTo(cm.AppDefinitionParameters{
-			Installation: installationParameters,
-			Instance:     instanceParameters,
-		})
+	if diags.HasError() {
+		return cm.AppDefinitionData{}, diags
 	}
 
 	return fields, diags
 }
 
-func (model AppDefinitionLocationsItem) ToAppDefinitionDataLocationsItem(_ context.Context, _ path.Path) cm.AppDefinitionDataLocationsItem {
+func (model AppDefinitionLocationsItem) ToAppDefinitionDataLocationsItem(_ context.Context, path path.Path) (cm.AppDefinitionDataLocationsItem, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	location, locationDiags := appRequestRequiredString(model.Location, path.AtName("location"))
+	diags.Append(locationDiags...)
+
 	item := cm.AppDefinitionDataLocationsItem{
-		Location: model.Location.ValueString(),
+		Location: location,
 	}
 
 	if model.FieldTypes != nil {
 		fieldTypes := make([]cm.AppDefinitionDataLocationsItemFieldTypesItem, 0, len(model.FieldTypes))
 
-		for _, fieldType := range model.FieldTypes {
+		for index, fieldType := range model.FieldTypes {
+			fieldType, fieldTypeDiags := appDefinitionLocationFieldTypeToRequest(
+				fieldType,
+				path.AtName("field_types").AtListIndex(index),
+			)
+			diags.Append(fieldTypeDiags...)
+
+			if fieldTypeDiags.HasError() {
+				continue
+			}
+
 			fieldTypesItem := cm.AppDefinitionDataLocationsItemFieldTypesItem{
-				Type:     fieldType.Type.ValueString(),
-				LinkType: cm.NewOptPointerString(fieldType.LinkType.ValueStringPointer()),
+				Type:     fieldType.Type,
+				LinkType: cm.NewOptPointerString(fieldType.LinkType),
 			}
 
 			if fieldType.Items != nil {
 				fieldTypesItem.Items.SetTo(cm.AppDefinitionDataLocationsItemFieldTypesItemItems{
-					Type:     fieldType.Items.Type.ValueString(),
-					LinkType: cm.NewOptPointerString(fieldType.Items.LinkType.ValueStringPointer()),
+					Type:     fieldType.Items.Type,
+					LinkType: cm.NewOptPointerString(fieldType.Items.LinkType),
 				})
 			}
 
@@ -107,53 +101,64 @@ func (model AppDefinitionLocationsItem) ToAppDefinitionDataLocationsItem(_ conte
 	}
 
 	if model.NavigationItem != nil {
+		name, nameDiags := appRequestRequiredString(model.NavigationItem.Name, path.AtName("navigation_item").AtName("name"))
+		pathValue, pathDiags := appRequestRequiredString(model.NavigationItem.Path, path.AtName("navigation_item").AtName("path"))
+
+		diags.Append(nameDiags...)
+		diags.Append(pathDiags...)
+
 		item.NavigationItem.SetTo(cm.AppDefinitionDataLocationsItemNavigationItem{
-			Name: model.NavigationItem.Name.ValueString(),
-			Path: model.NavigationItem.Path.ValueString(),
+			Name: name,
+			Path: pathValue,
 		})
 	}
 
-	return item
+	if diags.HasError() {
+		return cm.AppDefinitionDataLocationsItem{}, diags
+	}
+
+	return item, diags
 }
 
-func (model AppDefinitionParameter) ToAppDefinitionParameter(_ context.Context, _ path.Path) (cm.AppDefinitionParameter, diag.Diagnostics) {
+type appDefinitionLocationFieldTypeRequest struct {
+	Type     string
+	LinkType *string
+	Items    *appDefinitionLocationFieldTypeRequest
+}
+
+func appDefinitionLocationFieldTypeToRequest(
+	model AppDefinitionLocationFieldTypesItem,
+	path path.Path,
+) (appDefinitionLocationFieldTypeRequest, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	parameter := cm.AppDefinitionParameter{
-		ID:          model.ID,
-		Name:        model.Name,
-		Description: cm.NewOptPointerString(model.Description),
-		Type:        model.Type,
-		Required:    cm.NewOptPointerBool(model.Required),
+	typeValue, typeDiags := appRequestRequiredString(model.Type, path.AtName("type"))
+	linkType, linkTypeDiags := appRequestOptionalString(model.LinkType, path.AtName("link_type"))
+
+	diags.Append(typeDiags...)
+	diags.Append(linkTypeDiags...)
+
+	fieldType := appDefinitionLocationFieldTypeRequest{
+		Type:     typeValue,
+		LinkType: linkType,
 	}
 
-	if !model.Default.IsUnknown() {
-		value := model.Default.ValueStringPointer()
-		if value != nil {
-			parameter.Default = jx.Raw(*value)
+	if model.Items != nil {
+		itemsType, itemsTypeDiags := appRequestRequiredString(model.Items.Type, path.AtName("items").AtName("type"))
+		itemsLinkType, itemsLinkTypeDiags := appRequestOptionalString(model.Items.LinkType, path.AtName("items").AtName("link_type"))
+
+		diags.Append(itemsTypeDiags...)
+		diags.Append(itemsLinkTypeDiags...)
+
+		fieldType.Items = &appDefinitionLocationFieldTypeRequest{
+			Type:     itemsType,
+			LinkType: itemsLinkType,
 		}
 	}
 
-	if !model.Options.IsUnknown() && !model.Options.IsNull() {
-		options := make([]jx.Raw, 0, len(model.Options.Elements()))
-
-		for _, option := range model.Options.Elements() {
-			value := option.ValueStringPointer()
-			if value != nil {
-				options = append(options, jx.Raw(*value))
-			}
-		}
-
-		parameter.Options = options
+	if diags.HasError() {
+		return appDefinitionLocationFieldTypeRequest{}, diags
 	}
 
-	if model.Labels != nil {
-		parameter.Labels.SetTo(cm.AppDefinitionParameterLabels{
-			Empty: cm.NewOptPointerString(model.Labels.Empty),
-			True:  cm.NewOptPointerString(model.Labels.True),
-			False: cm.NewOptPointerString(model.Labels.False),
-		})
-	}
-
-	return parameter, diags
+	return fieldType, diags
 }

--- a/internal/provider/app_definition_model_request_test.go
+++ b/internal/provider/app_definition_model_request_test.go
@@ -1,0 +1,206 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validAppDefinitionRequestModel() AppDefinitionBaseModel {
+	return AppDefinitionBaseModel{
+		Name:     types.StringValue("App"),
+		Src:      types.StringUnknown(),
+		BundleID: types.StringUnknown(),
+		Locations: []AppDefinitionLocationsItem{
+			{
+				Location: types.StringValue("entry-field"),
+				FieldTypes: []AppDefinitionLocationFieldTypesItem{
+					{
+						Type:     types.StringValue("Array"),
+						LinkType: types.StringNull(),
+						Items: &AppDefinitionLocationFieldTypeItemsItem{
+							Type:     types.StringValue("Link"),
+							LinkType: types.StringNull(),
+						},
+					},
+				},
+				NavigationItem: &AppDefinitionLocationNavigationItem{
+					Name: types.StringValue("Entry"),
+					Path: types.StringValue("/entry"),
+				},
+			},
+		},
+	}
+}
+
+func TestAppDefinitionRequestRejectsUnresolvedScalars(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		mutate       func(*AppDefinitionBaseModel)
+		expectedPath string
+	}{
+		"unknown name": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Name = types.StringUnknown() },
+			expectedPath: "name",
+		},
+		"null name": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Name = types.StringNull() },
+			expectedPath: "name",
+		},
+		"unknown location": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].Location = types.StringUnknown() },
+			expectedPath: "locations[0].location",
+		},
+		"null location": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].Location = types.StringNull() },
+			expectedPath: "locations[0].location",
+		},
+		"unknown field type": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].FieldTypes[0].Type = types.StringUnknown() },
+			expectedPath: "locations[0].field_types[0].type",
+		},
+		"null field type": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].FieldTypes[0].Type = types.StringNull() },
+			expectedPath: "locations[0].field_types[0].type",
+		},
+		"unknown field link type": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].FieldTypes[0].LinkType = types.StringUnknown() },
+			expectedPath: "locations[0].field_types[0].link_type",
+		},
+		"unknown item type": {
+			mutate: func(model *AppDefinitionBaseModel) {
+				model.Locations[0].FieldTypes[0].Items.Type = types.StringUnknown()
+			},
+			expectedPath: "locations[0].field_types[0].items.type",
+		},
+		"null item type": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].FieldTypes[0].Items.Type = types.StringNull() },
+			expectedPath: "locations[0].field_types[0].items.type",
+		},
+		"unknown item link type": {
+			mutate: func(model *AppDefinitionBaseModel) {
+				model.Locations[0].FieldTypes[0].Items.LinkType = types.StringUnknown()
+			},
+			expectedPath: "locations[0].field_types[0].items.link_type",
+		},
+		"unknown navigation name": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].NavigationItem.Name = types.StringUnknown() },
+			expectedPath: "locations[0].navigation_item.name",
+		},
+		"null navigation name": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].NavigationItem.Name = types.StringNull() },
+			expectedPath: "locations[0].navigation_item.name",
+		},
+		"unknown navigation path": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].NavigationItem.Path = types.StringUnknown() },
+			expectedPath: "locations[0].navigation_item.path",
+		},
+		"null navigation path": {
+			mutate:       func(model *AppDefinitionBaseModel) { model.Locations[0].NavigationItem.Path = types.StringNull() },
+			expectedPath: "locations[0].navigation_item.path",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validAppDefinitionRequestModel()
+			test.mutate(&model)
+
+			actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+			assert.Equal(t, cm.AppDefinitionData{}, actual)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestAppDefinitionRequestFailsAtomically(t *testing.T) {
+	t.Parallel()
+
+	model := validAppDefinitionRequestModel()
+	model.Name = types.StringUnknown()
+	model.Locations[0].Location = types.StringNull()
+	model.Locations[0].FieldTypes[0].Items.LinkType = types.StringUnknown()
+	model.Locations[0].NavigationItem.Path = types.StringUnknown()
+
+	actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+	assert.Equal(t, cm.AppDefinitionData{}, actual)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{
+		"name",
+		"locations[0].location",
+		"locations[0].field_types[0].items.link_type",
+		"locations[0].navigation_item.path",
+	}, attributeDiagnosticPaths(t, diags))
+}
+
+func TestAppDefinitionRequestPreservesOptionalScalarPresence(t *testing.T) {
+	t.Parallel()
+
+	model := validAppDefinitionRequestModel()
+	model.Name = types.StringValue("")
+	model.Src = types.StringValue("")
+	model.BundleID = types.StringValue("")
+	model.Locations[0].FieldTypes[0].LinkType = types.StringValue("")
+	model.Locations[0].FieldTypes[0].Items.LinkType = types.StringValue("")
+
+	actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Empty(t, actual.Name)
+	assert.Empty(t, requireOptString(t, actual.Src))
+	bundle, ok := actual.Bundle.Get()
+	require.True(t, ok)
+	assert.Empty(t, bundle.Sys.ID)
+	assert.Empty(t, requireOptString(t, actual.Locations[0].FieldTypes[0].LinkType))
+	items, ok := actual.Locations[0].FieldTypes[0].Items.Get()
+	require.True(t, ok)
+	assert.Empty(t, requireOptString(t, items.LinkType))
+}
+
+func TestAppDefinitionRequestOmitsOptionalComputedUnknownsAndNullLinks(t *testing.T) {
+	t.Parallel()
+
+	model := validAppDefinitionRequestModel()
+
+	actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.False(t, actual.Src.IsSet())
+	assert.False(t, actual.Bundle.IsSet())
+	assert.False(t, actual.Locations[0].FieldTypes[0].LinkType.IsSet())
+	items, ok := actual.Locations[0].FieldTypes[0].Items.Get()
+	require.True(t, ok)
+	assert.False(t, items.LinkType.IsSet())
+}
+
+func TestAppDefinitionRequestOmitsOptionalComputedNulls(t *testing.T) {
+	t.Parallel()
+
+	model := validAppDefinitionRequestModel()
+	model.Src = types.StringNull()
+	model.BundleID = types.StringNull()
+
+	actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.False(t, actual.Src.IsSet())
+	assert.False(t, actual.Bundle.IsSet())
+}
+
+func requireOptString(t *testing.T, value cm.OptString) string {
+	t.Helper()
+
+	actual, ok := value.Get()
+	require.True(t, ok)
+
+	return actual
+}

--- a/internal/provider/app_definition_parameter_request.go
+++ b/internal/provider/app_definition_parameter_request.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"context"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/go-faster/jx"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func (model *AppDefinitionParameters) ToAppDefinitionParameters(ctx context.Context, valuePath path.Path) (cm.AppDefinitionParameters, diag.Diagnostics) {
+	installation, installationDiags := appDefinitionParameterListToRequest(ctx, valuePath.AtName("installation"), model.Installation)
+	instance, instanceDiags := appDefinitionParameterListToRequest(ctx, valuePath.AtName("instance"), model.Instance)
+
+	diags := diag.Diagnostics{}
+	diags.Append(installationDiags...)
+	diags.Append(instanceDiags...)
+
+	if diags.HasError() {
+		return cm.AppDefinitionParameters{}, diags
+	}
+
+	return cm.AppDefinitionParameters{
+		Installation: installation,
+		Instance:     instance,
+	}, diags
+}
+
+func appDefinitionParameterListToRequest(ctx context.Context, valuePath path.Path, models []AppDefinitionParameter) ([]cm.AppDefinitionParameter, diag.Diagnostics) {
+	if models == nil {
+		return nil, nil
+	}
+
+	parameters := make([]cm.AppDefinitionParameter, 0, len(models))
+	diags := diag.Diagnostics{}
+
+	for index, model := range models {
+		parameter, parameterDiags := model.ToAppDefinitionParameter(ctx, valuePath.AtListIndex(index))
+		diags.Append(parameterDiags...)
+
+		if !parameterDiags.HasError() {
+			parameters = append(parameters, parameter)
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return parameters, diags
+}
+
+func (model AppDefinitionParameter) ToAppDefinitionParameter(_ context.Context, parameterPath path.Path) (cm.AppDefinitionParameter, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	parameter := cm.AppDefinitionParameter{
+		ID:          model.ID,
+		Name:        model.Name,
+		Description: cm.NewOptPointerString(model.Description),
+		Type:        model.Type,
+		Required:    cm.NewOptPointerBool(model.Required),
+	}
+
+	switch {
+	case model.Default.IsUnknown():
+		diags.AddAttributeError(
+			parameterPath.AtName("default"),
+			"Unexpected unknown parameter default",
+			"The parameter default must be known before it can be sent to Contentful.",
+		)
+	case model.Default.IsNull():
+	default:
+		parameter.Default = jx.Raw(model.Default.ValueString())
+	}
+
+	options, optionsSet, optionsDiags := appDefinitionParameterOptionsToRequest(
+		parameterPath.AtName("options"),
+		model.Options,
+	)
+	diags.Append(optionsDiags...)
+
+	if optionsSet {
+		parameter.Options = options
+	}
+
+	if model.Labels != nil {
+		parameter.Labels.SetTo(cm.AppDefinitionParameterLabels{
+			Empty: cm.NewOptPointerString(model.Labels.Empty),
+			True:  cm.NewOptPointerString(model.Labels.True),
+			False: cm.NewOptPointerString(model.Labels.False),
+		})
+	}
+
+	if diags.HasError() {
+		return cm.AppDefinitionParameter{}, diags
+	}
+
+	return parameter, diags
+}
+
+func appDefinitionParameterOptionsToRequest(valuePath path.Path, value TypedList[jsontypes.Normalized]) ([]jx.Raw, bool, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown parameter options",
+			"Parameter options must be known before they can be sent to Contentful.",
+		)
+
+		return nil, false, diags
+	case value.IsNull():
+		return nil, false, diags
+	}
+
+	options := make([]jx.Raw, 0, len(value.Elements()))
+
+	for index, option := range value.Elements() {
+		optionPath := valuePath.AtListIndex(index)
+
+		switch {
+		case option.IsUnknown():
+			diags.AddAttributeError(
+				optionPath,
+				"Unexpected unknown parameter option",
+				"The parameter option must be known before it can be sent to Contentful.",
+			)
+		case option.IsNull():
+			diags.AddAttributeError(
+				optionPath,
+				"Unexpected null parameter option",
+				"The parameter option cannot be null when it is sent to Contentful.",
+			)
+		default:
+			options = append(options, jx.Raw(option.ValueString()))
+		}
+	}
+
+	if diags.HasError() {
+		return nil, false, diags
+	}
+
+	return options, true, diags
+}

--- a/internal/provider/app_definition_parameter_request_test.go
+++ b/internal/provider/app_definition_parameter_request_test.go
@@ -1,0 +1,213 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/go-faster/jx"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppDefinitionParameterToRequestRejectsUnresolvedJSON(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		model               AppDefinitionParameter
+		expectedDiagnostics []string
+	}{
+		"unknown default": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedUnknown(),
+				Options: NewTypedListNull[jsontypes.Normalized](),
+			},
+			expectedDiagnostics: []string{"parameters.installation[0].default"},
+		},
+		"unknown options": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedNull(),
+				Options: NewTypedListUnknown[jsontypes.Normalized](),
+			},
+			expectedDiagnostics: []string{"parameters.installation[0].options"},
+		},
+		"unknown option child": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedNull(),
+				Options: NewTypedList([]jsontypes.Normalized{
+					jsontypes.NewNormalizedValue(`"known"`),
+					jsontypes.NewNormalizedUnknown(),
+				}),
+			},
+			expectedDiagnostics: []string{"parameters.installation[0].options[1]"},
+		},
+		"null option child": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedNull(),
+				Options: NewTypedList([]jsontypes.Normalized{
+					jsontypes.NewNormalizedValue(`"known"`),
+					jsontypes.NewNormalizedNull(),
+				}),
+			},
+			expectedDiagnostics: []string{"parameters.installation[0].options[1]"},
+		},
+		"multiple unresolved values": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedUnknown(),
+				Options: NewTypedList([]jsontypes.Normalized{
+					jsontypes.NewNormalizedUnknown(),
+					jsontypes.NewNormalizedNull(),
+				}),
+			},
+			expectedDiagnostics: []string{
+				"parameters.installation[0].default",
+				"parameters.installation[0].options[0]",
+				"parameters.installation[0].options[1]",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.model.ToAppDefinitionParameter(
+				t.Context(),
+				path.Root("parameters").AtName("installation").AtListIndex(0),
+			)
+
+			assert.Equal(t, cm.AppDefinitionParameter{}, actual)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedDiagnostics, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestAppDefinitionParameterToRequestPreservesJSONPresence(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		model                  AppDefinitionParameter
+		expectedDefault        jx.Raw
+		expectedOptions        []jx.Raw
+		expectedOptionsPresent bool
+	}{
+		"absent": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedNull(),
+				Options: NewTypedListNull[jsontypes.Normalized](),
+			},
+		},
+		"known JSON null": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedValue("null"),
+				Options: NewTypedList([]jsontypes.Normalized{jsontypes.NewNormalizedValue("null")}),
+			},
+			expectedDefault:        jx.Raw("null"),
+			expectedOptions:        []jx.Raw{jx.Raw("null")},
+			expectedOptionsPresent: true,
+		},
+		"known empty options": {
+			model: AppDefinitionParameter{
+				Default: jsontypes.NewNormalizedNull(),
+				Options: NewTypedList([]jsontypes.Normalized{}),
+			},
+			expectedOptions:        []jx.Raw{},
+			expectedOptionsPresent: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.model.ToAppDefinitionParameter(t.Context(), path.Root("parameter"))
+
+			require.False(t, diags.HasError(), diags.Errors())
+			assert.Equal(t, test.expectedDefault, actual.Default)
+			assert.Equal(t, test.expectedOptions, actual.Options)
+			assert.Equal(t, test.expectedOptionsPresent, actual.Options != nil)
+		})
+	}
+}
+
+func TestAppDefinitionParameterListsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	model := AppDefinitionBaseModel{
+		Name: types.StringValue("App"),
+		Parameters: &AppDefinitionParameters{
+			Installation: []AppDefinitionParameter{
+				{
+					ID:      "known",
+					Default: jsontypes.NewNormalizedNull(),
+					Options: NewTypedListNull[jsontypes.Normalized](),
+				},
+			},
+			Instance: []AppDefinitionParameter{
+				{
+					ID:      "unresolved",
+					Default: jsontypes.NewNormalizedUnknown(),
+					Options: NewTypedListNull[jsontypes.Normalized](),
+				},
+			},
+		},
+	}
+
+	actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+	assert.Equal(t, cm.AppDefinitionData{}, actual)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"parameters.instance[0].default"}, attributeDiagnosticPaths(t, diags))
+}
+
+func TestAppDefinitionParameterListsPreserveNilAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		parameters         *AppDefinitionParameters
+		expectParameters   bool
+		expectInstallation bool
+		expectInstance     bool
+	}{
+		"absent parameters": {},
+		"empty installation and nil instance": {
+			parameters: &AppDefinitionParameters{
+				Installation: []AppDefinitionParameter{},
+				Instance:     nil,
+			},
+			expectParameters:   true,
+			expectInstallation: true,
+		},
+		"nil installation and empty instance": {
+			parameters: &AppDefinitionParameters{
+				Installation: nil,
+				Instance:     []AppDefinitionParameter{},
+			},
+			expectParameters: true,
+			expectInstance:   true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := AppDefinitionBaseModel{
+				Name:       types.StringValue("App"),
+				Parameters: test.parameters,
+			}
+
+			actual, diags := model.ToAppDefinitionData(t.Context(), path.Empty())
+
+			require.False(t, diags.HasError(), diags.Errors())
+
+			parameters, ok := actual.Parameters.Get()
+			assert.Equal(t, test.expectParameters, ok)
+
+			if !ok {
+				return
+			}
+
+			assert.Equal(t, test.expectInstallation, parameters.Installation != nil)
+			assert.Equal(t, test.expectInstance, parameters.Instance != nil)
+		})
+	}
+}

--- a/internal/provider/app_request_string.go
+++ b/internal/provider/app_request_string.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func appRequestRequiredString(value types.String, valuePath path.Path) (string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown request value",
+			"This value must be known before it can be sent to Contentful.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null request value",
+			"This value cannot be null when it is sent to Contentful.",
+		)
+	default:
+		return value.ValueString(), diags
+	}
+
+	return "", diags
+}
+
+func appRequestOptionalString(value types.String, valuePath path.Path) (*string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown request value",
+			"This value must be known before it can be sent to Contentful.",
+		)
+	case value.IsNull():
+		return nil, diags
+	default:
+		return value.ValueStringPointer(), diags
+	}
+
+	return nil, diags
+}

--- a/internal/provider/extension_model_request.go
+++ b/internal/provider/extension_model_request.go
@@ -22,96 +22,101 @@ func (model *ExtensionModel) ToExtensionData(ctx context.Context, path path.Path
 		fields.Parameters = []byte(model.Parameters.ValueString())
 	}
 
+	if diags.HasError() {
+		return cm.ExtensionData{}, diags
+	}
+
 	return fields, diags
 }
 
 func (model *ExtensionModelExtension) ToExtensionExtensionData(ctx context.Context, path path.Path) (cm.ExtensionDataExtension, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
+	name, nameDiags := appRequestRequiredString(model.Name, path.AtName("name"))
+	diags.Append(nameDiags...)
+
+	var sidebar *bool
+
+	switch {
+	case model.Sidebar.IsUnknown():
+		diags.AddAttributeError(
+			path.AtName("sidebar"),
+			"Unexpected unknown request value",
+			"This value must be known before it can be sent to Contentful.",
+		)
+	case model.Sidebar.IsNull():
+	default:
+		sidebar = model.Sidebar.ValueBoolPointer()
+	}
+
 	fields := cm.ExtensionDataExtension{
-		Name:    model.Name.ValueString(),
-		Sidebar: cm.NewOptPointerBool(model.Sidebar.ValueBoolPointer()),
+		Name:    name,
+		Sidebar: cm.NewOptPointerBool(sidebar),
 	}
 
-	src := model.Src.ValueString()
-	if src != "" {
-		fields.Src = cm.NewOptString(src)
+	if !model.Src.IsUnknown() && !model.Src.IsNull() && model.Src.ValueString() != "" {
+		fields.Src = cm.NewOptString(model.Src.ValueString())
 	}
 
-	srcdoc := model.SrcDoc.ValueString()
-	if srcdoc != "" {
-		fields.Srcdoc = cm.NewOptString(srcdoc)
+	if !model.SrcDoc.IsUnknown() && !model.SrcDoc.IsNull() && model.SrcDoc.ValueString() != "" {
+		fields.Srcdoc = cm.NewOptString(model.SrcDoc.ValueString())
 	}
 
 	if model.FieldTypes != nil {
 		fieldTypes := make([]cm.ExtensionDataExtensionFieldTypesItem, 0, len(model.FieldTypes))
 
-		for _, fieldType := range model.FieldTypes {
-			fieldTypes = append(fieldTypes, AppDefinitionLocationFieldTypesItemToExtensionDataExtensionFieldTypesItem(fieldType))
+		for index, fieldType := range model.FieldTypes {
+			requestFieldType, fieldTypeDiags := appDefinitionLocationFieldTypeToExtensionDataExtensionFieldTypesItem(
+				fieldType,
+				path.AtName("field_types").AtListIndex(index),
+			)
+			diags.Append(fieldTypeDiags...)
+
+			if !fieldTypeDiags.HasError() {
+				fieldTypes = append(fieldTypes, requestFieldType)
+			}
 		}
 
 		fields.FieldTypes = fieldTypes
 	}
 
 	if model.Parameters != nil {
-		path := path.AtName("parameters")
+		parameters, parameterDiags := model.Parameters.ToAppDefinitionParameters(ctx, path.AtName("parameters"))
+		diags.Append(parameterDiags...)
 
-		parameters := cm.AppDefinitionParameters{}
-
-		if model.Parameters.Installation != nil {
-			path := path.AtName("installation")
-
-			installationParameters := make([]cm.AppDefinitionParameter, 0, len(model.Parameters.Installation))
-
-			for index, parameter := range model.Parameters.Installation {
-				path := path.AtListIndex(index)
-
-				installationParameter, parameterDiags := parameter.ToAppDefinitionParameter(ctx, path)
-				diags.Append(parameterDiags...)
-
-				installationParameters = append(installationParameters, installationParameter)
-			}
-
-			parameters.Installation = installationParameters
+		if !parameterDiags.HasError() {
+			fields.Parameters.SetTo(parameters)
 		}
+	}
 
-		if model.Parameters.Instance != nil {
-			path := path.AtName("instance")
-
-			instanceParameters := make([]cm.AppDefinitionParameter, 0, len(model.Parameters.Instance))
-
-			for index, parameter := range model.Parameters.Instance {
-				path := path.AtListIndex(index)
-
-				instanceParameter, parameterDiags := parameter.ToAppDefinitionParameter(ctx, path)
-				diags.Append(parameterDiags...)
-
-				instanceParameters = append(instanceParameters, instanceParameter)
-			}
-
-			parameters.Instance = instanceParameters
-		}
-
-		fields.Parameters.SetTo(parameters)
+	if diags.HasError() {
+		return cm.ExtensionDataExtension{}, diags
 	}
 
 	return fields, diags
 }
 
-func AppDefinitionLocationFieldTypesItemToExtensionDataExtensionFieldTypesItem(
+func appDefinitionLocationFieldTypeToExtensionDataExtensionFieldTypesItem(
 	fieldType AppDefinitionLocationFieldTypesItem,
-) cm.ExtensionDataExtensionFieldTypesItem {
-	fieldTypesItem := cm.ExtensionDataExtensionFieldTypesItem{
-		Type:     fieldType.Type.ValueString(),
-		LinkType: cm.NewOptPointerString(fieldType.LinkType.ValueStringPointer()),
+	path path.Path,
+) (cm.ExtensionDataExtensionFieldTypesItem, diag.Diagnostics) {
+	requestFieldType, diags := appDefinitionLocationFieldTypeToRequest(fieldType, path)
+
+	if diags.HasError() {
+		return cm.ExtensionDataExtensionFieldTypesItem{}, diags
 	}
 
-	if fieldType.Items != nil {
+	fieldTypesItem := cm.ExtensionDataExtensionFieldTypesItem{
+		Type:     requestFieldType.Type,
+		LinkType: cm.NewOptPointerString(requestFieldType.LinkType),
+	}
+
+	if requestFieldType.Items != nil {
 		fieldTypesItem.Items.SetTo(cm.ExtensionDataExtensionFieldTypesItemItems{
-			Type:     fieldType.Items.Type.ValueString(),
-			LinkType: cm.NewOptPointerString(fieldType.Items.LinkType.ValueStringPointer()),
+			Type:     requestFieldType.Items.Type,
+			LinkType: cm.NewOptPointerString(requestFieldType.Items.LinkType),
 		})
 	}
 
-	return fieldTypesItem
+	return fieldTypesItem, diags
 }

--- a/internal/provider/extension_model_request_test.go
+++ b/internal/provider/extension_model_request_test.go
@@ -1,0 +1,256 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validExtensionRequestModel() ExtensionModel {
+	return ExtensionModel{
+		Extension: &ExtensionModelExtension{
+			Name:   types.StringValue("Extension"),
+			Src:    types.StringUnknown(),
+			SrcDoc: types.StringUnknown(),
+			FieldTypes: []AppDefinitionLocationFieldTypesItem{
+				{
+					Type:     types.StringValue("Array"),
+					LinkType: types.StringNull(),
+					Items: &AppDefinitionLocationFieldTypeItemsItem{
+						Type:     types.StringValue("Link"),
+						LinkType: types.StringNull(),
+					},
+				},
+			},
+			Sidebar: types.BoolValue(false),
+		},
+		Parameters: jsontypes.NewNormalizedUnknown(),
+	}
+}
+
+func TestExtensionRequestRejectsUnresolvedScalars(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		mutate       func(*ExtensionModel)
+		expectedPath string
+	}{
+		"unknown name": {
+			mutate:       func(model *ExtensionModel) { model.Extension.Name = types.StringUnknown() },
+			expectedPath: "extension.name",
+		},
+		"null name": {
+			mutate:       func(model *ExtensionModel) { model.Extension.Name = types.StringNull() },
+			expectedPath: "extension.name",
+		},
+		"unknown field type": {
+			mutate:       func(model *ExtensionModel) { model.Extension.FieldTypes[0].Type = types.StringUnknown() },
+			expectedPath: "extension.field_types[0].type",
+		},
+		"null field type": {
+			mutate:       func(model *ExtensionModel) { model.Extension.FieldTypes[0].Type = types.StringNull() },
+			expectedPath: "extension.field_types[0].type",
+		},
+		"unknown field link type": {
+			mutate:       func(model *ExtensionModel) { model.Extension.FieldTypes[0].LinkType = types.StringUnknown() },
+			expectedPath: "extension.field_types[0].link_type",
+		},
+		"unknown item type": {
+			mutate:       func(model *ExtensionModel) { model.Extension.FieldTypes[0].Items.Type = types.StringUnknown() },
+			expectedPath: "extension.field_types[0].items.type",
+		},
+		"null item type": {
+			mutate:       func(model *ExtensionModel) { model.Extension.FieldTypes[0].Items.Type = types.StringNull() },
+			expectedPath: "extension.field_types[0].items.type",
+		},
+		"unknown item link type": {
+			mutate:       func(model *ExtensionModel) { model.Extension.FieldTypes[0].Items.LinkType = types.StringUnknown() },
+			expectedPath: "extension.field_types[0].items.link_type",
+		},
+		"unknown sidebar": {
+			mutate:       func(model *ExtensionModel) { model.Extension.Sidebar = types.BoolUnknown() },
+			expectedPath: "extension.sidebar",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validExtensionRequestModel()
+			test.mutate(&model)
+
+			actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+			assert.Equal(t, cm.ExtensionData{}, actual)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestExtensionRequestFailsAtomically(t *testing.T) {
+	t.Parallel()
+
+	model := validExtensionRequestModel()
+	model.Extension.Name = types.StringUnknown()
+	model.Extension.FieldTypes[0].LinkType = types.StringUnknown()
+	model.Extension.FieldTypes[0].Items.Type = types.StringNull()
+	model.Extension.Sidebar = types.BoolUnknown()
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	assert.Equal(t, cm.ExtensionData{}, actual)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{
+		"extension.name",
+		"extension.sidebar",
+		"extension.field_types[0].link_type",
+		"extension.field_types[0].items.type",
+	}, attributeDiagnosticPaths(t, diags))
+}
+
+func TestExtensionRequestPreservesOptionalScalarPresence(t *testing.T) {
+	t.Parallel()
+
+	model := validExtensionRequestModel()
+	model.Extension.Name = types.StringValue("")
+	model.Extension.Src = types.StringValue("")
+	model.Extension.SrcDoc = types.StringValue("")
+	model.Extension.FieldTypes[0].LinkType = types.StringValue("")
+	model.Extension.FieldTypes[0].Items.LinkType = types.StringValue("")
+	model.Extension.Sidebar = types.BoolValue(false)
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Empty(t, actual.Extension.Name)
+	assert.False(t, actual.Extension.Src.IsSet())
+	assert.False(t, actual.Extension.Srcdoc.IsSet())
+	assert.Empty(t, requireOptString(t, actual.Extension.FieldTypes[0].LinkType))
+	items, ok := actual.Extension.FieldTypes[0].Items.Get()
+	require.True(t, ok)
+	assert.Empty(t, requireOptString(t, items.LinkType))
+
+	sidebar, ok := actual.Extension.Sidebar.Get()
+	require.True(t, ok)
+	assert.False(t, sidebar)
+}
+
+func TestExtensionRequestOmitsSchemaConsistentNulls(t *testing.T) {
+	t.Parallel()
+
+	model := validExtensionRequestModel()
+	model.Extension.Src = types.StringNull()
+	model.Extension.SrcDoc = types.StringNull()
+	model.Extension.Sidebar = types.BoolNull()
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.False(t, actual.Extension.Src.IsSet())
+	assert.False(t, actual.Extension.Srcdoc.IsSet())
+	assert.False(t, actual.Extension.Sidebar.IsSet())
+	assert.False(t, actual.Extension.FieldTypes[0].LinkType.IsSet())
+	items, ok := actual.Extension.FieldTypes[0].Items.Get()
+	require.True(t, ok)
+	assert.False(t, items.LinkType.IsSet())
+}
+
+func TestExtensionRequestPreservesKnownSources(t *testing.T) {
+	t.Parallel()
+
+	model := validExtensionRequestModel()
+	model.Extension.Src = types.StringValue("https://example.com")
+	model.Extension.SrcDoc = types.StringValue("<html></html>")
+	model.Parameters = jsontypes.NewNormalizedValue(`{"known":true}`)
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, "https://example.com", requireOptString(t, actual.Extension.Src))
+	assert.Equal(t, "<html></html>", requireOptString(t, actual.Extension.Srcdoc))
+	assert.JSONEq(t, `{"known":true}`, string(actual.Parameters))
+}
+
+func TestExtensionParameterListsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	model := ExtensionModel{
+		Extension: &ExtensionModelExtension{
+			Name: types.StringValue("Extension"),
+			Parameters: &AppDefinitionParameters{
+				Installation: []AppDefinitionParameter{
+					{
+						ID:      "known",
+						Default: jsontypes.NewNormalizedNull(),
+						Options: NewTypedListNull[jsontypes.Normalized](),
+					},
+				},
+				Instance: []AppDefinitionParameter{
+					{
+						ID:      "unresolved",
+						Default: jsontypes.NewNormalizedNull(),
+						Options: NewTypedList([]jsontypes.Normalized{jsontypes.NewNormalizedUnknown()}),
+					},
+				},
+			},
+		},
+		Parameters: jsontypes.NewNormalizedNull(),
+	}
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	assert.Equal(t, cm.ExtensionData{}, actual)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"extension.parameters.instance[0].options[0]"}, attributeDiagnosticPaths(t, diags))
+}
+
+func TestExtensionParameterListsPreserveNilAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	model := ExtensionModel{
+		Extension: &ExtensionModelExtension{
+			Name: types.StringValue("Extension"),
+			Parameters: &AppDefinitionParameters{
+				Installation: []AppDefinitionParameter{},
+				Instance:     nil,
+			},
+		},
+		Parameters: jsontypes.NewNormalizedNull(),
+	}
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+
+	parameters, ok := actual.Extension.Parameters.Get()
+	require.True(t, ok)
+	require.NotNil(t, parameters.Installation)
+	assert.Empty(t, parameters.Installation)
+	assert.Nil(t, parameters.Instance)
+}
+
+func TestExtensionOptionalComputedValuesCanRemainUnknown(t *testing.T) {
+	t.Parallel()
+
+	model := ExtensionModel{
+		Extension: &ExtensionModelExtension{
+			Name:   types.StringValue("Extension"),
+			Src:    types.StringUnknown(),
+			SrcDoc: types.StringUnknown(),
+		},
+		Parameters: jsontypes.NewNormalizedUnknown(),
+	}
+
+	actual, diags := model.ToExtensionData(t.Context(), path.Empty())
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.False(t, actual.Extension.Src.IsSet())
+	assert.False(t, actual.Extension.Srcdoc.IsSet())
+	assert.Nil(t, actual.Parameters)
+}


### PR DESCRIPTION
Stacked on #599.

## Summary
- reject unknown or null required App Definition and Extension request scalars at their exact Terraform paths
- reject unknown optional field link types and Extension sidebar values while preserving null omission, known empty strings, and known false
- share App-local field-type conversion across App Definition and Extension and fail both complete request aggregates closed
- reject unresolved parameter defaults, option collections, and option elements while preserving absent versus known-empty collections
- retain established omission semantics for Optional+Computed App Definition src/bundle and Extension parameters/src/srcdoc
- leave response conversion, schema, and remote-state reflection unchanged

## Validation
- focused App Definition and Extension request-conversion tests
- go test ./...
- go generate ./... (no generated diff)
- golangci-lint cache clean
- golangci-lint run (0 issues)