### PR TITLE
fix(team): reject unresolved request values

### DIFF
--- a/internal/provider/team_model_request.go
+++ b/internal/provider/team_model_request.go
@@ -8,18 +8,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-func (model *TeamModel) ToTeamData(_ context.Context, _ path.Path) (cm.TeamData, diag.Diagnostics) {
+func (model *TeamModel) ToTeamData(_ context.Context, valuePath path.Path) (cm.TeamData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	fields := cm.TeamData{
-		Name: model.Name.ValueString(),
+	name, nameDiags := requestRequiredString(model.Name, valuePath.AtName("name"))
+	diags.Append(nameDiags...)
+
+	description := cm.NilString{}
+
+	switch {
+	case model.Description.IsUnknown():
+		diags.AddAttributeError(
+			valuePath.AtName("description"),
+			"Unexpected unknown string",
+			"The string value must be known before it can be sent to Contentful.",
+		)
+	case model.Description.IsNull():
+		description = cm.NewNilStringNull()
+	default:
+		description = cm.NewNilString(model.Description.ValueString())
 	}
 
-	if !model.Description.IsNull() && !model.Description.IsUnknown() {
-		fields.Description = cm.NewNilString(model.Description.ValueString())
-	} else {
-		fields.Description = cm.NewNilStringNull()
+	if diags.HasError() {
+		return cm.TeamData{}, diags
 	}
 
-	return fields, diags
+	return cm.TeamData{
+		Name:        name,
+		Description: description,
+	}, diags
 }

--- a/internal/provider/team_model_request_test.go
+++ b/internal/provider/team_model_request_test.go
@@ -1,0 +1,91 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeamModelToTeamData(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		model               provider.TeamModel
+		expected            cm.TeamData
+		expectedDiagnostics []string
+	}{
+		"known": {
+			model: provider.TeamModel{
+				Name:        types.StringValue("Editors"),
+				Description: types.StringValue("Content editors"),
+			},
+			expected: cm.TeamData{
+				Name:        "Editors",
+				Description: cm.NewNilString("Content editors"),
+			},
+		},
+		"known empty description": {
+			model: provider.TeamModel{
+				Name:        types.StringValue("Editors"),
+				Description: types.StringValue(""),
+			},
+			expected: cm.TeamData{
+				Name:        "Editors",
+				Description: cm.NewNilString(""),
+			},
+		},
+		"null description": {
+			model: provider.TeamModel{
+				Name:        types.StringValue("Editors"),
+				Description: types.StringNull(),
+			},
+			expected: cm.TeamData{
+				Name:        "Editors",
+				Description: cm.NewNilStringNull(),
+			},
+		},
+		"unknown description": {
+			model: provider.TeamModel{
+				Name:        types.StringValue("Editors"),
+				Description: types.StringUnknown(),
+			},
+			expectedDiagnostics: []string{"description"},
+		},
+		"unknown name": {
+			model: provider.TeamModel{
+				Name:        types.StringUnknown(),
+				Description: types.StringValue("Content editors"),
+			},
+			expectedDiagnostics: []string{"name"},
+		},
+		"null name and unknown description": {
+			model: provider.TeamModel{
+				Name:        types.StringNull(),
+				Description: types.StringUnknown(),
+			},
+			expectedDiagnostics: []string{"name", "description"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := test.model.ToTeamData(t.Context(), path.Empty())
+
+			if len(test.expectedDiagnostics) == 0 {
+				require.False(t, diags.HasError(), diags.Errors())
+				assert.Equal(t, test.expected, actual)
+
+				return
+			}
+
+			assert.Equal(t, cm.TeamData{}, actual)
+			require.True(t, diags.HasError())
+			assert.Equal(t, test.expectedDiagnostics, attributeDiagnosticPaths(t, diags))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- convert the required Team name and nullable description through path-aware request helpers
- reject unknown request values and return a zero `TeamData` when any conversion fails
- preserve known strings (including an empty description) and preserve a null description as an explicit remote `null`

## Stack

This draft PR is based on and depends on #606 (`codex/request-scalar-values`). It adds the nullable-string helper with its first and only current consumer, keeping the foundation limited to primitives already used by Content Type.

## Scope

Team request conversion and focused tests only. Response conversion, schema, generated documentation, and lifecycle-guaranteed Team request identifiers are unchanged.

## Validation

- `go test ./internal/provider -run '^(TestRequestNullableString|TestRequestPrimitiveErrorsReturnZeroValues|TestTeamModelToTeamData)$' -count=1`
- `go test ./...`
- `go generate ./...` (clean worktree)
- `golangci-lint cache clean`
- `golangci-lint run` (`0 issues`)
