### PR TITLE
fix(content-type): reject unresolved field request values

### DIFF
--- a/internal/provider/content_type_metadata_request_test.go
+++ b/internal/provider/content_type_metadata_request_test.go
@@ -24,21 +24,32 @@ func TestContentTypeMetadataRequestSerialization(t *testing.T) {
 	}{
 		"absent metadata": {
 			metadata: NewTypedObjectNull[ContentTypeMetadataValue](),
-			expected: `{"name":"Test","description":null,"displayField":"title","fields":[]}`,
+			expected: `{"name":"Test","description":"A test content type","displayField":"title","fields":[]}`,
+		},
+		"unresolved computed metadata": {
+			metadata: NewTypedObjectUnknown[ContentTypeMetadataValue](),
+			expected: `{"name":"Test","description":"A test content type","displayField":"title","fields":[]}`,
 		},
 		"annotations with taxonomy omitted": {
 			metadata: NewTypedObject(ContentTypeMetadataValue{
 				Annotations: NewNormalizedJSONTypesNormalizedValue([]byte(`{"ContentType":[]}`)),
 				Taxonomy:    NewTypedListNull[TypedObject[ContentTypeMetadataTaxonomyItemValue]](),
 			}),
-			expected: `{"name":"Test","description":null,"displayField":"title","fields":[],"metadata":{"annotations":{"ContentType":[]}}}`,
+			expected: `{"name":"Test","description":"A test content type","displayField":"title","fields":[],"metadata":{"annotations":{"ContentType":[]}}}`,
+		},
+		"annotations with unresolved computed taxonomy": {
+			metadata: NewTypedObject(ContentTypeMetadataValue{
+				Annotations: NewNormalizedJSONTypesNormalizedValue([]byte(`{"ContentType":[]}`)),
+				Taxonomy:    NewTypedListUnknown[TypedObject[ContentTypeMetadataTaxonomyItemValue]](),
+			}),
+			expected: `{"name":"Test","description":"A test content type","displayField":"title","fields":[],"metadata":{"annotations":{"ContentType":[]}}}`,
 		},
 		"empty taxonomy": {
 			metadata: NewTypedObject(ContentTypeMetadataValue{
 				Annotations: jsontypes.NewNormalizedNull(),
 				Taxonomy:    NewTypedList([]TypedObject[ContentTypeMetadataTaxonomyItemValue]{}),
 			}),
-			expected: `{"name":"Test","description":null,"displayField":"title","fields":[],"metadata":{"taxonomy":[]}}`,
+			expected: `{"name":"Test","description":"A test content type","displayField":"title","fields":[],"metadata":{"taxonomy":[]}}`,
 		},
 		"populated taxonomy": {
 			metadata: NewTypedObject(ContentTypeMetadataValue{
@@ -50,7 +61,7 @@ func TestContentTypeMetadataRequestSerialization(t *testing.T) {
 					}),
 				}),
 			}),
-			expected: `{"name":"Test","description":null,"displayField":"title","fields":[],"metadata":{"taxonomy":[{"sys":{"type":"Link","id":"furniture","linkType":"TaxonomyConceptScheme"},"required":true}]}}`,
+			expected: `{"name":"Test","description":"A test content type","displayField":"title","fields":[],"metadata":{"taxonomy":[{"sys":{"type":"Link","id":"furniture","linkType":"TaxonomyConceptScheme"},"required":true}]}}`,
 		},
 	}
 
@@ -60,6 +71,7 @@ func TestContentTypeMetadataRequestSerialization(t *testing.T) {
 
 			model := ContentTypeModel{
 				Name:         types.StringValue("Test"),
+				Description:  types.StringValue("A test content type"),
 				DisplayField: types.StringValue("title"),
 				Fields:       NewTypedList([]TypedObject[ContentTypeFieldValue]{}),
 				Metadata:     test.metadata,

--- a/internal/provider/content_type_model_request.go
+++ b/internal/provider/content_type_model_request.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
-	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
 	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const contentfulEntryAllowedResourceType = "Contentful:Entry"
@@ -17,171 +17,323 @@ const contentfulEntryAllowedResourceType = "Contentful:Entry"
 func (m *ContentTypeModel) ToContentTypeRequestData(ctx context.Context) (cm.ContentTypeRequestData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	request := cm.ContentTypeRequestData{
-		Name:         m.Name.ValueString(),
-		Description:  cm.NewOptNilPointerString(m.Description.ValueStringPointer()),
-		DisplayField: m.DisplayField.ValueString(),
-	}
+	name, nameDiags := contentTypeRequiredString(m.Name, path.Root("name"))
+	diags.Append(nameDiags...)
+
+	description, descriptionDiags := contentTypeRequiredString(m.Description, path.Root("description"))
+	diags.Append(descriptionDiags...)
+
+	displayField, displayFieldDiags := contentTypeRequiredString(m.DisplayField, path.Root("display_field"))
+	diags.Append(displayFieldDiags...)
 
 	fields, fieldsDiags := FieldsListToContentTypeRequestDataFields(ctx, path.Root("fields"), m.Fields)
 	diags.Append(fieldsDiags...)
 
-	request.Fields = fields
-
 	metadata, metadataDiags := ToOptContentTypeMetadata(ctx, path.Root("metadata"), m.Metadata)
 	diags.Append(metadataDiags...)
 
-	request.Metadata = metadata
+	if diags.HasError() {
+		return cm.ContentTypeRequestData{}, diags
+	}
 
-	return request, diags
+	return cm.ContentTypeRequestData{
+		Name:         name,
+		Description:  cm.NewOptNilString(description),
+		DisplayField: displayField,
+		Fields:       fields,
+		Metadata:     metadata,
+	}, diags
 }
 
-func FieldsListToContentTypeRequestDataFields(ctx context.Context, path path.Path, fieldsList TypedList[TypedObject[ContentTypeFieldValue]]) ([]cm.ContentTypeRequestDataFieldsItem, diag.Diagnostics) {
+func FieldsListToContentTypeRequestDataFields(
+	ctx context.Context,
+	valuePath path.Path,
+	fieldsList TypedList[TypedObject[ContentTypeFieldValue]],
+) ([]cm.ContentTypeRequestDataFieldsItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	fieldsValues := fieldsList.Elements()
-
-	fieldsItems := make([]cm.ContentTypeRequestDataFieldsItem, len(fieldsValues))
-
-	for index, fieldsValue := range fieldsValues {
-		path := path.AtListIndex(index)
-
-		fieldsItem, fieldsItemDiags := ToContentTypeRequestDataFieldsItem(ctx, path, fieldsValue.Value())
-		diags.Append(fieldsItemDiags...)
-
-		fieldsItems[index] = fieldsItem
+	switch {
+	case fieldsList.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown content type fields",
+			"Content type fields must be known before they can be sent to Contentful.",
+		)
+	case fieldsList.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null content type fields",
+			"Content type fields are required.",
+		)
 	}
 
-	return fieldsItems, diags
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return convertKnownObjectListElements(ctx, valuePath, fieldsList.Elements(), ToContentTypeRequestDataFieldsItem)
 }
 
-func ToContentTypeRequestDataFieldsItem(ctx context.Context, path path.Path, v ContentTypeFieldValue) (cm.ContentTypeRequestDataFieldsItem, diag.Diagnostics) {
+func ToContentTypeRequestDataFieldsItem(
+	ctx context.Context,
+	valuePath path.Path,
+	v ContentTypeFieldValue,
+) (cm.ContentTypeRequestDataFieldsItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	fieldsItemItems, fieldsItemItemsDiags := ItemsObjectToOptContentTypeRequestDataFieldsItemItems(ctx, path.AtName("items"), v.Items)
-	diags.Append(fieldsItemItemsDiags...)
+	fieldID, idDiags := contentTypeRequiredString(v.ID, valuePath.AtName("id"))
+	diags.Append(idDiags...)
 
-	fieldsItemValidations, fieldsItemValidationsDiags := ValidationsListToContentTypeRequestDataFieldValidations(ctx, path.AtName("validations"), v.Validations)
-	diags.Append(fieldsItemValidationsDiags...)
+	name, nameDiags := contentTypeRequiredString(v.Name, valuePath.AtName("name"))
+	diags.Append(nameDiags...)
 
-	fieldsItem := cm.ContentTypeRequestDataFieldsItem{
-		ID:          v.ID.ValueString(),
-		Name:        v.Name.ValueString(),
-		Type:        v.FieldType.ValueString(),
-		LinkType:    util.StringValueToOptString(v.LinkType),
-		Items:       fieldsItemItems,
-		Validations: fieldsItemValidations,
-		Disabled:    util.BoolValueToOptBool(v.Disabled),
-		Omitted:     util.BoolValueToOptBool(v.Omitted),
-		Required:    util.BoolValueToOptBool(v.Required),
-		Localized:   util.BoolValueToOptBool(v.Localized),
+	fieldType, fieldTypeDiags := contentTypeRequiredString(v.FieldType, valuePath.AtName("type"))
+	diags.Append(fieldTypeDiags...)
+
+	localized, localizedDiags := contentTypeRequiredBool(v.Localized, valuePath.AtName("localized"))
+	diags.Append(localizedDiags...)
+
+	required, requiredDiags := contentTypeRequiredBool(v.Required, valuePath.AtName("required"))
+	diags.Append(requiredDiags...)
+
+	linkType, linkTypeDiags := contentTypeOptionalString(v.LinkType, valuePath.AtName("link_type"))
+	diags.Append(linkTypeDiags...)
+
+	disabled, disabledDiags := contentTypeOptionalBool(v.Disabled, valuePath.AtName("disabled"))
+	diags.Append(disabledDiags...)
+
+	omitted, omittedDiags := contentTypeOptionalBool(v.Omitted, valuePath.AtName("omitted"))
+	diags.Append(omittedDiags...)
+
+	items, itemsDiags := ItemsObjectToOptContentTypeRequestDataFieldsItemItems(ctx, valuePath.AtName("items"), v.Items)
+	diags.Append(itemsDiags...)
+
+	validations, validationsDiags := ValidationsListToContentTypeRequestDataFieldValidations(ctx, valuePath.AtName("validations"), v.Validations)
+	diags.Append(validationsDiags...)
+
+	defaultValue := jx.Raw(nil)
+
+	if v.DefaultValue.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath.AtName("default_value"),
+			"Unexpected unknown default value",
+			"The content type field default value must be known before it can be sent to Contentful.",
+		)
+	} else if !v.DefaultValue.IsNull() {
+		defaultValue = jx.Raw(v.DefaultValue.ValueString())
 	}
 
-	modelDefaultValueValue := v.DefaultValue.ValueString()
-	if modelDefaultValueValue != "" {
-		fieldsItem.DefaultValue = []byte(modelDefaultValueValue)
+	allowedResources := cm.OptNilResourceLinkArray{}
+
+	if v.AllowedResources.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath.AtName("allowed_resources"),
+			"Unexpected unknown allowed resources",
+			"Allowed resources must be known before they can be sent to Contentful.",
+		)
+	} else if !v.AllowedResources.IsNull() {
+		resourceLinks, resourceLinkDiags := AllowedResourceListToContentTypeRequestDataFieldAllowedResources(
+			ctx,
+			valuePath.AtName("allowed_resources"),
+			v.AllowedResources,
+		)
+		diags.Append(resourceLinkDiags...)
+
+		if !resourceLinkDiags.HasError() {
+			allowedResources.SetTo(resourceLinks)
+		}
 	}
 
-	if !v.AllowedResources.IsUnknown() && !v.AllowedResources.IsNull() {
-		fieldsItemAllowedResources, fieldsItemAllowedResourcesDiags := AllowedResourceListToContentTypeRequestDataFieldAllowedResources(ctx, path.AtName("allowed_resources"), v.AllowedResources)
-		diags.Append(fieldsItemAllowedResourcesDiags...)
-
-		fieldsItem.AllowedResources.SetTo(fieldsItemAllowedResources)
+	if diags.HasError() {
+		return cm.ContentTypeRequestDataFieldsItem{}, diags
 	}
 
-	return fieldsItem, diags
+	return cm.ContentTypeRequestDataFieldsItem{
+		ID:               fieldID,
+		Name:             name,
+		Type:             fieldType,
+		LinkType:         linkType,
+		Items:            items,
+		Localized:        cm.NewOptBool(localized),
+		Omitted:          omitted,
+		Required:         cm.NewOptBool(required),
+		Disabled:         disabled,
+		DefaultValue:     defaultValue,
+		Validations:      validations,
+		AllowedResources: allowedResources,
+	}, diags
 }
 
-func ItemsObjectToOptContentTypeRequestDataFieldsItemItems(ctx context.Context, path path.Path, itemsObject TypedObject[ContentTypeFieldItemsValue]) (cm.OptContentTypeRequestDataFieldsItemItems, diag.Diagnostics) {
+func ItemsObjectToOptContentTypeRequestDataFieldsItemItems(
+	ctx context.Context,
+	valuePath path.Path,
+	itemsObject TypedObject[ContentTypeFieldItemsValue],
+) (cm.OptContentTypeRequestDataFieldsItemItems, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	fieldsItemItems := cm.OptContentTypeRequestDataFieldsItemItems{}
+	if itemsObject.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown content type field items",
+			"Content type field items must be known before they can be sent to Contentful.",
+		)
 
-	itemsValue, itemsValueOk := itemsObject.GetValue()
-	if itemsValueOk {
-		items, itemsDiags := itemsValue.ToContentTypeRequestDataFieldsItemItems(ctx, path)
-		diags.Append(itemsDiags...)
-
-		fieldsItemItems.SetTo(items)
+		return cm.OptContentTypeRequestDataFieldsItemItems{}, diags
 	}
 
-	return fieldsItemItems, diags
+	itemsValue, ok := itemsObject.GetValue()
+	if !ok {
+		return cm.OptContentTypeRequestDataFieldsItemItems{}, diags
+	}
+
+	items, itemsDiags := itemsValue.ToContentTypeRequestDataFieldsItemItems(ctx, valuePath)
+	diags.Append(itemsDiags...)
+
+	if diags.HasError() {
+		return cm.OptContentTypeRequestDataFieldsItemItems{}, diags
+	}
+
+	return cm.NewOptContentTypeRequestDataFieldsItemItems(items), diags
 }
 
-func (v ContentTypeFieldItemsValue) ToContentTypeRequestDataFieldsItemItems(ctx context.Context, path path.Path) (cm.ContentTypeRequestDataFieldsItemItems, diag.Diagnostics) {
+func (v ContentTypeFieldItemsValue) ToContentTypeRequestDataFieldsItemItems(
+	ctx context.Context,
+	valuePath path.Path,
+) (cm.ContentTypeRequestDataFieldsItemItems, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	itemsValidations, itemsValidationsDiags := ValidationsListToContentTypeRequestDataFieldValidations(ctx, path.AtName("validations"), v.Validations)
-	diags.Append(itemsValidationsDiags...)
+	itemsType, itemsTypeDiags := contentTypeRequiredString(v.ItemsType, valuePath.AtName("type"))
+	diags.Append(itemsTypeDiags...)
 
-	items := cm.ContentTypeRequestDataFieldsItemItems{
-		Type:        util.StringValueToOptString(v.ItemsType),
-		LinkType:    util.StringValueToOptString(v.LinkType),
-		Validations: itemsValidations,
+	linkType, linkTypeDiags := contentTypeOptionalString(v.LinkType, valuePath.AtName("link_type"))
+	diags.Append(linkTypeDiags...)
+
+	validations, validationsDiags := ValidationsListToContentTypeRequestDataFieldValidations(ctx, valuePath.AtName("validations"), v.Validations)
+	diags.Append(validationsDiags...)
+
+	if diags.HasError() {
+		return cm.ContentTypeRequestDataFieldsItemItems{}, diags
 	}
 
-	return items, diags
+	return cm.ContentTypeRequestDataFieldsItemItems{
+		Type:        cm.NewOptString(itemsType),
+		LinkType:    linkType,
+		Validations: validations,
+	}, diags
 }
 
-func ValidationsListToContentTypeRequestDataFieldValidations(ctx context.Context, _ path.Path, validationsList TypedList[jsontypes.Normalized]) ([]jx.Raw, diag.Diagnostics) {
+func ValidationsListToContentTypeRequestDataFieldValidations(
+	_ context.Context,
+	valuePath path.Path,
+	validationsList TypedList[jsontypes.Normalized],
+) ([]jx.Raw, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	validationsStrings := []string{}
-	if !validationsList.IsNull() && !validationsList.IsUnknown() {
-		diags.Append(tfsdk.ValueAs(ctx, validationsList, &validationsStrings)...)
+	if validationsList.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown content type field validations",
+			"Content type field validations must be known before they can be sent to Contentful.",
+		)
+
+		return nil, diags
 	}
 
-	validations := make([]jx.Raw, len(validationsStrings))
-	for index, validationsString := range validationsStrings {
-		validations[index] = jx.Raw(validationsString)
+	if validationsList.IsNull() {
+		return []jx.Raw{}, diags
+	}
+
+	validations := make([]jx.Raw, 0, len(validationsList.Elements()))
+	for index, validation := range validationsList.Elements() {
+		validationPath := valuePath.AtListIndex(index)
+
+		switch {
+		case validation.IsUnknown():
+			diags.AddAttributeError(
+				validationPath,
+				"Unexpected unknown content type field validation",
+				"The validation must be known before it can be sent to Contentful.",
+			)
+		case validation.IsNull():
+			diags.AddAttributeError(
+				validationPath,
+				"Unexpected null content type field validation",
+				"Null validations cannot be sent to Contentful.",
+			)
+		default:
+			validations = append(validations, jx.Raw(validation.ValueString()))
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return validations, diags
 }
 
-func AllowedResourceListToContentTypeRequestDataFieldAllowedResources(ctx context.Context, path path.Path, allowedResourcesList TypedList[TypedObject[ContentTypeFieldAllowedResourceItemValue]]) ([]cm.ResourceLink, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	allowedResources := allowedResourcesList.Elements()
-	resourceLinks := make([]cm.ResourceLink, len(allowedResources))
-
-	for index, resource := range allowedResources {
-		resourceLink, resourceDiags := resource.Value().ToResourceLink(ctx, path.AtListIndex(index))
-		diags.Append(resourceDiags...)
-
-		resourceLinks[index] = resourceLink
+func AllowedResourceListToContentTypeRequestDataFieldAllowedResources(
+	ctx context.Context,
+	valuePath path.Path,
+	allowedResourcesList TypedList[TypedObject[ContentTypeFieldAllowedResourceItemValue]],
+) ([]cm.ResourceLink, diag.Diagnostics) {
+	if allowedResourcesList.IsUnknown() {
+		return nil, diag.Diagnostics{diag.NewAttributeErrorDiagnostic(
+			valuePath,
+			"Unexpected unknown allowed resources",
+			"Allowed resources must be known before they can be sent to Contentful.",
+		)}
 	}
 
-	return resourceLinks, diags
+	if allowedResourcesList.IsNull() {
+		return nil, nil
+	}
+
+	return convertKnownObjectListElements(
+		ctx,
+		valuePath,
+		allowedResourcesList.Elements(),
+		func(ctx context.Context, resourcePath path.Path, value ContentTypeFieldAllowedResourceItemValue) (cm.ResourceLink, diag.Diagnostics) {
+			return value.ToResourceLink(ctx, resourcePath)
+		},
+	)
 }
 
-func (v ContentTypeFieldAllowedResourceItemValue) ToResourceLink(ctx context.Context, path path.Path) (cm.ResourceLink, diag.Diagnostics) {
+func (v ContentTypeFieldAllowedResourceItemValue) ToResourceLink(
+	ctx context.Context,
+	valuePath path.Path,
+) (cm.ResourceLink, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
-
 	resourceLink := cm.ResourceLink{}
 
-	if !v.External.IsNull() && !v.External.IsUnknown() {
-		diags.Append(v.External.Value().SetResourceLink(ctx, path, &resourceLink)...)
+	if external, ok := v.External.GetValue(); ok {
+		diags.Append(external.SetResourceLink(ctx, valuePath.AtName("external"), &resourceLink)...)
 	}
 
-	if !v.ContentfulEntry.IsNull() && !v.ContentfulEntry.IsUnknown() {
-		diags.Append(v.ContentfulEntry.Value().SetResourceLink(ctx, path, &resourceLink)...)
+	if contentfulEntry, ok := v.ContentfulEntry.GetValue(); ok {
+		diags.Append(contentfulEntry.SetResourceLink(ctx, valuePath.AtName("contentful_entry"), &resourceLink)...)
 	}
 
 	return resourceLink, diags
 }
 
-func (v ContentTypeFieldAllowedResourceItemExternalValue) SetResourceLink(_ context.Context, _ path.Path, resourceLink *cm.ResourceLink) diag.Diagnostics {
-	diags := diag.Diagnostics{}
-
+func (v ContentTypeFieldAllowedResourceItemExternalValue) SetResourceLink(
+	_ context.Context,
+	_ path.Path,
+	resourceLink *cm.ResourceLink,
+) diag.Diagnostics {
 	resourceLink.Type = v.TypeID.ValueString()
 	resourceLink.Source = cm.OptString{}
 	resourceLink.ContentTypes = nil
 
-	return diags
+	return nil
 }
 
-func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) SetResourceLink(ctx context.Context, _ path.Path, resourceLink *cm.ResourceLink) diag.Diagnostics {
+func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) SetResourceLink(
+	ctx context.Context,
+	_ path.Path,
+	resourceLink *cm.ResourceLink,
+) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
 	contentTypes := make([]string, len(v.ContentTypes.Elements()))
@@ -192,4 +344,90 @@ func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) SetResourceLink
 	resourceLink.ContentTypes = contentTypes
 
 	return diags
+}
+
+func contentTypeRequiredString(value types.String, valuePath path.Path) (string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown string",
+			"The string value must be known before it can be sent to Contentful.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null string",
+			"The required string value cannot be null.",
+		)
+	default:
+		return value.ValueString(), diags
+	}
+
+	return "", diags
+}
+
+func contentTypeRequiredBool(value types.Bool, valuePath path.Path) (bool, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown boolean",
+			"The boolean value must be known before it can be sent to Contentful.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null boolean",
+			"The required boolean value cannot be null.",
+		)
+	default:
+		return value.ValueBool(), diags
+	}
+
+	return false, diags
+}
+
+func contentTypeOptionalString(value types.String, valuePath path.Path) (cm.OptString, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown string",
+			"The string value must be known before it can be sent to Contentful.",
+		)
+
+		return cm.OptString{}, diags
+	}
+
+	if value.IsNull() {
+		return cm.OptString{}, diags
+	}
+
+	return cm.NewOptString(value.ValueString()), diags
+}
+
+func contentTypeOptionalBool(value types.Bool, valuePath path.Path) (cm.OptBool, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown boolean",
+			"The boolean value must be known before it can be sent to Contentful.",
+		)
+
+		return cm.OptBool{}, diags
+	}
+
+	if value.IsNull() {
+		return cm.OptBool{}, diags
+	}
+
+	return cm.NewOptBool(value.ValueBool()), diags
 }

--- a/internal/provider/content_type_model_request_test.go
+++ b/internal/provider/content_type_model_request_test.go
@@ -3,21 +3,311 @@ package provider_test
 import (
 	"testing"
 
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToOptContentTypeFieldsItemItemsErrorHandling(t *testing.T) {
+func TestContentTypeRequestRejectsUnresolvedRequiredValues(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	tests := map[string]struct {
+		mutate       func(*ContentTypeModel)
+		expectedPath string
+	}{
+		"unknown name": {
+			mutate:       func(model *ContentTypeModel) { model.Name = types.StringUnknown() },
+			expectedPath: "name",
+		},
+		"null name": {
+			mutate:       func(model *ContentTypeModel) { model.Name = types.StringNull() },
+			expectedPath: "name",
+		},
+		"unknown description": {
+			mutate:       func(model *ContentTypeModel) { model.Description = types.StringUnknown() },
+			expectedPath: "description",
+		},
+		"null description": {
+			mutate:       func(model *ContentTypeModel) { model.Description = types.StringNull() },
+			expectedPath: "description",
+		},
+		"unknown display field": {
+			mutate:       func(model *ContentTypeModel) { model.DisplayField = types.StringUnknown() },
+			expectedPath: "display_field",
+		},
+		"null display field": {
+			mutate:       func(model *ContentTypeModel) { model.DisplayField = types.StringNull() },
+			expectedPath: "display_field",
+		},
+		"unknown fields": {
+			mutate: func(model *ContentTypeModel) {
+				model.Fields = NewTypedListUnknown[TypedObject[ContentTypeFieldValue]]()
+			},
+			expectedPath: "fields",
+		},
+		"null fields": {
+			mutate: func(model *ContentTypeModel) {
+				model.Fields = NewTypedListNull[TypedObject[ContentTypeFieldValue]]()
+			},
+			expectedPath: "fields",
+		},
+	}
 
-	_, itemsObjectDiags := NewTypedObjectFromAttributes[ContentTypeFieldItemsValue](ctx, map[string]attr.Value{
-		"type":        types.StringNull(),
-		"link_type":   types.StringNull(),
-		"validations": NewTypedList([]types.String{types.StringNull()}),
-	})
-	assert.NotEmpty(t, itemsObjectDiags)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validContentTypeRequestModel()
+			test.mutate(&model)
+
+			actual, diags := model.ToContentTypeRequestData(t.Context())
+
+			assert.Equal(t, cm.ContentTypeRequestData{}, actual)
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestContentTypeFieldsRejectUnresolvedElementsWithoutPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	result, diags := FieldsListToContentTypeRequestDataFields(
+		t.Context(),
+		path.Root("fields"),
+		NewTypedList([]TypedObject[ContentTypeFieldValue]{
+			NewTypedObject(validContentTypeFieldValue()),
+			NewTypedObjectNull[ContentTypeFieldValue](),
+			NewTypedObjectUnknown[ContentTypeFieldValue](),
+		}),
+	)
+
+	assert.Nil(t, result)
+	assert.Equal(t, []string{"fields[1]", "fields[2]"}, diagnosticPaths(t, diags))
+}
+
+func TestContentTypeFieldRejectsUnresolvedRequiredValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		mutate       func(*ContentTypeFieldValue)
+		expectedPath string
+	}{
+		"unknown id": {
+			mutate:       func(value *ContentTypeFieldValue) { value.ID = types.StringUnknown() },
+			expectedPath: "fields[0].id",
+		},
+		"null id": {
+			mutate:       func(value *ContentTypeFieldValue) { value.ID = types.StringNull() },
+			expectedPath: "fields[0].id",
+		},
+		"unknown name": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Name = types.StringUnknown() },
+			expectedPath: "fields[0].name",
+		},
+		"null name": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Name = types.StringNull() },
+			expectedPath: "fields[0].name",
+		},
+		"unknown type": {
+			mutate:       func(value *ContentTypeFieldValue) { value.FieldType = types.StringUnknown() },
+			expectedPath: "fields[0].type",
+		},
+		"null type": {
+			mutate:       func(value *ContentTypeFieldValue) { value.FieldType = types.StringNull() },
+			expectedPath: "fields[0].type",
+		},
+		"unknown localized": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Localized = types.BoolUnknown() },
+			expectedPath: "fields[0].localized",
+		},
+		"null localized": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Localized = types.BoolNull() },
+			expectedPath: "fields[0].localized",
+		},
+		"unknown required": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Required = types.BoolUnknown() },
+			expectedPath: "fields[0].required",
+		},
+		"null required": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Required = types.BoolNull() },
+			expectedPath: "fields[0].required",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			value := validContentTypeFieldValue()
+			test.mutate(&value)
+
+			actual, diags := ToContentTypeRequestDataFieldsItem(t.Context(), path.Root("fields").AtListIndex(0), value)
+
+			assert.Equal(t, cm.ContentTypeRequestDataFieldsItem{}, actual)
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestContentTypeFieldRejectsUnresolvedOptionalValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		mutate       func(*ContentTypeFieldValue)
+		expectedPath string
+	}{
+		"link type": {
+			mutate:       func(value *ContentTypeFieldValue) { value.LinkType = types.StringUnknown() },
+			expectedPath: "fields[0].link_type",
+		},
+		"disabled": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Disabled = types.BoolUnknown() },
+			expectedPath: "fields[0].disabled",
+		},
+		"omitted": {
+			mutate:       func(value *ContentTypeFieldValue) { value.Omitted = types.BoolUnknown() },
+			expectedPath: "fields[0].omitted",
+		},
+		"items": {
+			mutate: func(value *ContentTypeFieldValue) {
+				value.Items = NewTypedObjectUnknown[ContentTypeFieldItemsValue]()
+			},
+			expectedPath: "fields[0].items",
+		},
+		"default value": {
+			mutate:       func(value *ContentTypeFieldValue) { value.DefaultValue = jsontypes.NewNormalizedUnknown() },
+			expectedPath: "fields[0].default_value",
+		},
+		"validations": {
+			mutate: func(value *ContentTypeFieldValue) {
+				value.Validations = NewTypedListUnknown[jsontypes.Normalized]()
+			},
+			expectedPath: "fields[0].validations",
+		},
+		"allowed resources": {
+			mutate: func(value *ContentTypeFieldValue) {
+				value.AllowedResources = NewTypedListUnknown[TypedObject[ContentTypeFieldAllowedResourceItemValue]]()
+			},
+			expectedPath: "fields[0].allowed_resources",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			value := validContentTypeFieldValue()
+			test.mutate(&value)
+
+			actual, diags := ToContentTypeRequestDataFieldsItem(t.Context(), path.Root("fields").AtListIndex(0), value)
+
+			assert.Equal(t, cm.ContentTypeRequestDataFieldsItem{}, actual)
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestContentTypeFieldItemsRejectUnresolvedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value        ContentTypeFieldItemsValue
+		expectedPath string
+	}{
+		"unknown type": {
+			value: ContentTypeFieldItemsValue{
+				ItemsType:   types.StringUnknown(),
+				LinkType:    types.StringNull(),
+				Validations: NewTypedList([]jsontypes.Normalized{}),
+			},
+			expectedPath: "fields[0].items.type",
+		},
+		"null type": {
+			value: ContentTypeFieldItemsValue{
+				ItemsType:   types.StringNull(),
+				LinkType:    types.StringNull(),
+				Validations: NewTypedList([]jsontypes.Normalized{}),
+			},
+			expectedPath: "fields[0].items.type",
+		},
+		"unknown link type": {
+			value: ContentTypeFieldItemsValue{
+				ItemsType:   types.StringValue("Link"),
+				LinkType:    types.StringUnknown(),
+				Validations: NewTypedList([]jsontypes.Normalized{}),
+			},
+			expectedPath: "fields[0].items.link_type",
+		},
+		"unknown validations": {
+			value: ContentTypeFieldItemsValue{
+				ItemsType:   types.StringValue("Link"),
+				LinkType:    types.StringNull(),
+				Validations: NewTypedListUnknown[jsontypes.Normalized](),
+			},
+			expectedPath: "fields[0].items.validations",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.value.ToContentTypeRequestDataFieldsItemItems(
+				t.Context(),
+				path.Root("fields").AtListIndex(0).AtName("items"),
+			)
+
+			assert.Equal(t, cm.ContentTypeRequestDataFieldsItemItems{}, actual)
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestContentTypeValidationsFailClosedWithExactPaths(t *testing.T) {
+	t.Parallel()
+
+	actual, diags := ValidationsListToContentTypeRequestDataFieldValidations(
+		t.Context(),
+		path.Root("fields").AtListIndex(0).AtName("validations"),
+		NewTypedList([]jsontypes.Normalized{
+			jsontypes.NewNormalizedValue(`{"size":{"min":1}}`),
+			jsontypes.NewNormalizedNull(),
+			jsontypes.NewNormalizedUnknown(),
+		}),
+	)
+
+	assert.Nil(t, actual)
+	assert.Equal(t, []string{"fields[0].validations[1]", "fields[0].validations[2]"}, diagnosticPaths(t, diags))
+}
+
+func validContentTypeRequestModel() ContentTypeModel {
+	return ContentTypeModel{
+		Name:         types.StringValue("Test"),
+		Description:  types.StringValue("A test content type"),
+		DisplayField: types.StringValue("title"),
+		Fields: NewTypedList([]TypedObject[ContentTypeFieldValue]{
+			NewTypedObject(validContentTypeFieldValue()),
+		}),
+		Metadata: NewTypedObjectNull[ContentTypeMetadataValue](),
+	}
+}
+
+func validContentTypeFieldValue() ContentTypeFieldValue {
+	return ContentTypeFieldValue{
+		ID:               types.StringValue("title"),
+		Name:             types.StringValue("Title"),
+		FieldType:        types.StringValue("Symbol"),
+		LinkType:         types.StringNull(),
+		Disabled:         types.BoolValue(false),
+		Omitted:          types.BoolValue(false),
+		Required:         types.BoolValue(true),
+		DefaultValue:     jsontypes.NewNormalizedNull(),
+		Items:            NewTypedObjectNull[ContentTypeFieldItemsValue](),
+		Localized:        types.BoolValue(false),
+		Validations:      NewTypedList([]jsontypes.Normalized{}),
+		AllowedResources: NewTypedListNull[TypedObject[ContentTypeFieldAllowedResourceItemValue]](),
+	}
 }

--- a/internal/provider/request_diagnostics_test.go
+++ b/internal/provider/request_diagnostics_test.go
@@ -1,0 +1,23 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/require"
+)
+
+func diagnosticPaths(t *testing.T, diags diag.Diagnostics) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(diags.Errors()))
+
+	for _, diagnostic := range diags.Errors() {
+		withPath, ok := diagnostic.(diag.DiagnosticWithPath)
+		require.True(t, ok)
+
+		paths = append(paths, withPath.Path().String())
+	}
+
+	return paths
+}

--- a/internal/provider/request_object_list.go
+++ b/internal/provider/request_object_list.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+type knownObjectListElementConverter[T any, R any] func(context.Context, path.Path, T) (R, diag.Diagnostics)
+
+func convertKnownObjectListElements[T any, R any](
+	ctx context.Context,
+	valuePath path.Path,
+	elements []TypedObject[T],
+	convert knownObjectListElementConverter[T, R],
+) ([]R, diag.Diagnostics) {
+	result := make([]R, 0, len(elements))
+	diags := diag.Diagnostics{}
+
+	for index, element := range elements {
+		elementPath := valuePath.AtListIndex(index)
+		value, ok := element.GetValue()
+
+		if !ok {
+			if element.IsUnknown() {
+				diags.AddAttributeError(
+					elementPath,
+					"Unexpected unknown object",
+					"The object value must be known before it can be sent to Contentful.",
+				)
+			} else {
+				diags.AddAttributeError(
+					elementPath,
+					"Unexpected null object",
+					"Null object values are not valid collection elements.",
+				)
+			}
+
+			continue
+		}
+
+		converted, conversionDiags := convert(ctx, elementPath, value)
+		diags.Append(conversionDiags...)
+
+		if !conversionDiags.HasError() {
+			result = append(result, converted)
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return result, diags
+}

--- a/internal/provider/request_object_list_test.go
+++ b/internal/provider/request_object_list_test.go
@@ -1,0 +1,91 @@
+//nolint:testpackage // The package-private request conversion module is intentionally tested through its interface.
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertKnownObjectListElements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts known elements with exact paths", func(t *testing.T) {
+		t.Parallel()
+
+		actualPaths := []string{}
+		actual, diags := convertKnownObjectListElements(
+			t.Context(),
+			path.Root("items"),
+			[]TypedObject[string]{NewTypedObject("first"), NewTypedObject("second")},
+			func(_ context.Context, valuePath path.Path, value string) (string, diag.Diagnostics) {
+				actualPaths = append(actualPaths, valuePath.String())
+
+				return value, nil
+			},
+		)
+
+		require.False(t, diags.HasError(), diags.Errors())
+		assert.Equal(t, []string{"first", "second"}, actual)
+		assert.Equal(t, []string{"items[0]", "items[1]"}, actualPaths)
+	})
+
+	t.Run("rejects unresolved elements without partial output", func(t *testing.T) {
+		t.Parallel()
+
+		actual, diags := convertKnownObjectListElements(
+			t.Context(),
+			path.Root("items"),
+			[]TypedObject[string]{
+				NewTypedObject("first"),
+				NewTypedObjectNull[string](),
+				NewTypedObjectUnknown[string](),
+			},
+			func(_ context.Context, _ path.Path, value string) (string, diag.Diagnostics) {
+				return value, nil
+			},
+		)
+
+		assert.Nil(t, actual)
+		assert.Equal(t, []string{"items[1]", "items[2]"}, diagnosticPathStrings(t, diags))
+	})
+
+	t.Run("discards converted values after a child conversion error", func(t *testing.T) {
+		t.Parallel()
+
+		actual, diags := convertKnownObjectListElements(
+			t.Context(),
+			path.Root("items"),
+			[]TypedObject[string]{NewTypedObject("first"), NewTypedObject("second")},
+			func(_ context.Context, valuePath path.Path, value string) (string, diag.Diagnostics) {
+				if value == "second" {
+					return "partial", diag.Diagnostics{diag.NewAttributeErrorDiagnostic(valuePath, "Conversion failed", "test failure")}
+				}
+
+				return value, nil
+			},
+		)
+
+		assert.Nil(t, actual)
+		assert.Equal(t, []string{"items[1]"}, diagnosticPathStrings(t, diags))
+	})
+}
+
+func diagnosticPathStrings(t *testing.T, diags diag.Diagnostics) []string {
+	t.Helper()
+
+	paths := make([]string, 0, len(diags.Errors()))
+
+	for _, diagnostic := range diags.Errors() {
+		withPath, ok := diagnostic.(diag.DiagnosticWithPath)
+		require.True(t, ok)
+
+		paths = append(paths, withPath.Path().String())
+	}
+
+	return paths
+}


### PR DESCRIPTION
## Summary

- reject null or unknown required Content Type request values at their exact Terraform paths
- reject unresolved field items, defaults, validations, and allowed-resource collections before API mutation
- convert typed object lists transactionally so child diagnostics cannot publish partial request aggregates
- preserve null versus empty semantics for optional request values and Optional+Computed defaults

## Why

The previous request conversion read unresolved Terraform values through value accessors, which could silently turn unknown values into zero values or omit them. This stacked change establishes fail-closed field conversion without changing response conversion, schema, or documentation.

This draft is based on `codex/app-installation-request-values` (PR #599).

## Validation

- focused Content Type and object-list tests
- `go test ./...`
- `go generate ./...` with a clean worktree
- `golangci-lint cache clean`
- `golangci-lint run`
