### PR TITLE
fix(webhook): reject unresolved request values

### DIFF
--- a/internal/provider/webhook_header_value_request.go
+++ b/internal/provider/webhook_header_value_request.go
@@ -11,17 +11,19 @@ import (
 func (v WebhookHeaderValue) ToWebhookDefinitionHeader(_ context.Context, path path.Path, key string) (cm.WebhookDefinitionHeader, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	header := cm.WebhookDefinitionHeader{
-		Key: key,
+	value, valueDiags := requestRequiredString(v.Value, path.AtName("value"))
+	diags.Append(valueDiags...)
+
+	secret, secretDiags := requestRequiredBool(v.Secret, path.AtName("secret"))
+	diags.Append(secretDiags...)
+
+	if diags.HasError() {
+		return cm.WebhookDefinitionHeader{}, diags
 	}
 
-	if v.Value.IsNull() || v.Value.IsUnknown() {
-		diags.AddAttributeError(path.AtName("value"), "Value is required", "")
-	}
-
-	header.Value = cm.NewOptPointerString(v.Value.ValueStringPointer())
-
-	header.Secret = cm.NewOptBool(v.Secret.ValueBool())
-
-	return header, diags
+	return cm.WebhookDefinitionHeader{
+		Key:    key,
+		Value:  cm.NewOptString(value),
+		Secret: cm.NewOptBool(secret),
+	}, diags
 }

--- a/internal/provider/webhook_headers_request.go
+++ b/internal/provider/webhook_headers_request.go
@@ -33,11 +33,37 @@ func ToWebhookDefinitionHeaders(ctx context.Context, path path.Path, model Typed
 
 	for index, key := range headersKeys {
 		headersValue := headersValues[key]
+		headerValue, ok := headersValue.GetValue()
+		headerPath := path.AtMapKey(key)
 
-		header, headerDiags := headersValue.Value().ToWebhookDefinitionHeader(ctx, path.AtMapKey(key), key)
+		if !ok {
+			if headersValue.IsUnknown() {
+				diags.AddAttributeError(
+					headerPath,
+					"Unexpected unknown webhook header",
+					"The webhook header must be known before it can be sent to Contentful.",
+				)
+			} else {
+				diags.AddAttributeError(
+					headerPath,
+					"Unexpected null webhook header",
+					"Null webhook headers cannot be sent to Contentful.",
+				)
+			}
+
+			continue
+		}
+
+		header, headerDiags := headerValue.ToWebhookDefinitionHeader(ctx, headerPath, key)
 		diags.Append(headerDiags...)
 
-		headers[index] = header
+		if !headerDiags.HasError() {
+			headers[index] = header
+		}
+	}
+
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return headers, diags

--- a/internal/provider/webhook_model_request.go
+++ b/internal/provider/webhook_model_request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
-	"github.com/cysp/terraform-provider-contentful/internal/provider/util"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -13,19 +12,41 @@ import (
 func (model *WebhookModel) ToWebhookDefinitionData(ctx context.Context, path path.Path) (cm.WebhookDefinitionData, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
+	name, nameDiags := requestRequiredString(model.Name, path.AtName("name"))
+	diags.Append(nameDiags...)
+
+	url, urlDiags := requestRequiredString(model.URL, path.AtName("url"))
+	diags.Append(urlDiags...)
+
+	active, activeDiags := requestRequiredBool(model.Active, path.AtName("active"))
+	diags.Append(activeDiags...)
+
+	httpBasicUsername, httpBasicUsernameDiags := webhookOptionalNullableString(model.HTTPBasicUsername, path.AtName("http_basic_username"))
+	diags.Append(httpBasicUsernameDiags...)
+
+	httpBasicPassword, httpBasicPasswordDiags := webhookOptionalNullableString(model.HTTPBasicPassword, path.AtName("http_basic_password"))
+	diags.Append(httpBasicPasswordDiags...)
+
 	req := cm.WebhookDefinitionData{
-		Name:              model.Name.ValueString(),
-		URL:               model.URL.ValueString(),
-		Active:            util.BoolValueToOptBool(model.Active),
-		HttpBasicUsername: cm.NewOptNilPointerString(model.HTTPBasicUsername.ValueStringPointer()),
-		HttpBasicPassword: cm.NewOptNilPointerString(model.HTTPBasicPassword.ValueStringPointer()),
+		Name:              name,
+		URL:               url,
+		Active:            cm.NewOptBool(active),
+		HttpBasicUsername: httpBasicUsername,
+		HttpBasicPassword: httpBasicPassword,
 	}
 
-	if model.Topics.IsNull() || model.Topics.IsUnknown() {
+	switch {
+	case model.Topics.IsUnknown():
+		diags.AddAttributeError(
+			path.AtName("topics"),
+			"Unexpected unknown webhook topics",
+			"Webhook topics must be known before they can be sent to Contentful.",
+		)
+	case model.Topics.IsNull():
 		req.Topics = nil
-	} else {
-		topics := make([]string, len(model.Topics.Elements()))
-		diags.Append(tfsdk.ValueAs(ctx, model.Topics, &topics)...)
+	default:
+		topics, topicDiags := knownStringListElements(path.AtName("topics"), model.Topics.Elements())
+		diags.Append(topicDiags...)
 
 		req.Topics = topics
 	}
@@ -61,6 +82,10 @@ func (model *WebhookModel) ToWebhookDefinitionData(ctx context.Context, path pat
 	diags.Append(transformationDiags...)
 
 	req.Transformation = transformation
+
+	if diags.HasError() {
+		return cm.WebhookDefinitionData{}, diags
+	}
 
 	return req, diags
 }

--- a/internal/provider/webhook_optional_nullable_string_request.go
+++ b/internal/provider/webhook_optional_nullable_string_request.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func webhookOptionalNullableString(value types.String, valuePath path.Path) (cm.OptNilString, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown string",
+			"The string value must be known before it can be sent to Contentful.",
+		)
+
+		return cm.OptNilString{}, diags
+	}
+
+	if value.IsNull() {
+		return cm.NewOptNilStringNull(), diags
+	}
+
+	return cm.NewOptNilString(value.ValueString()), diags
+}

--- a/internal/provider/webhook_optional_nullable_string_request_test.go
+++ b/internal/provider/webhook_optional_nullable_string_request_test.go
@@ -1,0 +1,34 @@
+//nolint:testpackage // The package-private Webhook request converter is intentionally tested directly.
+package provider
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhookOptionalNullableString(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		value         types.String
+		expected      cm.OptNilString
+		expectedPaths []string
+	}{
+		"known":   {value: types.StringValue("value"), expected: cm.NewOptNilString("value"), expectedPaths: []string{}},
+		"null":    {value: types.StringNull(), expected: cm.NewOptNilStringNull(), expectedPaths: []string{}},
+		"unknown": {value: types.StringUnknown(), expectedPaths: []string{"value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := webhookOptionalNullableString(test.value, path.Root("value"))
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, requestDiagnosticPaths(t, diags))
+		})
+	}
+}

--- a/internal/provider/webhook_request_values_test.go
+++ b/internal/provider/webhook_request_values_test.go
@@ -1,0 +1,249 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookModelRejectsUnresolvedScalarRequestValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setValue     func(*WebhookModel)
+		expectedPath string
+	}{
+		"unknown name": {
+			setValue:     func(model *WebhookModel) { model.Name = types.StringUnknown() },
+			expectedPath: "name",
+		},
+		"null name": {
+			setValue:     func(model *WebhookModel) { model.Name = types.StringNull() },
+			expectedPath: "name",
+		},
+		"unknown URL": {
+			setValue:     func(model *WebhookModel) { model.URL = types.StringUnknown() },
+			expectedPath: "url",
+		},
+		"null URL": {
+			setValue:     func(model *WebhookModel) { model.URL = types.StringNull() },
+			expectedPath: "url",
+		},
+		"unknown active": {
+			setValue:     func(model *WebhookModel) { model.Active = types.BoolUnknown() },
+			expectedPath: "active",
+		},
+		"null active": {
+			setValue:     func(model *WebhookModel) { model.Active = types.BoolNull() },
+			expectedPath: "active",
+		},
+		"unknown username": {
+			setValue:     func(model *WebhookModel) { model.HTTPBasicUsername = types.StringUnknown() },
+			expectedPath: "http_basic_username",
+		},
+		"unknown password": {
+			setValue:     func(model *WebhookModel) { model.HTTPBasicPassword = types.StringUnknown() },
+			expectedPath: "http_basic_password",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validWebhookRequestModel()
+			test.setValue(&model)
+
+			actual, diags := model.ToWebhookDefinitionData(t.Context(), path.Empty())
+
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+			assert.Equal(t, cm.WebhookDefinitionData{}, actual)
+		})
+	}
+}
+
+func TestWebhookModelTopicsRequestValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		topics        TypedList[types.String]
+		expected      []string
+		expectedPaths []string
+	}{
+		"null is omitted": {
+			topics: NewTypedListNull[types.String](),
+		},
+		"empty is preserved": {
+			topics:   NewTypedList([]types.String{}),
+			expected: []string{},
+		},
+		"known": {
+			topics: NewTypedList([]types.String{
+				types.StringValue("Entry.create"),
+				types.StringValue("Entry.delete"),
+			}),
+			expected: []string{"Entry.create", "Entry.delete"},
+		},
+		"unknown list": {
+			topics:        NewTypedListUnknown[types.String](),
+			expectedPaths: []string{"topics"},
+		},
+		"unknown and null children fail atomically": {
+			topics: NewTypedList([]types.String{
+				types.StringValue("Entry.create"),
+				types.StringUnknown(),
+				types.StringNull(),
+			}),
+			expectedPaths: []string{"topics[1]", "topics[2]"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := validWebhookRequestModel()
+			model.Topics = test.topics
+
+			actual, diags := model.ToWebhookDefinitionData(t.Context(), path.Empty())
+
+			if len(test.expectedPaths) > 0 {
+				require.True(t, diags.HasError())
+				assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+				assert.Equal(t, cm.WebhookDefinitionData{}, actual)
+			} else {
+				require.False(t, diags.HasError())
+				assert.Equal(t, test.expected, actual.Topics)
+			}
+		})
+	}
+}
+
+func TestWebhookHeadersRequestValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	validHeader := DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
+		"value":  types.StringValue("value"),
+		"secret": types.BoolValue(false),
+	}))
+	unknownValueHeader := DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
+		"value":  types.StringUnknown(),
+		"secret": types.BoolValue(false),
+	}))
+	unknownSecretHeader := DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
+		"value":  types.StringValue("value"),
+		"secret": types.BoolUnknown(),
+	}))
+	nullValueHeader := DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
+		"value":  types.StringNull(),
+		"secret": types.BoolValue(false),
+	}))
+	nullSecretHeader := DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookHeaderValue](ctx, map[string]attr.Value{
+		"value":  types.StringValue("value"),
+		"secret": types.BoolNull(),
+	}))
+
+	tests := map[string]struct {
+		headers       TypedMap[TypedObject[WebhookHeaderValue]]
+		expected      cm.WebhookDefinitionHeaders
+		expectedPaths []string
+	}{
+		"null is omitted": {
+			headers: NewTypedMapNull[TypedObject[WebhookHeaderValue]](),
+		},
+		"computed unknown is omitted": {
+			headers: NewTypedMapUnknown[TypedObject[WebhookHeaderValue]](),
+		},
+		"empty is preserved": {
+			headers:  NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{}),
+			expected: cm.WebhookDefinitionHeaders{},
+		},
+		"known values are sorted": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"Z-Header": validHeader,
+				"A-Header": validHeader,
+			}),
+			expected: cm.WebhookDefinitionHeaders{
+				{Key: "A-Header", Value: cm.NewOptString("value"), Secret: cm.NewOptBool(false)},
+				{Key: "Z-Header", Value: cm.NewOptString("value"), Secret: cm.NewOptBool(false)},
+			},
+		},
+		"unknown object": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"X-Header": NewTypedObjectUnknown[WebhookHeaderValue](),
+			}),
+			expectedPaths: []string{"headers[\"X-Header\"]"},
+		},
+		"null object": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"X-Header": NewTypedObjectNull[WebhookHeaderValue](),
+			}),
+			expectedPaths: []string{"headers[\"X-Header\"]"},
+		},
+		"unknown value": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"X-Header": unknownValueHeader,
+			}),
+			expectedPaths: []string{"headers[\"X-Header\"].value"},
+		},
+		"null value": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"X-Header": nullValueHeader,
+			}),
+			expectedPaths: []string{"headers[\"X-Header\"].value"},
+		},
+		"null secret": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"X-Header": nullSecretHeader,
+			}),
+			expectedPaths: []string{"headers[\"X-Header\"].secret"},
+		},
+		"mixed valid and unknown values fail atomically": {
+			headers: NewTypedMap(map[string]TypedObject[WebhookHeaderValue]{
+				"A-Header": validHeader,
+				"X-Header": unknownSecretHeader,
+			}),
+			expectedPaths: []string{"headers[\"X-Header\"].secret"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := ToWebhookDefinitionHeaders(ctx, path.Root("headers"), test.headers)
+
+			if len(test.expectedPaths) > 0 {
+				require.True(t, diags.HasError())
+				assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+				assert.Nil(t, actual)
+			} else {
+				require.False(t, diags.HasError())
+				assert.Equal(t, test.expected, actual)
+			}
+		})
+	}
+}
+
+func validWebhookRequestModel() WebhookModel {
+	return WebhookModel{
+		Name:              types.StringValue("webhook"),
+		URL:               types.StringValue("https://example.com/webhook"),
+		Active:            types.BoolValue(true),
+		HTTPBasicUsername: types.StringNull(),
+		HTTPBasicPassword: types.StringNull(),
+		Topics:            NewTypedListNull[types.String](),
+		Filters:           NewTypedListNull[TypedObject[WebhookFilterValue]](),
+		Headers:           NewTypedMapNull[TypedObject[WebhookHeaderValue]](),
+		Transformation:    NewTypedObjectNull[WebhookTransformationValue](),
+	}
+}

--- a/internal/provider/webhook_transformation_value_request.go
+++ b/internal/provider/webhook_transformation_value_request.go
@@ -8,37 +8,59 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
-func ToOptNilWebhookDefinitionDataTransformation(_ context.Context, _ path.Path, value TypedObject[WebhookTransformationValue]) (cm.OptNilWebhookDefinitionDataTransformation, diag.Diagnostics) {
+func ToOptNilWebhookDefinitionDataTransformation(_ context.Context, valuePath path.Path, value TypedObject[WebhookTransformationValue]) (cm.OptNilWebhookDefinitionDataTransformation, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	optNilTransformation := cm.OptNilWebhookDefinitionDataTransformation{}
 
 	switch {
 	case value.IsUnknown():
-		//
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown webhook transformation",
+			"The webhook transformation must be known before it can be sent to Contentful.",
+		)
 	case value.IsNull():
 		optNilTransformation.SetToNull()
 	default:
-		transformation := cm.WebhookDefinitionDataTransformation{}
-
 		value := value.Value()
 
-		transformation.Method = cm.NewOptPointerString(value.Method.ValueStringPointer())
-		transformation.ContentType = cm.NewOptPointerString(value.ContentType.ValueStringPointer())
-		transformation.IncludeContentLength = cm.NewOptPointerBool(value.IncludeContentLength.ValueBoolPointer())
+		method, methodDiags := requestOptionalString(value.Method, valuePath.AtName("method"))
+		diags.Append(methodDiags...)
 
-		//nolint:revive
-		if value.Body.IsUnknown() {
-		} else {
-			bodyStringPointer := value.Body.ValueStringPointer()
-			if bodyStringPointer != nil {
-				transformation.Body = []byte(*bodyStringPointer)
-			} else {
-				transformation.Body = nil
-			}
+		contentType, contentTypeDiags := requestOptionalString(value.ContentType, valuePath.AtName("content_type"))
+		diags.Append(contentTypeDiags...)
+
+		includeContentLength, includeContentLengthDiags := requestOptionalBool(
+			value.IncludeContentLength,
+			valuePath.AtName("include_content_length"),
+		)
+		diags.Append(includeContentLengthDiags...)
+
+		var body []byte
+
+		switch {
+		case value.Body.IsUnknown():
+			diags.AddAttributeError(
+				valuePath.AtName("body"),
+				"Unexpected unknown webhook transformation body",
+				"The webhook transformation body must be known before it can be sent to Contentful.",
+			)
+		case value.Body.IsNull():
+		default:
+			body = []byte(value.Body.ValueString())
 		}
 
-		optNilTransformation.SetTo(transformation)
+		if diags.HasError() {
+			return cm.OptNilWebhookDefinitionDataTransformation{}, diags
+		}
+
+		optNilTransformation.SetTo(cm.WebhookDefinitionDataTransformation{
+			Method:               method,
+			ContentType:          contentType,
+			IncludeContentLength: includeContentLength,
+			Body:                 body,
+		})
 	}
 
 	return optNilTransformation, diags

--- a/internal/provider/webhook_transformation_value_request_test.go
+++ b/internal/provider/webhook_transformation_value_request_test.go
@@ -1,0 +1,155 @@
+package provider_test
+
+import (
+	"testing"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	. "github.com/cysp/terraform-provider-contentful/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookTransformationRequestValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	valuePath := path.Root("transformation")
+
+	known := func(values map[string]attr.Value) TypedObject[WebhookTransformationValue] {
+		t.Helper()
+
+		return DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookTransformationValue](ctx, values))
+	}
+
+	nullChildren := map[string]attr.Value{
+		"method":                 types.StringNull(),
+		"content_type":           types.StringNull(),
+		"include_content_length": types.BoolNull(),
+		"body":                   jsontypes.NewNormalizedNull(),
+	}
+
+	tests := map[string]struct {
+		value         TypedObject[WebhookTransformationValue]
+		expected      cm.OptNilWebhookDefinitionDataTransformation
+		expectedPaths []string
+	}{
+		"null is explicit null": {
+			value:    NewTypedObjectNull[WebhookTransformationValue](),
+			expected: cm.OptNilWebhookDefinitionDataTransformation{Set: true, Null: true},
+		},
+		"unknown object": {
+			value:         NewTypedObjectUnknown[WebhookTransformationValue](),
+			expectedPaths: []string{"transformation"},
+		},
+		"null children are omitted": {
+			value: known(nullChildren),
+			expected: cm.NewOptNilWebhookDefinitionDataTransformation(
+				cm.WebhookDefinitionDataTransformation{},
+			),
+		},
+		"known": {
+			value: known(map[string]attr.Value{
+				"method":                 types.StringValue("POST"),
+				"content_type":           types.StringValue("application/json"),
+				"include_content_length": types.BoolValue(true),
+				"body":                   NewNormalizedJSONTypesNormalizedValue([]byte(`{"key":"value"}`)),
+			}),
+			expected: cm.NewOptNilWebhookDefinitionDataTransformation(
+				cm.WebhookDefinitionDataTransformation{
+					Method:               cm.NewOptString("POST"),
+					ContentType:          cm.NewOptString("application/json"),
+					IncludeContentLength: cm.NewOptBool(true),
+					Body:                 []byte(`{"key":"value"}`),
+				},
+			),
+		},
+		"unknown method": {
+			value: known(map[string]attr.Value{
+				"method":                 types.StringUnknown(),
+				"content_type":           types.StringNull(),
+				"include_content_length": types.BoolNull(),
+				"body":                   jsontypes.NewNormalizedNull(),
+			}),
+			expectedPaths: []string{"transformation.method"},
+		},
+		"unknown content type": {
+			value: known(map[string]attr.Value{
+				"method":                 types.StringNull(),
+				"content_type":           types.StringUnknown(),
+				"include_content_length": types.BoolNull(),
+				"body":                   jsontypes.NewNormalizedNull(),
+			}),
+			expectedPaths: []string{"transformation.content_type"},
+		},
+		"unknown content length": {
+			value: known(map[string]attr.Value{
+				"method":                 types.StringNull(),
+				"content_type":           types.StringNull(),
+				"include_content_length": types.BoolUnknown(),
+				"body":                   jsontypes.NewNormalizedNull(),
+			}),
+			expectedPaths: []string{"transformation.include_content_length"},
+		},
+		"unknown body": {
+			value: known(map[string]attr.Value{
+				"method":                 types.StringNull(),
+				"content_type":           types.StringNull(),
+				"include_content_length": types.BoolNull(),
+				"body":                   jsontypes.NewNormalizedUnknown(),
+			}),
+			expectedPaths: []string{"transformation.body"},
+		},
+		"multiple unknown children fail atomically": {
+			value: known(map[string]attr.Value{
+				"method":                 types.StringValue("POST"),
+				"content_type":           types.StringUnknown(),
+				"include_content_length": types.BoolUnknown(),
+				"body":                   jsontypes.NewNormalizedUnknown(),
+			}),
+			expectedPaths: []string{
+				"transformation.content_type",
+				"transformation.include_content_length",
+				"transformation.body",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := ToOptNilWebhookDefinitionDataTransformation(ctx, valuePath, test.value)
+
+			if len(test.expectedPaths) > 0 {
+				require.True(t, diags.HasError())
+				assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+				assert.Equal(t, cm.OptNilWebhookDefinitionDataTransformation{}, actual)
+			} else {
+				require.False(t, diags.HasError())
+				assert.Equal(t, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestWebhookModelFailsClosedForNestedRequestError(t *testing.T) {
+	t.Parallel()
+
+	model := validWebhookRequestModel()
+	model.Transformation = DiagsNoErrorsMust(NewTypedObjectFromAttributes[WebhookTransformationValue](t.Context(), map[string]attr.Value{
+		"method":                 types.StringValue("POST"),
+		"content_type":           types.StringUnknown(),
+		"include_content_length": types.BoolNull(),
+		"body":                   jsontypes.NewNormalizedNull(),
+	}))
+
+	actual, diags := model.ToWebhookDefinitionData(t.Context(), path.Empty())
+
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"transformation.content_type"}, diagnosticPaths(t, diags))
+	assert.Equal(t, cm.WebhookDefinitionData{}, actual)
+}


### PR DESCRIPTION
## Summary

- validate all non-filter Webhook mutation payload scalars, topics, credentials, headers, and transformation values before building the Contentful request
- preserve null and known-empty wire semantics, including omission of an unresolved whole headers map under its Optional+Computed state-reuse contract
- report exact nested Terraform paths and fail closed with a zero complete request when any configured value remains unresolved
- keep the optional-nullable credential converter Webhook-local to avoid broadening the shared scalar seam or conflicting with sibling stack branches

## Stack

This draft is stacked on #606 (codex/request-scalar-values), which is itself stacked on the Content Type request-union work. Merge or rebase #606 first. Webhook filter unions are intentionally excluded and will be a child PR.

## Validation

- focused Webhook request tests
- go test ./...
- go generate ./... (clean)
- golangci-lint cache clean immediately before golangci-lint run (0 issues)

No shared helper, schema, documentation, filter conversion, or response conversion changes are included.