### PR TITLE
refactor(provider): share request scalar conversion

### DIFF
--- a/internal/provider/content_type_metadata_request.go
+++ b/internal/provider/content_type_metadata_request.go
@@ -120,10 +120,8 @@ func contentTypeMetadataTaxonomyItem(
 	valuePath path.Path,
 	linkType cm.ContentTypeMetadataTaxonomyItemSysLinkType,
 ) (cm.ContentTypeMetadataTaxonomyItem, diag.Diagnostics) {
-	// Keep scalar conversion local to Content Type; the reusable seam here is
-	// union selection, not a repository-wide value-conversion abstraction.
-	taxonomyID, idDiags := contentTypeRequiredString(idValue, valuePath.AtName("id"))
-	required, requiredDiags := contentTypeOptionalBool(requiredValue, valuePath.AtName("required"))
+	taxonomyID, idDiags := requestRequiredString(idValue, valuePath.AtName("id"))
+	required, requiredDiags := requestOptionalBool(requiredValue, valuePath.AtName("required"))
 	diags := diag.Diagnostics{}
 	diags.Append(idDiags...)
 	diags.Append(requiredDiags...)

--- a/internal/provider/content_type_model_request.go
+++ b/internal/provider/content_type_model_request.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const contentfulEntryAllowedResourceType = "Contentful:Entry"
@@ -16,13 +15,13 @@ const contentfulEntryAllowedResourceType = "Contentful:Entry"
 func (m *ContentTypeModel) ToContentTypeRequestData(ctx context.Context) (cm.ContentTypeRequestData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	name, nameDiags := contentTypeRequiredString(m.Name, path.Root("name"))
+	name, nameDiags := requestRequiredString(m.Name, path.Root("name"))
 	diags.Append(nameDiags...)
 
-	description, descriptionDiags := contentTypeRequiredString(m.Description, path.Root("description"))
+	description, descriptionDiags := requestRequiredString(m.Description, path.Root("description"))
 	diags.Append(descriptionDiags...)
 
-	displayField, displayFieldDiags := contentTypeRequiredString(m.DisplayField, path.Root("display_field"))
+	displayField, displayFieldDiags := requestRequiredString(m.DisplayField, path.Root("display_field"))
 	diags.Append(displayFieldDiags...)
 
 	fields, fieldsDiags := FieldsListToContentTypeRequestDataFields(ctx, path.Root("fields"), m.Fields)
@@ -80,28 +79,28 @@ func ToContentTypeRequestDataFieldsItem(
 ) (cm.ContentTypeRequestDataFieldsItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	fieldID, idDiags := contentTypeRequiredString(v.ID, valuePath.AtName("id"))
+	fieldID, idDiags := requestRequiredString(v.ID, valuePath.AtName("id"))
 	diags.Append(idDiags...)
 
-	name, nameDiags := contentTypeRequiredString(v.Name, valuePath.AtName("name"))
+	name, nameDiags := requestRequiredString(v.Name, valuePath.AtName("name"))
 	diags.Append(nameDiags...)
 
-	fieldType, fieldTypeDiags := contentTypeRequiredString(v.FieldType, valuePath.AtName("type"))
+	fieldType, fieldTypeDiags := requestRequiredString(v.FieldType, valuePath.AtName("type"))
 	diags.Append(fieldTypeDiags...)
 
-	localized, localizedDiags := contentTypeRequiredBool(v.Localized, valuePath.AtName("localized"))
+	localized, localizedDiags := requestRequiredBool(v.Localized, valuePath.AtName("localized"))
 	diags.Append(localizedDiags...)
 
-	required, requiredDiags := contentTypeRequiredBool(v.Required, valuePath.AtName("required"))
+	required, requiredDiags := requestRequiredBool(v.Required, valuePath.AtName("required"))
 	diags.Append(requiredDiags...)
 
-	linkType, linkTypeDiags := contentTypeOptionalString(v.LinkType, valuePath.AtName("link_type"))
+	linkType, linkTypeDiags := requestOptionalString(v.LinkType, valuePath.AtName("link_type"))
 	diags.Append(linkTypeDiags...)
 
-	disabled, disabledDiags := contentTypeOptionalBool(v.Disabled, valuePath.AtName("disabled"))
+	disabled, disabledDiags := requestOptionalBool(v.Disabled, valuePath.AtName("disabled"))
 	diags.Append(disabledDiags...)
 
-	omitted, omittedDiags := contentTypeOptionalBool(v.Omitted, valuePath.AtName("omitted"))
+	omitted, omittedDiags := requestOptionalBool(v.Omitted, valuePath.AtName("omitted"))
 	diags.Append(omittedDiags...)
 
 	items, itemsDiags := ItemsObjectToOptContentTypeRequestDataFieldsItemItems(ctx, valuePath.AtName("items"), v.Items)
@@ -201,10 +200,10 @@ func (v ContentTypeFieldItemsValue) ToContentTypeRequestDataFieldsItemItems(
 ) (cm.ContentTypeRequestDataFieldsItemItems, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	itemsType, itemsTypeDiags := contentTypeRequiredString(v.ItemsType, valuePath.AtName("type"))
+	itemsType, itemsTypeDiags := requestRequiredString(v.ItemsType, valuePath.AtName("type"))
 	diags.Append(itemsTypeDiags...)
 
-	linkType, linkTypeDiags := contentTypeOptionalString(v.LinkType, valuePath.AtName("link_type"))
+	linkType, linkTypeDiags := requestOptionalString(v.LinkType, valuePath.AtName("link_type"))
 	diags.Append(linkTypeDiags...)
 
 	validations, validationsDiags := ValidationsListToContentTypeRequestDataFieldValidations(ctx, valuePath.AtName("validations"), v.Validations)
@@ -334,7 +333,7 @@ func (v ContentTypeFieldAllowedResourceItemExternalValue) ToResourceLink(
 	_ context.Context,
 	valuePath path.Path,
 ) (cm.ResourceLink, diag.Diagnostics) {
-	typeID, diags := contentTypeRequiredString(v.TypeID, valuePath.AtName("type"))
+	typeID, diags := requestRequiredString(v.TypeID, valuePath.AtName("type"))
 	if diags.HasError() {
 		return cm.ResourceLink{}, diags
 	}
@@ -348,7 +347,7 @@ func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) ToResourceLink(
 ) (cm.ResourceLink, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	source, sourceDiags := contentTypeRequiredString(v.Source, valuePath.AtName("source"))
+	source, sourceDiags := requestRequiredString(v.Source, valuePath.AtName("source"))
 	diags.Append(sourceDiags...)
 
 	contentTypesPath := valuePath.AtName("content_types")
@@ -383,90 +382,4 @@ func (v ContentTypeFieldAllowedResourceItemContentfulEntryValue) ToResourceLink(
 		Source:       cm.NewOptString(source),
 		ContentTypes: contentTypes,
 	}, diags
-}
-
-func contentTypeRequiredString(value types.String, valuePath path.Path) (string, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	switch {
-	case value.IsUnknown():
-		diags.AddAttributeError(
-			valuePath,
-			"Unexpected unknown string",
-			"The string value must be known before it can be sent to Contentful.",
-		)
-	case value.IsNull():
-		diags.AddAttributeError(
-			valuePath,
-			"Unexpected null string",
-			"The required string value cannot be null.",
-		)
-	default:
-		return value.ValueString(), diags
-	}
-
-	return "", diags
-}
-
-func contentTypeRequiredBool(value types.Bool, valuePath path.Path) (bool, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	switch {
-	case value.IsUnknown():
-		diags.AddAttributeError(
-			valuePath,
-			"Unexpected unknown boolean",
-			"The boolean value must be known before it can be sent to Contentful.",
-		)
-	case value.IsNull():
-		diags.AddAttributeError(
-			valuePath,
-			"Unexpected null boolean",
-			"The required boolean value cannot be null.",
-		)
-	default:
-		return value.ValueBool(), diags
-	}
-
-	return false, diags
-}
-
-func contentTypeOptionalString(value types.String, valuePath path.Path) (cm.OptString, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	if value.IsUnknown() {
-		diags.AddAttributeError(
-			valuePath,
-			"Unexpected unknown string",
-			"The string value must be known before it can be sent to Contentful.",
-		)
-
-		return cm.OptString{}, diags
-	}
-
-	if value.IsNull() {
-		return cm.OptString{}, diags
-	}
-
-	return cm.NewOptString(value.ValueString()), diags
-}
-
-func contentTypeOptionalBool(value types.Bool, valuePath path.Path) (cm.OptBool, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	if value.IsUnknown() {
-		diags.AddAttributeError(
-			valuePath,
-			"Unexpected unknown boolean",
-			"The boolean value must be known before it can be sent to Contentful.",
-		)
-
-		return cm.OptBool{}, diags
-	}
-
-	if value.IsNull() {
-		return cm.OptBool{}, diags
-	}
-
-	return cm.NewOptBool(value.ValueBool()), diags
 }

--- a/internal/provider/request_primitive.go
+++ b/internal/provider/request_primitive.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func requestRequiredString(value types.String, valuePath path.Path) (string, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown string",
+			"The string value must be known before it can be sent to Contentful.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null string",
+			"The required string value cannot be null.",
+		)
+	default:
+		return value.ValueString(), diags
+	}
+
+	return "", diags
+}
+
+func requestRequiredBool(value types.Bool, valuePath path.Path) (bool, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown boolean",
+			"The boolean value must be known before it can be sent to Contentful.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null boolean",
+			"The required boolean value cannot be null.",
+		)
+	default:
+		return value.ValueBool(), diags
+	}
+
+	return false, diags
+}
+
+func requestOptionalString(value types.String, valuePath path.Path) (cm.OptString, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown string",
+			"The string value must be known before it can be sent to Contentful.",
+		)
+
+		return cm.OptString{}, diags
+	}
+
+	if value.IsNull() {
+		return cm.OptString{}, diags
+	}
+
+	return cm.NewOptString(value.ValueString()), diags
+}
+
+func requestOptionalBool(value types.Bool, valuePath path.Path) (cm.OptBool, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown boolean",
+			"The boolean value must be known before it can be sent to Contentful.",
+		)
+
+		return cm.OptBool{}, diags
+	}
+
+	if value.IsNull() {
+		return cm.OptBool{}, diags
+	}
+
+	return cm.NewOptBool(value.ValueBool()), diags
+}

--- a/internal/provider/request_primitive_test.go
+++ b/internal/provider/request_primitive_test.go
@@ -1,0 +1,123 @@
+//nolint:testpackage // The package-private request conversion module is intentionally tested through its interface.
+package provider
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestRequiredString(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		value         types.String
+		expected      string
+		expectedPaths []string
+	}{
+		"known":   {value: types.StringValue("value"), expected: "value", expectedPaths: []string{}},
+		"null":    {value: types.StringNull(), expectedPaths: []string{"value"}},
+		"unknown": {value: types.StringUnknown(), expectedPaths: []string{"value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := requestRequiredString(test.value, path.Root("value"))
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, requestDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestRequestRequiredBool(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		value         types.Bool
+		expected      bool
+		expectedPaths []string
+	}{
+		"known true":  {value: types.BoolValue(true), expected: true, expectedPaths: []string{}},
+		"known false": {value: types.BoolValue(false), expected: false, expectedPaths: []string{}},
+		"null":        {value: types.BoolNull(), expectedPaths: []string{"value"}},
+		"unknown":     {value: types.BoolUnknown(), expectedPaths: []string{"value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := requestRequiredBool(test.value, path.Root("value"))
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, requestDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestRequestOptionalString(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		value         types.String
+		expected      cm.OptString
+		expectedPaths []string
+	}{
+		"known":   {value: types.StringValue("value"), expected: cm.NewOptString("value"), expectedPaths: []string{}},
+		"null":    {value: types.StringNull(), expectedPaths: []string{}},
+		"unknown": {value: types.StringUnknown(), expectedPaths: []string{"value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := requestOptionalString(test.value, path.Root("value"))
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, requestDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestRequestOptionalBool(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		value         types.Bool
+		expected      cm.OptBool
+		expectedPaths []string
+	}{
+		"known":   {value: types.BoolValue(true), expected: cm.NewOptBool(true), expectedPaths: []string{}},
+		"null":    {value: types.BoolNull(), expectedPaths: []string{}},
+		"unknown": {value: types.BoolUnknown(), expectedPaths: []string{"value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := requestOptionalBool(test.value, path.Root("value"))
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, requestDiagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestRequestPrimitiveErrorsReturnZeroValues(t *testing.T) {
+	t.Parallel()
+
+	stringValue, stringDiags := requestRequiredString(types.StringUnknown(), path.Root("string"))
+	boolValue, boolDiags := requestRequiredBool(types.BoolUnknown(), path.Root("bool"))
+	optionalString, optionalStringDiags := requestOptionalString(types.StringUnknown(), path.Root("optional_string"))
+	optionalBool, optionalBoolDiags := requestOptionalBool(types.BoolUnknown(), path.Root("optional_bool"))
+
+	require.True(t, stringDiags.HasError())
+	require.True(t, boolDiags.HasError())
+	require.True(t, optionalStringDiags.HasError())
+	require.True(t, optionalBoolDiags.HasError())
+	assert.Empty(t, stringValue)
+	assert.False(t, boolValue)
+	assert.Equal(t, cm.OptString{}, optionalString)
+	assert.Equal(t, cm.OptBool{}, optionalBool)
+}


### PR DESCRIPTION
## Summary
- move Content Type request scalar validation into package-internal request primitives
- preserve existing required and optional null/unknown semantics while making the converters reusable by later request-boundary PRs
- cover known, null, unknown, exact diagnostic paths, and fail-closed zero values

## Stack
- Depends on the Content Type request-union branch (`codex/content-type-request-unions`).
- Editor Interface, Webhook, and Team request-value PRs will stack on this branch.

## Validation
- `go test ./internal/provider -run 'TestRequest(Required|Optional|Primitive)' -count=1`\n- `go test ./...`\n- `go generate ./...` (clean working tree afterward)\n- `golangci-lint cache clean` immediately followed by `golangci-lint run` (0 issues)