### PR TITLE
fix(list): reject unresolved configuration values

### DIFF
--- a/internal/provider/list_resource_content_type.go
+++ b/internal/provider/list_resource_content_type.go
@@ -45,10 +45,11 @@ func (r *contentTypeListResource) List(ctx context.Context, req list.ListRequest
 		return
 	}
 
-	params := cm.GetContentTypesParams{
-		SpaceID:       config.SpaceID.ValueString(),
-		EnvironmentID: config.EnvironmentID.ValueString(),
-		Order:         []string{"sys.id"},
+	params, paramsDiags := config.requestParams()
+	if paramsDiags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(paramsDiags)
+
+		return
 	}
 
 	stream.Results = paginateContentfulCollectionItemsAsListResults(ctx, req,

--- a/internal/provider/list_resource_content_type_config.go
+++ b/internal/provider/list_resource_content_type_config.go
@@ -3,13 +3,35 @@ package provider
 import (
 	"context"
 
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type contentTypeListResourceConfig struct {
 	SpaceID       types.String `tfsdk:"space_id"`
 	EnvironmentID types.String `tfsdk:"environment_id"`
+}
+
+func (c contentTypeListResourceConfig) requestParams() (cm.GetContentTypesParams, diag.Diagnostics) {
+	spaceID, spaceIDDiags := knownListResourceString(path.Root("space_id"), c.SpaceID)
+	environmentID, environmentIDDiags := knownListResourceString(path.Root("environment_id"), c.EnvironmentID)
+
+	diags := diag.Diagnostics{}
+	diags.Append(spaceIDDiags...)
+	diags.Append(environmentIDDiags...)
+
+	if diags.HasError() {
+		return cm.GetContentTypesParams{}, diags
+	}
+
+	return cm.GetContentTypesParams{
+		SpaceID:       spaceID,
+		EnvironmentID: environmentID,
+		Order:         []string{"sys.id"},
+	}, diags
 }
 
 func ContentTypeListResourceConfigSchema(_ context.Context) listschema.Schema {

--- a/internal/provider/list_resource_entry.go
+++ b/internal/provider/list_resource_entry.go
@@ -47,34 +47,18 @@ func (r *entryListResource) List(ctx context.Context, req list.ListRequest, stre
 		return
 	}
 
-	params := cm.GetEntriesParams{
-		SpaceID:       config.SpaceID.ValueString(),
-		EnvironmentID: config.EnvironmentID.ValueString(),
-	}
+	request, requestDiags := config.request()
+	if requestDiags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(requestDiags)
 
-	configContentType := config.ContentType.ValueString()
-	if configContentType != "" {
-		params.ContentType.SetTo(configContentType)
-	}
-
-	configOrder := config.Order.Elements()
-	if configOrder != nil {
-		order := make([]string, 0, len(configOrder))
-		for _, orderElement := range configOrder {
-			orderElementString := orderElement.ValueString()
-			if orderElementString != "" {
-				order = append(order, orderElementString)
-			}
-		}
-
-		params.Order = order
+		return
 	}
 
 	getEntriesQueryOption := cm.WithEditRequest(func(req *http.Request) error {
 		urlQuery := req.URL.Query()
 
-		for key, value := range config.Query.Elements() {
-			setEntryListQueryParam(urlQuery, key, value.ValueString())
+		for key, value := range request.query {
+			setEntryListQueryParam(urlQuery, key, value)
 		}
 
 		req.URL.RawQuery = urlQuery.Encode()
@@ -85,7 +69,7 @@ func (r *entryListResource) List(ctx context.Context, req list.ListRequest, stre
 	stream.Results = paginateContentfulCollectionItemsAsListResults(ctx, req,
 		"Failed to list entries",
 		func(ctx context.Context, skip int64, limit int64) (cm.GetEntriesRes, error) {
-			pageParams := params
+			pageParams := request.params
 			pageParams.Skip = cm.NewOptInt64(skip)
 			pageParams.Limit = cm.NewOptInt64(limit)
 

--- a/internal/provider/list_resource_entry_config.go
+++ b/internal/provider/list_resource_entry_config.go
@@ -3,7 +3,10 @@ package provider
 import (
 	"context"
 
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -13,6 +16,56 @@ type entryListResourceConfig struct {
 	ContentType   types.String            `tfsdk:"content_type"`
 	Order         TypedList[types.String] `tfsdk:"order"`
 	Query         TypedMap[types.String]  `tfsdk:"query"`
+}
+
+type entryListResourceRequest struct {
+	params cm.GetEntriesParams
+	query  map[string]string
+}
+
+func (c entryListResourceConfig) request() (entryListResourceRequest, diag.Diagnostics) {
+	spaceID, spaceIDDiags := knownListResourceString(path.Root("space_id"), c.SpaceID)
+	environmentID, environmentIDDiags := knownListResourceString(path.Root("environment_id"), c.EnvironmentID)
+	contentType, contentTypePresent, contentTypeDiags := knownOptionalListResourceString(path.Root("content_type"), c.ContentType)
+	order, orderDiags := knownOptionalListResourceStringList(path.Root("order"), c.Order)
+	query, queryDiags := knownOptionalListResourceStringMap(path.Root("query"), c.Query)
+
+	if order != nil {
+		filteredOrder := make([]string, 0, len(order))
+		for _, value := range order {
+			if value != "" {
+				filteredOrder = append(filteredOrder, value)
+			}
+		}
+
+		order = filteredOrder
+	}
+
+	diags := diag.Diagnostics{}
+	diags.Append(spaceIDDiags...)
+	diags.Append(environmentIDDiags...)
+	diags.Append(contentTypeDiags...)
+	diags.Append(orderDiags...)
+	diags.Append(queryDiags...)
+
+	if diags.HasError() {
+		return entryListResourceRequest{}, diags
+	}
+
+	request := entryListResourceRequest{
+		params: cm.GetEntriesParams{
+			SpaceID:       spaceID,
+			EnvironmentID: environmentID,
+			Order:         order,
+		},
+		query: query,
+	}
+
+	if contentTypePresent && contentType != "" {
+		request.params.ContentType.SetTo(contentType)
+	}
+
+	return request, diags
 }
 
 func EntryListResourceConfigSchema(ctx context.Context) listschema.Schema {

--- a/internal/provider/list_resource_request.go
+++ b/internal/provider/list_resource_request.go
@@ -1,0 +1,128 @@
+package provider
+
+import (
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func knownListResourceString(valuePath path.Path, value types.String) (string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown list configuration value",
+			"The string value must be known before Contentful resources can be listed.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null list configuration value",
+			"The string value cannot be null when Contentful resources are listed.",
+		)
+	default:
+		return value.ValueString(), diags
+	}
+
+	return "", diags
+}
+
+func knownOptionalListResourceString(valuePath path.Path, value types.String) (string, bool, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown list configuration value",
+			"The string value must be known before Contentful resources can be listed.",
+		)
+
+		return "", false, diags
+	}
+
+	if value.IsNull() {
+		return "", false, diags
+	}
+
+	return value.ValueString(), true, diags
+}
+
+func knownOptionalListResourceStringList(valuePath path.Path, value TypedList[types.String]) ([]string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown list configuration value",
+			"The list must be known before Contentful resources can be listed.",
+		)
+
+		return nil, diags
+	}
+
+	if value.IsNull() {
+		return nil, diags
+	}
+
+	return knownStringListElements(valuePath, value.Elements())
+}
+
+func knownOptionalListResourceStringMap(valuePath path.Path, value TypedMap[types.String]) (map[string]string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown list configuration value",
+			"The map must be known before Contentful resources can be listed.",
+		)
+
+		return nil, diags
+	}
+
+	if value.IsNull() {
+		return nil, diags
+	}
+
+	elements := value.Elements()
+
+	keys := make([]string, 0, len(elements))
+	for key := range elements {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	values := make(map[string]string, len(elements))
+	for _, key := range keys {
+		element := elements[key]
+		elementPath := valuePath.AtMapKey(key)
+
+		switch {
+		case element.IsUnknown():
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected unknown list configuration value",
+				"The map value must be known before Contentful resources can be listed.",
+			)
+		case element.IsNull():
+			diags.AddAttributeError(
+				elementPath,
+				"Unexpected null list configuration value",
+				"The map value cannot be null when Contentful resources are listed.",
+			)
+		default:
+			values[key] = element.ValueString()
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return values, diags
+}

--- a/internal/provider/list_resource_request_test.go
+++ b/internal/provider/list_resource_request_test.go
@@ -1,0 +1,258 @@
+//nolint:testpackage // List request conversion is intentionally tested through its package-private boundary.
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContentTypeListResourceConfigRequestParamsRejectsUnresolvedValues(t *testing.T) {
+	t.Parallel()
+
+	params, diags := (contentTypeListResourceConfig{
+		SpaceID:       types.StringUnknown(),
+		EnvironmentID: types.StringNull(),
+	}).requestParams()
+
+	assert.Empty(t, params)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"space_id", "environment_id"}, requestDiagnosticPaths(t, diags))
+}
+
+func TestContentTypeListResourceListReturnsConfigurationDiagnosticsOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	configSchema := ContentTypeListResourceConfigSchema(ctx)
+	config := tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"space_id":       tftypes.String,
+				"environment_id": tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"space_id":       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			"environment_id": tftypes.NewValue(tftypes.String, "environment"),
+		}),
+		Schema: configSchema,
+	}
+
+	var stream list.ListResultsStream
+	(&contentTypeListResource{}).List(ctx, list.ListRequest{Config: config}, &stream)
+
+	result := requireSingleDiagnosticOnlyListResult(t, stream)
+	assert.Equal(t, []string{"space_id"}, requestDiagnosticPaths(t, result.Diagnostics))
+}
+
+func TestEntryListResourceConfigRequestRejectsUnresolvedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		configure           func(*entryListResourceConfig)
+		expectedDiagnostics []string
+	}{
+		"required identifiers": {
+			configure: func(config *entryListResourceConfig) {
+				config.SpaceID = types.StringUnknown()
+				config.EnvironmentID = types.StringNull()
+			},
+			expectedDiagnostics: []string{"space_id", "environment_id"},
+		},
+		"content type": {
+			configure: func(config *entryListResourceConfig) {
+				config.ContentType = types.StringUnknown()
+			},
+			expectedDiagnostics: []string{"content_type"},
+		},
+		"order container": {
+			configure: func(config *entryListResourceConfig) {
+				config.Order = NewTypedListUnknown[types.String]()
+			},
+			expectedDiagnostics: []string{"order"},
+		},
+		"order elements": {
+			configure: func(config *entryListResourceConfig) {
+				config.Order = NewTypedList([]types.String{
+					types.StringValue("sys.createdAt"),
+					types.StringNull(),
+					types.StringUnknown(),
+				})
+			},
+			expectedDiagnostics: []string{"order[1]", "order[2]"},
+		},
+		"query container": {
+			configure: func(config *entryListResourceConfig) {
+				config.Query = NewTypedMapUnknown[types.String]()
+			},
+			expectedDiagnostics: []string{"query"},
+		},
+		"query values": {
+			configure: func(config *entryListResourceConfig) {
+				config.Query = NewTypedMap(map[string]types.String{
+					"null":    types.StringNull(),
+					"unknown": types.StringUnknown(),
+				})
+			},
+			expectedDiagnostics: []string{`query["null"]`, `query["unknown"]`},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			config := validEntryListResourceConfig()
+			test.configure(&config)
+
+			request, diags := config.request()
+
+			assert.Empty(t, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedDiagnostics, requestDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestEntryListResourceConfigRequestPreservesExistingOptionalSemantics(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		configure           func(*entryListResourceConfig)
+		expectedContentType string
+		expectedOrder       []string
+		expectedQuery       map[string]string
+	}{
+		"null values are omitted": {
+			configure: func(_ *entryListResourceConfig) {},
+		},
+		"known empty containers remain empty": {
+			configure: func(config *entryListResourceConfig) {
+				config.Order = NewTypedList([]types.String{})
+				config.Query = NewTypedMap(map[string]types.String{})
+			},
+			expectedOrder: []string{},
+			expectedQuery: map[string]string{},
+		},
+		"empty content type and order elements remain omitted": {
+			configure: func(config *entryListResourceConfig) {
+				config.ContentType = types.StringValue("")
+				config.Order = NewTypedList([]types.String{
+					types.StringValue(""),
+					types.StringValue("sys.createdAt"),
+					types.StringValue(""),
+				})
+			},
+			expectedOrder: []string{"sys.createdAt"},
+		},
+		"known values are preserved": {
+			configure: func(config *entryListResourceConfig) {
+				config.ContentType = types.StringValue("author")
+				config.Query = NewTypedMap(map[string]types.String{
+					"fields.name[match]": types.StringValue(""),
+				})
+			},
+			expectedContentType: "author",
+			expectedQuery: map[string]string{
+				"fields.name[match]": "",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			config := validEntryListResourceConfig()
+			test.configure(&config)
+
+			request, diags := config.request()
+
+			require.False(t, diags.HasError(), diags.Errors())
+			assert.Equal(t, test.expectedOrder, request.params.Order)
+			assert.Equal(t, test.expectedQuery, request.query)
+
+			contentType, contentTypeSet := request.params.ContentType.Get()
+			if test.expectedContentType == "" {
+				assert.False(t, contentTypeSet)
+			} else {
+				require.True(t, contentTypeSet)
+				assert.Equal(t, test.expectedContentType, contentType)
+			}
+		})
+	}
+}
+
+func TestEntryListResourceListReturnsConfigurationDiagnosticsOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	config := entryListResourceTerraformConfig(ctx, tftypes.NewValue(tftypes.String, tftypes.UnknownValue))
+
+	var stream list.ListResultsStream
+	(&entryListResource{}).List(ctx, list.ListRequest{Config: config}, &stream)
+
+	result := requireSingleDiagnosticOnlyListResult(t, stream)
+	assert.Equal(t, []string{"content_type"}, requestDiagnosticPaths(t, result.Diagnostics))
+}
+
+func validEntryListResourceConfig() entryListResourceConfig {
+	return entryListResourceConfig{
+		SpaceID:       types.StringValue("space"),
+		EnvironmentID: types.StringValue("environment"),
+		ContentType:   types.StringNull(),
+		Order:         NewTypedListNull[types.String](),
+		Query:         NewTypedMapNull[types.String](),
+	}
+}
+
+func entryListResourceTerraformConfig(ctx context.Context, contentType tftypes.Value) tfsdk.Config {
+	listType := tftypes.List{ElementType: tftypes.String}
+	mapType := tftypes.Map{ElementType: tftypes.String}
+
+	return tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"space_id":       tftypes.String,
+				"environment_id": tftypes.String,
+				"content_type":   tftypes.String,
+				"order":          listType,
+				"query":          mapType,
+			},
+		}, map[string]tftypes.Value{
+			"space_id":       tftypes.NewValue(tftypes.String, "space"),
+			"environment_id": tftypes.NewValue(tftypes.String, "environment"),
+			"content_type":   contentType,
+			"order":          tftypes.NewValue(listType, nil),
+			"query":          tftypes.NewValue(mapType, nil),
+		}),
+		Schema: EntryListResourceConfigSchema(ctx),
+	}
+}
+
+func requireSingleDiagnosticOnlyListResult(t *testing.T, stream list.ListResultsStream) list.ListResult {
+	t.Helper()
+
+	var results []list.ListResult
+
+	stream.Results(func(result list.ListResult) bool {
+		results = append(results, result)
+
+		return true
+	})
+
+	require.Len(t, results, 1)
+	result := results[0]
+	require.True(t, result.Diagnostics.HasError())
+	assert.Nil(t, result.Identity)
+	assert.Nil(t, result.Resource)
+	assert.Empty(t, result.DisplayName)
+
+	return result
+}


### PR DESCRIPTION
## Summary
- validate Content Type and Entry list configuration before the first Contentful request
- report unknown and invalid null values at their exact Terraform paths and emit diagnostics-only list output
- preserve existing optional-value behavior while distinguishing null, unknown, and known-empty collections

## Validation
- go test ./...
- go generate ./...
- golangci-lint cache clean
- golangci-lint run

## Stack
- depends on #599