### PR TITLE
fix(content-type): reject unresolved request unions

### DIFF
--- a/internal/provider/content_type_allowed_resource_request_test.go
+++ b/internal/provider/content_type_allowed_resource_request_test.go
@@ -1,0 +1,156 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentTypeAllowedResourceRequiresExactlyOneAlternative(t *testing.T) {
+	t.Parallel()
+
+	valuePath := path.Root("allowed_resources").AtListIndex(0)
+	external := NewTypedObject(ContentTypeFieldAllowedResourceItemExternalValue{
+		TypeID: types.StringValue("ExternalType"),
+	})
+	contentfulEntry := NewTypedObject(ContentTypeFieldAllowedResourceItemContentfulEntryValue{
+		Source:       types.StringValue("crn:contentful:::content:spaces/example"),
+		ContentTypes: NewTypedList([]types.String{types.StringValue("article")}),
+	})
+
+	tests := map[string]struct {
+		value         ContentTypeFieldAllowedResourceItemValue
+		expected      cm.ResourceLink
+		expectedPaths []string
+	}{
+		"external": {
+			value: ContentTypeFieldAllowedResourceItemValue{
+				External:        external,
+				ContentfulEntry: NewTypedObjectNull[ContentTypeFieldAllowedResourceItemContentfulEntryValue](),
+			},
+			expected:      cm.ResourceLink{Type: "ExternalType"},
+			expectedPaths: []string{},
+		},
+		"contentful entry": {
+			value: ContentTypeFieldAllowedResourceItemValue{
+				External:        NewTypedObjectNull[ContentTypeFieldAllowedResourceItemExternalValue](),
+				ContentfulEntry: contentfulEntry,
+			},
+			expected: cm.ResourceLink{
+				Type:         "Contentful:Entry",
+				Source:       cm.NewOptString("crn:contentful:::content:spaces/example"),
+				ContentTypes: []string{"article"},
+			},
+			expectedPaths: []string{},
+		},
+		"neither": {
+			value: ContentTypeFieldAllowedResourceItemValue{
+				External:        NewTypedObjectNull[ContentTypeFieldAllowedResourceItemExternalValue](),
+				ContentfulEntry: NewTypedObjectNull[ContentTypeFieldAllowedResourceItemContentfulEntryValue](),
+			},
+			expectedPaths: []string{"allowed_resources[0]"},
+		},
+		"both": {
+			value: ContentTypeFieldAllowedResourceItemValue{
+				External:        external,
+				ContentfulEntry: contentfulEntry,
+			},
+			expectedPaths: []string{"allowed_resources[0]"},
+		},
+		"unknown": {
+			value: ContentTypeFieldAllowedResourceItemValue{
+				External:        NewTypedObjectUnknown[ContentTypeFieldAllowedResourceItemExternalValue](),
+				ContentfulEntry: NewTypedObjectNull[ContentTypeFieldAllowedResourceItemContentfulEntryValue](),
+			},
+			expectedPaths: []string{"allowed_resources[0].external"},
+		},
+		"invalid external": {
+			value: ContentTypeFieldAllowedResourceItemValue{
+				External: NewTypedObject(ContentTypeFieldAllowedResourceItemExternalValue{
+					TypeID: types.StringUnknown(),
+				}),
+				ContentfulEntry: NewTypedObjectNull[ContentTypeFieldAllowedResourceItemContentfulEntryValue](),
+			},
+			expectedPaths: []string{"allowed_resources[0].external.type"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.value.ToResourceLink(t.Context(), valuePath)
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestContentTypeAllowedContentfulEntryRejectsUnresolvedValues(t *testing.T) {
+	t.Parallel()
+
+	valuePath := path.Root("allowed_resources").AtListIndex(0).AtName("contentful_entry")
+	tests := map[string]struct {
+		value         ContentTypeFieldAllowedResourceItemContentfulEntryValue
+		expectedPaths []string
+	}{
+		"unknown source": {
+			value: ContentTypeFieldAllowedResourceItemContentfulEntryValue{
+				Source:       types.StringUnknown(),
+				ContentTypes: NewTypedList([]types.String{}),
+			},
+			expectedPaths: []string{"allowed_resources[0].contentful_entry.source"},
+		},
+		"null source": {
+			value: ContentTypeFieldAllowedResourceItemContentfulEntryValue{
+				Source:       types.StringNull(),
+				ContentTypes: NewTypedList([]types.String{}),
+			},
+			expectedPaths: []string{"allowed_resources[0].contentful_entry.source"},
+		},
+		"unknown content types": {
+			value: ContentTypeFieldAllowedResourceItemContentfulEntryValue{
+				Source:       types.StringValue("source"),
+				ContentTypes: NewTypedListUnknown[types.String](),
+			},
+			expectedPaths: []string{"allowed_resources[0].contentful_entry.content_types"},
+		},
+		"null content types": {
+			value: ContentTypeFieldAllowedResourceItemContentfulEntryValue{
+				Source:       types.StringValue("source"),
+				ContentTypes: NewTypedListNull[types.String](),
+			},
+			expectedPaths: []string{"allowed_resources[0].contentful_entry.content_types"},
+		},
+		"unresolved content type elements": {
+			value: ContentTypeFieldAllowedResourceItemContentfulEntryValue{
+				Source: types.StringValue("source"),
+				ContentTypes: NewTypedList([]types.String{
+					types.StringValue("valid"),
+					types.StringNull(),
+					types.StringUnknown(),
+				}),
+			},
+			expectedPaths: []string{
+				"allowed_resources[0].contentful_entry.content_types[1]",
+				"allowed_resources[0].contentful_entry.content_types[2]",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.value.ToResourceLink(t.Context(), valuePath)
+
+			assert.Equal(t, cm.ResourceLink{}, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+		})
+	}
+}

--- a/internal/provider/content_type_metadata_request.go
+++ b/internal/provider/content_type_metadata_request.go
@@ -6,88 +6,138 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func ToOptContentTypeMetadata(ctx context.Context, path path.Path, m TypedObject[ContentTypeMetadataValue]) (cm.OptContentTypeMetadata, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	value, valueOk := m.GetValue()
-	if !valueOk {
-		return cm.OptContentTypeMetadata{}, diags
+func ToOptContentTypeMetadata(
+	ctx context.Context,
+	valuePath path.Path,
+	metadataObject TypedObject[ContentTypeMetadataValue],
+) (cm.OptContentTypeMetadata, diag.Diagnostics) {
+	value, ok := metadataObject.GetValue()
+	if !ok {
+		// Optional+Computed metadata uses both null and unknown to represent omission
+		// while plan reconciliation preserves remote taxonomy configuration.
+		return cm.OptContentTypeMetadata{}, nil
 	}
 
-	taxonomy := ContentTypeMetadataTaxonomyItemsToContentTypeMetadataTaxonomySlice(ctx, path.AtName("taxonomy"), value.Taxonomy)
+	diags := diag.Diagnostics{}
+	taxonomy, taxonomyDiags := ContentTypeMetadataTaxonomyItemsToContentTypeMetadataTaxonomySlice(
+		ctx,
+		valuePath.AtName("taxonomy"),
+		value.Taxonomy,
+	)
+	diags.Append(taxonomyDiags...)
 
 	var annotations []byte
-	if !value.Annotations.IsNull() && !value.Annotations.IsUnknown() {
+
+	if value.Annotations.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath.AtName("annotations"),
+			"Unexpected unknown content type metadata annotations",
+			"Content type metadata annotations must be known before they can be sent to Contentful.",
+		)
+	} else if !value.Annotations.IsNull() {
 		annotations = []byte(value.Annotations.ValueString())
 	}
 
-	metadata := cm.ContentTypeMetadata{
-		Annotations: annotations,
-		Taxonomy:    taxonomy,
+	if diags.HasError() {
+		return cm.OptContentTypeMetadata{}, diags
 	}
 
-	return cm.NewOptContentTypeMetadata(metadata), diags
+	return cm.NewOptContentTypeMetadata(cm.ContentTypeMetadata{
+		Annotations: annotations,
+		Taxonomy:    taxonomy,
+	}), diags
 }
 
 func ContentTypeMetadataTaxonomyItemsToContentTypeMetadataTaxonomySlice(
 	ctx context.Context,
-	path path.Path,
+	valuePath path.Path,
 	items TypedList[TypedObject[ContentTypeMetadataTaxonomyItemValue]],
-) []cm.ContentTypeMetadataTaxonomyItem {
+) ([]cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
 	if items.IsNull() || items.IsUnknown() {
-		return nil
+		// taxonomy is Optional+Computed: an unresolved container represents
+		// omission, while a known empty list explicitly removes taxonomy items.
+		return nil, nil
 	}
 
-	itemValues := items.Elements()
-
-	requestItems := make([]cm.ContentTypeMetadataTaxonomyItem, 0, len(itemValues))
-
-	for index, itemValue := range itemValues {
-		item := ToContentTypeMetadataTaxonomyItem(ctx, path.AtListIndex(index), itemValue)
-
-		requestItems = append(requestItems, item...)
-	}
-
-	return requestItems
+	return convertKnownObjectListElements(
+		ctx,
+		valuePath,
+		items.Elements(),
+		func(ctx context.Context, itemPath path.Path, value ContentTypeMetadataTaxonomyItemValue) (cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
+			return value.ToContentTypeMetadataTaxonomyItem(ctx, itemPath)
+		},
+	)
 }
 
-func ToContentTypeMetadataTaxonomyItem(
+func (value ContentTypeMetadataTaxonomyItemValue) ToContentTypeMetadataTaxonomyItem(
 	_ context.Context,
-	_ path.Path,
-	object TypedObject[ContentTypeMetadataTaxonomyItemValue],
-) []cm.ContentTypeMetadataTaxonomyItem {
-	value, valueOk := object.GetValue()
-	if !valueOk {
-		return nil
-	}
+	valuePath path.Path,
+) (cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
+	conceptPath := valuePath.AtName("taxonomy_concept")
+	conceptSchemePath := valuePath.AtName("taxonomy_concept_scheme")
 
-	items := make([]cm.ContentTypeMetadataTaxonomyItem, 0, 1)
+	return convertExactlyOneKnownAlternative(
+		valuePath,
+		knownUnionAlternative[cm.ContentTypeMetadataTaxonomyItem]{
+			Name:  "taxonomy_concept",
+			Path:  conceptPath,
+			Value: value.TaxonomyConcept,
+			Convert: func() (cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
+				concept, _ := value.TaxonomyConcept.GetValue()
 
-	taxonomyConceptScheme, taxonomyConceptSchemeOk := value.TaxonomyConceptScheme.GetValue()
-	if taxonomyConceptSchemeOk {
-		items = append(items, cm.ContentTypeMetadataTaxonomyItem{
-			Sys: cm.ContentTypeMetadataTaxonomyItemSys{
-				Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
-				LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConceptScheme,
-				ID:       taxonomyConceptScheme.ID.ValueString(),
+				return contentTypeMetadataTaxonomyItem(
+					concept.ID,
+					concept.Required,
+					conceptPath,
+					cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConcept,
+				)
 			},
-			Required: cm.NewOptPointerBool(taxonomyConceptScheme.Required.ValueBoolPointer()),
-		})
-	}
+		},
+		knownUnionAlternative[cm.ContentTypeMetadataTaxonomyItem]{
+			Name:  "taxonomy_concept_scheme",
+			Path:  conceptSchemePath,
+			Value: value.TaxonomyConceptScheme,
+			Convert: func() (cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
+				conceptScheme, _ := value.TaxonomyConceptScheme.GetValue()
 
-	taxonomyConcept, taxonomyConceptOk := value.TaxonomyConcept.GetValue()
-	if taxonomyConceptOk {
-		items = append(items, cm.ContentTypeMetadataTaxonomyItem{
-			Sys: cm.ContentTypeMetadataTaxonomyItemSys{
-				Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
-				LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConcept,
-				ID:       taxonomyConcept.ID.ValueString(),
+				return contentTypeMetadataTaxonomyItem(
+					conceptScheme.ID,
+					conceptScheme.Required,
+					conceptSchemePath,
+					cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConceptScheme,
+				)
 			},
-			Required: cm.NewOptPointerBool(taxonomyConcept.Required.ValueBoolPointer()),
-		})
+		},
+	)
+}
+
+func contentTypeMetadataTaxonomyItem(
+	idValue types.String,
+	requiredValue types.Bool,
+	valuePath path.Path,
+	linkType cm.ContentTypeMetadataTaxonomyItemSysLinkType,
+) (cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
+	// Keep scalar conversion local to Content Type; the reusable seam here is
+	// union selection, not a repository-wide value-conversion abstraction.
+	taxonomyID, idDiags := contentTypeRequiredString(idValue, valuePath.AtName("id"))
+	required, requiredDiags := contentTypeOptionalBool(requiredValue, valuePath.AtName("required"))
+	diags := diag.Diagnostics{}
+	diags.Append(idDiags...)
+	diags.Append(requiredDiags...)
+
+	if diags.HasError() {
+		return cm.ContentTypeMetadataTaxonomyItem{}, diags
 	}
 
-	return items
+	return cm.ContentTypeMetadataTaxonomyItem{
+		Sys: cm.ContentTypeMetadataTaxonomyItemSys{
+			Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
+			LinkType: linkType,
+			ID:       taxonomyID,
+		},
+		Required: required,
+	}, diags
 }

--- a/internal/provider/content_type_metadata_request_test.go
+++ b/internal/provider/content_type_metadata_request_test.go
@@ -3,8 +3,10 @@ package provider_test
 import (
 	"testing"
 
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,4 +87,178 @@ func TestContentTypeMetadataRequestSerialization(t *testing.T) {
 			assert.JSONEq(t, test.expected, string(requestBody))
 		})
 	}
+}
+
+func TestContentTypeMetadataRejectsUnknownAnnotations(t *testing.T) {
+	t.Parallel()
+
+	actual, diags := ToOptContentTypeMetadata(
+		t.Context(),
+		path.Root("metadata"),
+		NewTypedObject(ContentTypeMetadataValue{
+			Annotations: jsontypes.NewNormalizedUnknown(),
+			Taxonomy:    NewTypedListNull[TypedObject[ContentTypeMetadataTaxonomyItemValue]](),
+		}),
+	)
+
+	assert.Equal(t, cm.OptContentTypeMetadata{}, actual)
+	assert.Equal(t, []string{"metadata.annotations"}, diagnosticPaths(t, diags))
+}
+
+func TestContentTypeMetadataTaxonomyRejectsUnresolvedElements(t *testing.T) {
+	t.Parallel()
+
+	items := NewTypedList([]TypedObject[ContentTypeMetadataTaxonomyItemValue]{
+		NewTypedObject(ContentTypeMetadataTaxonomyItemValue{
+			TaxonomyConcept: NewTypedObject(ContentTypeMetadataTaxonomyItemConceptValue{
+				ID:       types.StringValue("valid"),
+				Required: types.BoolValue(false),
+			}),
+			TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+		}),
+		NewTypedObjectNull[ContentTypeMetadataTaxonomyItemValue](),
+		NewTypedObjectUnknown[ContentTypeMetadataTaxonomyItemValue](),
+	})
+
+	result, diags := ContentTypeMetadataTaxonomyItemsToContentTypeMetadataTaxonomySlice(
+		t.Context(),
+		path.Root("metadata").AtName("taxonomy"),
+		items,
+	)
+
+	assert.Nil(t, result)
+	assert.Equal(t, []string{"metadata.taxonomy[1]", "metadata.taxonomy[2]"}, diagnosticPaths(t, diags))
+}
+
+func TestContentTypeMetadataTaxonomyRequiresExactlyOneAlternative(t *testing.T) {
+	t.Parallel()
+
+	valuePath := path.Root("metadata").AtName("taxonomy").AtListIndex(0)
+	concept := NewTypedObject(ContentTypeMetadataTaxonomyItemConceptValue{
+		ID:       types.StringValue("concept"),
+		Required: types.BoolValue(false),
+	})
+	conceptScheme := NewTypedObject(ContentTypeMetadataTaxonomyItemConceptSchemeValue{
+		ID:       types.StringValue("scheme"),
+		Required: types.BoolValue(true),
+	})
+
+	tests := map[string]struct {
+		value         ContentTypeMetadataTaxonomyItemValue
+		expected      cm.ContentTypeMetadataTaxonomyItem
+		expectedPaths []string
+	}{
+		"concept": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept:       concept,
+				TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+			},
+			expected: cm.ContentTypeMetadataTaxonomyItem{
+				Sys: cm.ContentTypeMetadataTaxonomyItemSys{
+					Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
+					LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConcept,
+					ID:       "concept",
+				},
+				Required: cm.NewOptBool(false),
+			},
+			expectedPaths: []string{},
+		},
+		"concept scheme": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept:       NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptValue](),
+				TaxonomyConceptScheme: conceptScheme,
+			},
+			expected: cm.ContentTypeMetadataTaxonomyItem{
+				Sys: cm.ContentTypeMetadataTaxonomyItemSys{
+					Type:     cm.ContentTypeMetadataTaxonomyItemSysTypeLink,
+					LinkType: cm.ContentTypeMetadataTaxonomyItemSysLinkTypeTaxonomyConceptScheme,
+					ID:       "scheme",
+				},
+				Required: cm.NewOptBool(true),
+			},
+			expectedPaths: []string{},
+		},
+		"neither": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept:       NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptValue](),
+				TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+			},
+			expectedPaths: []string{"metadata.taxonomy[0]"},
+		},
+		"both": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept:       concept,
+				TaxonomyConceptScheme: conceptScheme,
+			},
+			expectedPaths: []string{"metadata.taxonomy[0]"},
+		},
+		"unknown concept": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept:       NewTypedObjectUnknown[ContentTypeMetadataTaxonomyItemConceptValue](),
+				TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+			},
+			expectedPaths: []string{"metadata.taxonomy[0].taxonomy_concept"},
+		},
+		"unknown id": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept: NewTypedObject(ContentTypeMetadataTaxonomyItemConceptValue{
+					ID:       types.StringUnknown(),
+					Required: types.BoolValue(false),
+				}),
+				TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+			},
+			expectedPaths: []string{"metadata.taxonomy[0].taxonomy_concept.id"},
+		},
+		"unknown required": {
+			value: ContentTypeMetadataTaxonomyItemValue{
+				TaxonomyConcept: NewTypedObject(ContentTypeMetadataTaxonomyItemConceptValue{
+					ID:       types.StringValue("concept"),
+					Required: types.BoolUnknown(),
+				}),
+				TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+			},
+			expectedPaths: []string{"metadata.taxonomy[0].taxonomy_concept.required"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.value.ToContentTypeMetadataTaxonomyItem(t.Context(), valuePath)
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestContentTypeMetadataTaxonomyFailsWithoutPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	items := NewTypedList([]TypedObject[ContentTypeMetadataTaxonomyItemValue]{
+		NewTypedObject(ContentTypeMetadataTaxonomyItemValue{
+			TaxonomyConcept: NewTypedObject(ContentTypeMetadataTaxonomyItemConceptValue{
+				ID:       types.StringValue("valid"),
+				Required: types.BoolValue(false),
+			}),
+			TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+		}),
+		NewTypedObject(ContentTypeMetadataTaxonomyItemValue{
+			TaxonomyConcept: NewTypedObject(ContentTypeMetadataTaxonomyItemConceptValue{
+				ID:       types.StringUnknown(),
+				Required: types.BoolValue(false),
+			}),
+			TaxonomyConceptScheme: NewTypedObjectNull[ContentTypeMetadataTaxonomyItemConceptSchemeValue](),
+		}),
+	})
+
+	result, diags := ContentTypeMetadataTaxonomyItemsToContentTypeMetadataTaxonomySlice(
+		t.Context(),
+		path.Root("metadata").AtName("taxonomy"),
+		items,
+	)
+
+	assert.Nil(t, result)
+	assert.Equal(t, []string{"metadata.taxonomy[1].taxonomy_concept.id"}, diagnosticPaths(t, diags))
 }

--- a/internal/provider/content_type_model_request.go
+++ b/internal/provider/content_type_model_request.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -303,47 +302,87 @@ func (v ContentTypeFieldAllowedResourceItemValue) ToResourceLink(
 	ctx context.Context,
 	valuePath path.Path,
 ) (cm.ResourceLink, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-	resourceLink := cm.ResourceLink{}
+	externalPath := valuePath.AtName("external")
+	contentfulEntryPath := valuePath.AtName("contentful_entry")
 
-	if external, ok := v.External.GetValue(); ok {
-		diags.Append(external.SetResourceLink(ctx, valuePath.AtName("external"), &resourceLink)...)
-	}
+	return convertExactlyOneKnownAlternative(
+		valuePath,
+		knownUnionAlternative[cm.ResourceLink]{
+			Name:  "external",
+			Path:  externalPath,
+			Value: v.External,
+			Convert: func() (cm.ResourceLink, diag.Diagnostics) {
+				external, _ := v.External.GetValue()
 
-	if contentfulEntry, ok := v.ContentfulEntry.GetValue(); ok {
-		diags.Append(contentfulEntry.SetResourceLink(ctx, valuePath.AtName("contentful_entry"), &resourceLink)...)
-	}
+				return external.ToResourceLink(ctx, externalPath)
+			},
+		},
+		knownUnionAlternative[cm.ResourceLink]{
+			Name:  "contentful_entry",
+			Path:  contentfulEntryPath,
+			Value: v.ContentfulEntry,
+			Convert: func() (cm.ResourceLink, diag.Diagnostics) {
+				contentfulEntry, _ := v.ContentfulEntry.GetValue()
 
-	return resourceLink, diags
+				return contentfulEntry.ToResourceLink(ctx, contentfulEntryPath)
+			},
+		},
+	)
 }
 
-func (v ContentTypeFieldAllowedResourceItemExternalValue) SetResourceLink(
+func (v ContentTypeFieldAllowedResourceItemExternalValue) ToResourceLink(
 	_ context.Context,
-	_ path.Path,
-	resourceLink *cm.ResourceLink,
-) diag.Diagnostics {
-	resourceLink.Type = v.TypeID.ValueString()
-	resourceLink.Source = cm.OptString{}
-	resourceLink.ContentTypes = nil
+	valuePath path.Path,
+) (cm.ResourceLink, diag.Diagnostics) {
+	typeID, diags := contentTypeRequiredString(v.TypeID, valuePath.AtName("type"))
+	if diags.HasError() {
+		return cm.ResourceLink{}, diags
+	}
 
-	return nil
+	return cm.ResourceLink{Type: typeID}, diags
 }
 
-func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) SetResourceLink(
-	ctx context.Context,
-	_ path.Path,
-	resourceLink *cm.ResourceLink,
-) diag.Diagnostics {
+func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) ToResourceLink(
+	_ context.Context,
+	valuePath path.Path,
+) (cm.ResourceLink, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	contentTypes := make([]string, len(v.ContentTypes.Elements()))
-	diags.Append(tfsdk.ValueAs(ctx, v.ContentTypes, &contentTypes)...)
+	source, sourceDiags := contentTypeRequiredString(v.Source, valuePath.AtName("source"))
+	diags.Append(sourceDiags...)
 
-	resourceLink.Type = contentfulEntryAllowedResourceType
-	resourceLink.Source = cm.NewOptString(v.Source.ValueString())
-	resourceLink.ContentTypes = contentTypes
+	contentTypesPath := valuePath.AtName("content_types")
+	contentTypes := []string(nil)
 
-	return diags
+	switch {
+	case v.ContentTypes.IsUnknown():
+		diags.AddAttributeError(
+			contentTypesPath,
+			"Unexpected unknown content types",
+			"Allowed content types must be known before they can be sent to Contentful.",
+		)
+	case v.ContentTypes.IsNull():
+		diags.AddAttributeError(
+			contentTypesPath,
+			"Unexpected null content types",
+			"Allowed content types are required.",
+		)
+	default:
+		var contentTypeDiags diag.Diagnostics
+
+		contentTypes, contentTypeDiags = knownStringListElements(contentTypesPath, v.ContentTypes.Elements())
+		diags.Append(contentTypeDiags...)
+	}
+
+	if diags.HasError() {
+		return cm.ResourceLink{}, diags
+	}
+
+	return cm.ResourceLink{
+		Type:         contentfulEntryAllowedResourceType,
+		Source:       cm.NewOptString(source),
+		ContentTypes: contentTypes,
+	}, diags
 }
 
 func contentTypeRequiredString(value types.String, valuePath path.Path) (string, diag.Diagnostics) {

--- a/internal/provider/request_union.go
+++ b/internal/provider/request_union.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+type knownUnionAlternative[T any] struct {
+	Name    string
+	Path    path.Path
+	Value   attr.Value
+	Convert func() (T, diag.Diagnostics)
+}
+
+//nolint:ireturn // The selected converter supplies the concrete result type.
+func convertExactlyOneKnownAlternative[T any](
+	unionPath path.Path,
+	alternatives ...knownUnionAlternative[T],
+) (T, diag.Diagnostics) {
+	var zero T
+
+	selectedIndex := -1
+	knownCount := 0
+	names := make([]string, 0, len(alternatives))
+	diags := diag.Diagnostics{}
+
+	for index, alternative := range alternatives {
+		names = append(names, alternative.Name)
+
+		switch {
+		case alternative.Value.IsUnknown():
+			diags.AddAttributeError(
+				alternative.Path,
+				"Unexpected unknown union alternative",
+				fmt.Sprintf("%q must be known before the union can be sent to Contentful.", alternative.Name),
+			)
+		case alternative.Value.IsNull():
+		default:
+			knownCount++
+			selectedIndex = index
+		}
+	}
+
+	if knownCount > 1 || (knownCount == 0 && !diags.HasError()) {
+		diags.AddAttributeError(
+			unionPath,
+			"Invalid union value",
+			fmt.Sprintf("Exactly one of %s must be known and non-null.", strings.Join(names, ", ")),
+		)
+	}
+
+	if diags.HasError() {
+		return zero, diags
+	}
+
+	result, conversionDiags := alternatives[selectedIndex].Convert()
+	diags.Append(conversionDiags...)
+
+	if diags.HasError() {
+		return zero, diags
+	}
+
+	return result, diags
+}

--- a/internal/provider/request_union_test.go
+++ b/internal/provider/request_union_test.go
@@ -1,0 +1,110 @@
+//nolint:testpackage // The package-private request conversion module is intentionally tested through its interface.
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertExactlyOneKnownAlternative(t *testing.T) {
+	t.Parallel()
+
+	unionPath := path.Root("union")
+	firstPath := unionPath.AtName("first")
+	secondPath := unionPath.AtName("second")
+
+	tests := map[string]struct {
+		first         types.String
+		second        types.String
+		firstError    bool
+		expected      string
+		expectedPaths []string
+		expectedCalls []string
+	}{
+		"first": {
+			first:         types.StringValue("first"),
+			second:        types.StringNull(),
+			expected:      "first",
+			expectedPaths: []string{},
+			expectedCalls: []string{"first"},
+		},
+		"second": {
+			first:         types.StringNull(),
+			second:        types.StringValue("second"),
+			expected:      "second",
+			expectedPaths: []string{},
+			expectedCalls: []string{"second"},
+		},
+		"neither": {
+			first:         types.StringNull(),
+			second:        types.StringNull(),
+			expectedPaths: []string{"union"},
+		},
+		"both": {
+			first:         types.StringValue("first"),
+			second:        types.StringValue("second"),
+			expectedPaths: []string{"union"},
+		},
+		"unknown alternative": {
+			first:         types.StringUnknown(),
+			second:        types.StringNull(),
+			expectedPaths: []string{"union.first"},
+		},
+		"known and unknown alternatives": {
+			first:         types.StringValue("first"),
+			second:        types.StringUnknown(),
+			expectedPaths: []string{"union.second"},
+		},
+		"selected conversion error": {
+			first:         types.StringValue("first"),
+			second:        types.StringNull(),
+			firstError:    true,
+			expectedPaths: []string{"union.first"},
+			expectedCalls: []string{"first"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls []string
+
+			actual, diags := convertExactlyOneKnownAlternative(
+				unionPath,
+				knownUnionAlternative[string]{
+					Name:  "first",
+					Path:  firstPath,
+					Value: test.first,
+					Convert: func() (string, diag.Diagnostics) {
+						calls = append(calls, "first")
+
+						if test.firstError {
+							return "partial", diag.Diagnostics{diag.NewAttributeErrorDiagnostic(firstPath, "Conversion failed", "test failure")}
+						}
+
+						return "first", nil
+					},
+				},
+				knownUnionAlternative[string]{
+					Name:  "second",
+					Path:  secondPath,
+					Value: test.second,
+					Convert: func() (string, diag.Diagnostics) {
+						calls = append(calls, "second")
+
+						return "second", nil
+					},
+				},
+			)
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPathStrings(t, diags))
+			assert.Equal(t, test.expectedCalls, calls)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- require exactly one known Content Type request alternative for allowed resources and taxonomy metadata
- convert only the selected union branch and discard its result if conversion reports diagnostics
- reject unresolved external types, Contentful entry sources, content-type lists, and taxonomy children at exact Terraform paths
- retain metadata and taxonomy null/unknown container omission semantics for Optional+Computed planning

## Why

The previous request conversion silently skipped unknown union alternatives, accepted zero or multiple selected branches, and could publish partially converted request aggregates. This change adds a small package-internal lazy union conversion seam and applies it only to the two Content Type unions that need it.

Response conversion is deliberately unchanged: known remote Contentful configuration is still represented as faithfully as the current Terraform schema permits.

This draft is stacked on `codex/content-type-request-values` (PR #604).

## Validation

- focused Content Type and union-helper tests
- `go test ./...`
- `go generate ./...` with a clean worktree
- `golangci-lint cache clean`
- `golangci-lint run`
