### PR TITLE
fix(editor-interface): reject unresolved request values

### DIFF
--- a/internal/provider/editor_interface_model_controls.go
+++ b/internal/provider/editor_interface_model_controls.go
@@ -12,21 +12,31 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func (v EditorInterfaceControlValue) ToEditorInterfaceDataControlsItem(_ context.Context, _ path.Path) (cm.EditorInterfaceDataControlsItem, diag.Diagnostics) {
+func (v EditorInterfaceControlValue) ToEditorInterfaceDataControlsItem(_ context.Context, valuePath path.Path) (cm.EditorInterfaceDataControlsItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	item := cm.EditorInterfaceDataControlsItem{
-		FieldId:         v.FieldID.ValueString(),
-		WidgetNamespace: util.StringValueToOptString(v.WidgetNamespace),
-		WidgetId:        util.StringValueToOptString(v.WidgetID),
+	fieldID, fieldIDDiags := requestRequiredString(v.FieldID, valuePath.AtName("field_id"))
+	diags.Append(fieldIDDiags...)
+
+	widgetNamespace, widgetNamespaceDiags := requestOptionalString(v.WidgetNamespace, valuePath.AtName("widget_namespace"))
+	diags.Append(widgetNamespaceDiags...)
+
+	widgetID, widgetIDDiags := requestOptionalString(v.WidgetID, valuePath.AtName("widget_id"))
+	diags.Append(widgetIDDiags...)
+
+	settings, settingsDiags := editorInterfaceOptionalSettings(v.Settings, valuePath.AtName("settings"))
+	diags.Append(settingsDiags...)
+
+	if diags.HasError() {
+		return cm.EditorInterfaceDataControlsItem{}, diags
 	}
 
-	modelSettingsString := v.Settings.ValueString()
-	if modelSettingsString != "" {
-		item.Settings = []byte(modelSettingsString)
-	}
-
-	return item, diags
+	return cm.EditorInterfaceDataControlsItem{
+		FieldId:         fieldID,
+		WidgetNamespace: widgetNamespace,
+		WidgetId:        widgetID,
+		Settings:        settings,
+	}, diags
 }
 
 func NewEditorInterfaceControlListValueFromResponse(_ context.Context, path path.Path, controlsItems []cm.EditorInterfaceControlsItem) (TypedList[TypedObject[EditorInterfaceControlValue]], diag.Diagnostics) {

--- a/internal/provider/editor_interface_model_editor_layout_item.go
+++ b/internal/provider/editor_interface_model_editor_layout_item.go
@@ -9,21 +9,19 @@ import (
 )
 
 func (v EditorInterfaceEditorLayoutItemValue) ToEditorInterfaceEditorLayoutItem(ctx context.Context, path path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+	groupPath := path.AtName("group")
+	group, diags := editorInterfaceRequiredObject(v.Group, groupPath)
 
-	// if !v.Field.IsUnknown() && !v.Field.IsNull() {
-	// 	fieldItem, fieldItemDiags := v.Field.Value().ToEditorInterfaceEditorLayoutFieldItem(ctx, path.AtName("field"))
-	// 	diags.Append(fieldItemDiags...)
-
-	// 	return cm.NewEditorInterfaceEditorLayoutFieldItemEditorInterfaceEditorLayoutItem(fieldItem), diags
-	// }
-
-	if !v.Group.IsUnknown() && !v.Group.IsNull() {
-		groupItem, groupItemDiags := v.Group.Value().ToEditorInterfaceEditorLayoutItem(ctx, path.AtName("group"))
-		diags.Append(groupItemDiags...)
-
-		return groupItem, diags
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutItem{}, diags
 	}
 
-	return cm.EditorInterfaceEditorLayoutItem{}, diags
+	item, itemDiags := group.ToEditorInterfaceEditorLayoutItem(ctx, groupPath)
+	diags.Append(itemDiags...)
+
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutItem{}, diags
+	}
+
+	return item, diags
 }

--- a/internal/provider/editor_interface_model_editor_layout_item_group.go
+++ b/internal/provider/editor_interface_model_editor_layout_item_group.go
@@ -37,27 +37,19 @@ func NewEditorInterfaceEditorLayoutItemGroupValueFromResponse(ctx context.Contex
 	return NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupValue](), diags
 }
 
-func (v EditorInterfaceEditorLayoutItemGroupValue) ToEditorInterfaceEditorLayoutItem(ctx context.Context, path path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	item := cm.EditorInterfaceEditorLayoutGroupItem{
-		GroupId: v.GroupID.ValueString(),
-		Name:    v.Name.ValueString(),
-	}
-
-	if !v.Items.IsNull() && !v.Items.IsUnknown() {
-		itemItemsValues := v.Items.Elements()
-
-		itemItems := make([]cm.EditorInterfaceEditorLayoutItem, len(itemItemsValues))
-
-		for index, itemItem := range itemItemsValues {
-			itemItemObject, itemItemObjectDiags := itemItem.Value().ToEditorInterfaceEditorLayoutItem(ctx, path.AtListIndex(index))
-			diags.Append(itemItemObjectDiags...)
-
-			itemItems[index] = itemItemObject
-		}
-
-		item.Items = itemItems
+func (v EditorInterfaceEditorLayoutItemGroupValue) ToEditorInterfaceEditorLayoutItem(ctx context.Context, valuePath path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+	item, diags := toEditorInterfaceEditorLayoutGroupItem(
+		ctx,
+		valuePath,
+		v.GroupID,
+		v.Name,
+		v.Items,
+		func(ctx context.Context, valuePath path.Path, value EditorInterfaceEditorLayoutItemGroupItemValue) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+			return value.ToEditorInterfaceEditorLayoutItem(ctx, valuePath)
+		},
+	)
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutItem{}, diags
 	}
 
 	return cm.NewEditorInterfaceEditorLayoutGroupItemEditorInterfaceEditorLayoutItem(item), diags

--- a/internal/provider/editor_interface_model_editor_layout_item_group_item.go
+++ b/internal/provider/editor_interface_model_editor_layout_item_group_item.go
@@ -66,22 +66,41 @@ func NewEditorInterfaceEditorLayoutItemValueFromResponse(ctx context.Context, pa
 	}
 }
 
-func (v EditorInterfaceEditorLayoutItemGroupItemValue) ToEditorInterfaceEditorLayoutItem(ctx context.Context, path path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+func (v EditorInterfaceEditorLayoutItemGroupItemValue) ToEditorInterfaceEditorLayoutItem(ctx context.Context, valuePath path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+	fieldPath := valuePath.AtName("field")
+	groupPath := valuePath.AtName("group")
 
-	if !v.Field.IsUnknown() && !v.Field.IsNull() {
-		fieldItem, fieldItemDiags := v.Field.Value().ToEditorInterfaceEditorLayoutFieldItem(ctx, path.AtName("field"))
-		diags.Append(fieldItemDiags...)
+	return convertExactlyOneKnownAlternative(
+		valuePath,
+		knownUnionAlternative[cm.EditorInterfaceEditorLayoutItem]{
+			Name:  "field",
+			Path:  fieldPath,
+			Value: v.Field,
+			Convert: func() (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+				field, _ := v.Field.GetValue()
+				fieldItem, diags := field.ToEditorInterfaceEditorLayoutFieldItem(ctx, fieldPath)
 
-		return cm.NewEditorInterfaceEditorLayoutFieldItemEditorInterfaceEditorLayoutItem(fieldItem), diags
-	}
+				if diags.HasError() {
+					return cm.EditorInterfaceEditorLayoutItem{}, diags
+				}
 
-	if !v.Group.IsUnknown() && !v.Group.IsNull() {
-		groupItem, groupItemDiags := v.Group.Value().ToEditorInterfaceEditorLayoutGroupItem(ctx, path.AtName("group"))
-		diags.Append(groupItemDiags...)
+				return cm.NewEditorInterfaceEditorLayoutFieldItemEditorInterfaceEditorLayoutItem(fieldItem), diags
+			},
+		},
+		knownUnionAlternative[cm.EditorInterfaceEditorLayoutItem]{
+			Name:  "group",
+			Path:  groupPath,
+			Value: v.Group,
+			Convert: func() (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+				group, _ := v.Group.GetValue()
+				groupItem, diags := group.ToEditorInterfaceEditorLayoutGroupItem(ctx, groupPath)
 
-		return cm.NewEditorInterfaceEditorLayoutGroupItemEditorInterfaceEditorLayoutItem(groupItem), diags
-	}
+				if diags.HasError() {
+					return cm.EditorInterfaceEditorLayoutItem{}, diags
+				}
 
-	return cm.EditorInterfaceEditorLayoutItem{}, diags
+				return cm.NewEditorInterfaceEditorLayoutGroupItemEditorInterfaceEditorLayoutItem(groupItem), diags
+			},
+		},
+	)
 }

--- a/internal/provider/editor_interface_model_editor_layout_item_group_item_field.go
+++ b/internal/provider/editor_interface_model_editor_layout_item_group_item_field.go
@@ -17,21 +17,27 @@ func NewEditorInterfaceEditorLayoutItemGroupItemFieldValueFromResponse(_ context
 	}), diags
 }
 
-func (v EditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValue) ToEditorInterfaceEditorLayoutItem(_ context.Context, _ path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+func (v EditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValue) ToEditorInterfaceEditorLayoutItem(_ context.Context, valuePath path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+	fieldID, diags := requestRequiredString(v.FieldID, valuePath.AtName("field_id"))
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutItem{}, diags
+	}
 
 	fieldItem := cm.EditorInterfaceEditorLayoutFieldItem{
-		FieldId: v.FieldID.ValueString(),
+		FieldId: fieldID,
 	}
 
 	return cm.NewEditorInterfaceEditorLayoutFieldItemEditorInterfaceEditorLayoutItem(fieldItem), diags
 }
 
-func (v EditorInterfaceEditorLayoutItemGroupItemFieldValue) ToEditorInterfaceEditorLayoutFieldItem(_ context.Context, _ path.Path) (cm.EditorInterfaceEditorLayoutFieldItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+func (v EditorInterfaceEditorLayoutItemGroupItemFieldValue) ToEditorInterfaceEditorLayoutFieldItem(_ context.Context, valuePath path.Path) (cm.EditorInterfaceEditorLayoutFieldItem, diag.Diagnostics) {
+	fieldID, diags := requestRequiredString(v.FieldID, valuePath.AtName("field_id"))
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutFieldItem{}, diags
+	}
 
 	fieldItem := cm.EditorInterfaceEditorLayoutFieldItem{
-		FieldId: v.FieldID.ValueString(),
+		FieldId: fieldID,
 	}
 
 	return fieldItem, diags

--- a/internal/provider/editor_interface_model_editor_layout_item_group_item_group.go
+++ b/internal/provider/editor_interface_model_editor_layout_item_group_item_group.go
@@ -22,28 +22,15 @@ func NewEditorInterfaceEditorLayoutItemGroupItemGroupValueFromResponse(ctx conte
 	}), diags
 }
 
-func (v EditorInterfaceEditorLayoutItemGroupItemGroupValue) ToEditorInterfaceEditorLayoutGroupItem(ctx context.Context, path path.Path) (cm.EditorInterfaceEditorLayoutGroupItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-
-	groupItem := cm.EditorInterfaceEditorLayoutGroupItem{
-		GroupId: v.GroupID.ValueString(),
-		Name:    v.Name.ValueString(),
-	}
-
-	if !v.Items.IsNull() && !v.Items.IsUnknown() {
-		itemItemsValues := v.Items.Elements()
-
-		itemItems := make([]cm.EditorInterfaceEditorLayoutItem, len(itemItemsValues))
-
-		for index, itemItem := range itemItemsValues {
-			itemItemObject, itemItemObjectDiags := itemItem.Value().ToEditorInterfaceEditorLayoutItem(ctx, path.AtListIndex(index))
-			diags.Append(itemItemObjectDiags...)
-
-			itemItems[index] = itemItemObject
-		}
-
-		groupItem.Items = itemItems
-	}
-
-	return groupItem, diags
+func (v EditorInterfaceEditorLayoutItemGroupItemGroupValue) ToEditorInterfaceEditorLayoutGroupItem(ctx context.Context, valuePath path.Path) (cm.EditorInterfaceEditorLayoutGroupItem, diag.Diagnostics) {
+	return toEditorInterfaceEditorLayoutGroupItem(
+		ctx,
+		valuePath,
+		v.GroupID,
+		v.Name,
+		v.Items,
+		func(ctx context.Context, valuePath path.Path, value EditorInterfaceEditorLayoutItemGroupItemGroupItemValue) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+			return value.ToEditorInterfaceEditorLayoutItem(ctx, valuePath)
+		},
+	)
 }

--- a/internal/provider/editor_interface_model_editor_layout_item_group_item_group_item.go
+++ b/internal/provider/editor_interface_model_editor_layout_item_group_item_group_item.go
@@ -54,21 +54,19 @@ func NewEditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValueFromResponse(
 }
 
 func (v EditorInterfaceEditorLayoutItemGroupItemGroupItemValue) ToEditorInterfaceEditorLayoutItem(ctx context.Context, path path.Path) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+	fieldPath := path.AtName("field")
+	field, diags := editorInterfaceRequiredObject(v.Field, fieldPath)
 
-	if !v.Field.IsUnknown() && !v.Field.IsNull() {
-		fieldItem, fieldItemDiags := v.Field.Value().ToEditorInterfaceEditorLayoutItem(ctx, path.AtName("field"))
-		diags.Append(fieldItemDiags...)
-
-		return fieldItem, diags
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutItem{}, diags
 	}
 
-	// if !v.Group.IsUnknown() && !v.Group.IsNull() {
-	// 	groupItem, groupItemDiags := v.Group.Value().ToEditorInterfaceEditorLayoutGroupItem(ctx, path.AtName("group"))
-	// 	diags.Append(groupItemDiags...)
+	item, itemDiags := field.ToEditorInterfaceEditorLayoutItem(ctx, fieldPath)
+	diags.Append(itemDiags...)
 
-	// 	return cm.NewEditorInterfaceEditorLayoutGroupItemEditorInterfaceEditorLayoutItem(groupItem), diags
-	// }
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutItem{}, diags
+	}
 
-	return cm.EditorInterfaceEditorLayoutItem{}, diags
+	return item, diags
 }

--- a/internal/provider/editor_interface_model_group_controls.go
+++ b/internal/provider/editor_interface_model_group_controls.go
@@ -12,21 +12,31 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func (v EditorInterfaceGroupControlValue) ToEditorInterfaceDataGroupControlsItem(_ context.Context, _ path.Path) (cm.EditorInterfaceDataGroupControlsItem, diag.Diagnostics) {
+func (v EditorInterfaceGroupControlValue) ToEditorInterfaceDataGroupControlsItem(_ context.Context, valuePath path.Path) (cm.EditorInterfaceDataGroupControlsItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	item := cm.EditorInterfaceDataGroupControlsItem{
-		GroupId:         v.GroupID.ValueString(),
-		WidgetNamespace: util.StringValueToOptString(v.WidgetNamespace),
-		WidgetId:        util.StringValueToOptString(v.WidgetID),
+	groupID, groupIDDiags := requestRequiredString(v.GroupID, valuePath.AtName("group_id"))
+	diags.Append(groupIDDiags...)
+
+	widgetNamespace, widgetNamespaceDiags := requestOptionalString(v.WidgetNamespace, valuePath.AtName("widget_namespace"))
+	diags.Append(widgetNamespaceDiags...)
+
+	widgetID, widgetIDDiags := requestOptionalString(v.WidgetID, valuePath.AtName("widget_id"))
+	diags.Append(widgetIDDiags...)
+
+	settings, settingsDiags := editorInterfaceOptionalSettings(v.Settings, valuePath.AtName("settings"))
+	diags.Append(settingsDiags...)
+
+	if diags.HasError() {
+		return cm.EditorInterfaceDataGroupControlsItem{}, diags
 	}
 
-	modelSettingsString := v.Settings.ValueString()
-	if modelSettingsString != "" {
-		item.Settings = []byte(modelSettingsString)
-	}
-
-	return item, diags
+	return cm.EditorInterfaceDataGroupControlsItem{
+		GroupId:         groupID,
+		WidgetNamespace: widgetNamespace,
+		WidgetId:        widgetID,
+		Settings:        settings,
+	}, diags
 }
 
 func NewEditorInterfaceGroupControlListValueFromResponse(_ context.Context, path path.Path, groupControlsItems []cm.EditorInterfaceGroupControlsItem) (TypedList[TypedObject[EditorInterfaceGroupControlValue]], diag.Diagnostics) {

--- a/internal/provider/editor_interface_model_request.go
+++ b/internal/provider/editor_interface_model_request.go
@@ -13,88 +13,64 @@ func (model *EditorInterfaceModel) ToEditorInterfaceData(ctx context.Context) (c
 
 	request := cm.EditorInterfaceData{}
 
-	if model.EditorLayout.IsNull() || model.EditorLayout.IsUnknown() {
-		request.EditorLayout.Reset()
-	} else {
-		editorLayoutPath := path.Root("editor_layout")
+	editorLayout, editorLayoutSet, editorLayoutDiags := editorInterfaceOptionalObjectList(
+		ctx,
+		path.Root("editor_layout"),
+		model.EditorLayout,
+		func(ctx context.Context, valuePath path.Path, value EditorInterfaceEditorLayoutItemValue) (cm.EditorInterfaceEditorLayoutItem, diag.Diagnostics) {
+			return value.ToEditorInterfaceEditorLayoutItem(ctx, valuePath)
+		},
+	)
+	diags.Append(editorLayoutDiags...)
 
-		editorLayoutElementValues := model.EditorLayout.Elements()
-
-		requestEditorLayoutItems := make([]cm.EditorInterfaceEditorLayoutItem, len(editorLayoutElementValues))
-
-		for index, editorLayoutElement := range editorLayoutElementValues {
-			path := editorLayoutPath.AtListIndex(index)
-
-			requestEditorLayoutItem, requestEditorLayoutItemDiags := editorLayoutElement.Value().ToEditorInterfaceEditorLayoutItem(ctx, path)
-			diags.Append(requestEditorLayoutItemDiags...)
-
-			requestEditorLayoutItems[index] = requestEditorLayoutItem
-		}
-
-		request.EditorLayout.SetTo(requestEditorLayoutItems)
+	if editorLayoutSet && !editorLayoutDiags.HasError() {
+		request.EditorLayout.SetTo(editorLayout)
 	}
 
-	if model.Controls.IsNull() || model.Controls.IsUnknown() {
-		request.Controls.Reset()
-	} else {
-		controlsPath := path.Root("controls")
+	controls, controlsSet, controlsDiags := editorInterfaceOptionalObjectList(
+		ctx,
+		path.Root("controls"),
+		model.Controls,
+		func(ctx context.Context, valuePath path.Path, value EditorInterfaceControlValue) (cm.EditorInterfaceDataControlsItem, diag.Diagnostics) {
+			return value.ToEditorInterfaceDataControlsItem(ctx, valuePath)
+		},
+	)
+	diags.Append(controlsDiags...)
 
-		controlsElementValues := model.Controls.Elements()
-
-		requestControlsItems := make([]cm.EditorInterfaceDataControlsItem, len(controlsElementValues))
-
-		for index, controlsElement := range controlsElementValues {
-			path := controlsPath.AtListIndex(index)
-
-			requestControlsItem, requestControlsItemDiags := controlsElement.Value().ToEditorInterfaceDataControlsItem(ctx, path)
-			diags.Append(requestControlsItemDiags...)
-
-			requestControlsItems[index] = requestControlsItem
-		}
-
-		request.Controls.SetTo(requestControlsItems)
+	if controlsSet && !controlsDiags.HasError() {
+		request.Controls.SetTo(controls)
 	}
 
-	if model.GroupControls.IsNull() || model.GroupControls.IsUnknown() {
-		request.GroupControls.Reset()
-	} else {
-		controlsPath := path.Root("group_controls")
+	groupControls, groupControlsSet, groupControlsDiags := editorInterfaceOptionalObjectList(
+		ctx,
+		path.Root("group_controls"),
+		model.GroupControls,
+		func(ctx context.Context, valuePath path.Path, value EditorInterfaceGroupControlValue) (cm.EditorInterfaceDataGroupControlsItem, diag.Diagnostics) {
+			return value.ToEditorInterfaceDataGroupControlsItem(ctx, valuePath)
+		},
+	)
+	diags.Append(groupControlsDiags...)
 
-		groupControlsElementValues := model.GroupControls.Elements()
-
-		requestGroupControlsItems := make([]cm.EditorInterfaceDataGroupControlsItem, len(groupControlsElementValues))
-
-		for index, groupControlsElement := range groupControlsElementValues {
-			path := controlsPath.AtListIndex(index)
-
-			requestGroupControlsItem, requestGroupControlsItemDiags := groupControlsElement.Value().ToEditorInterfaceDataGroupControlsItem(ctx, path)
-			diags.Append(requestGroupControlsItemDiags...)
-
-			requestGroupControlsItems[index] = requestGroupControlsItem
-		}
-
-		request.GroupControls.SetTo(requestGroupControlsItems)
+	if groupControlsSet && !groupControlsDiags.HasError() {
+		request.GroupControls.SetTo(groupControls)
 	}
 
-	if model.Sidebar.IsNull() || model.Sidebar.IsUnknown() {
-		request.Sidebar.Reset()
-	} else {
-		sidebarPath := path.Root("sidebar")
+	sidebar, sidebarSet, sidebarDiags := editorInterfaceOptionalObjectList(
+		ctx,
+		path.Root("sidebar"),
+		model.Sidebar,
+		func(ctx context.Context, valuePath path.Path, value EditorInterfaceSidebarValue) (cm.EditorInterfaceDataSidebarItem, diag.Diagnostics) {
+			return value.ToEditorInterfaceDataSidebarItem(ctx, valuePath)
+		},
+	)
+	diags.Append(sidebarDiags...)
 
-		sidebarElementValues := model.Sidebar.Elements()
+	if sidebarSet && !sidebarDiags.HasError() {
+		request.Sidebar.SetTo(sidebar)
+	}
 
-		requestSidebarItems := make([]cm.EditorInterfaceDataSidebarItem, len(sidebarElementValues))
-
-		for index, sidebarElement := range sidebarElementValues {
-			path := sidebarPath.AtListIndex(index)
-
-			requestSidebarItem, requestSidebarItemDiags := sidebarElement.Value().ToEditorInterfaceDataSidebarItem(ctx, path)
-			diags.Append(requestSidebarItemDiags...)
-
-			requestSidebarItems[index] = requestSidebarItem
-		}
-
-		request.Sidebar.SetTo(requestSidebarItems)
+	if diags.HasError() {
+		return cm.EditorInterfaceData{}, diags
 	}
 
 	return request, diags

--- a/internal/provider/editor_interface_model_request_test.go
+++ b/internal/provider/editor_interface_model_request_test.go
@@ -7,8 +7,10 @@ import (
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoundTripToEditorInterfaceData(t *testing.T) {
@@ -268,4 +270,434 @@ func TestToEditorInterfaceDataErrorHandling(t *testing.T) {
 	}, req)
 
 	assert.Empty(t, diags)
+}
+
+func TestToEditorInterfaceDataOptionalListStates(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		setValue     func(*EditorInterfaceModel, bool)
+		expectedPath string
+		assertSet    func(*testing.T, cm.EditorInterfaceData)
+	}{
+		"editor layout": {
+			setValue: func(model *EditorInterfaceModel, unknown bool) {
+				if unknown {
+					model.EditorLayout = NewTypedListUnknown[TypedObject[EditorInterfaceEditorLayoutItemValue]]()
+				} else {
+					model.EditorLayout = NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemValue]{})
+				}
+			},
+			expectedPath: "editor_layout",
+			assertSet: func(t *testing.T, request cm.EditorInterfaceData) {
+				t.Helper()
+				assert.True(t, request.EditorLayout.Set)
+				assert.NotNil(t, request.EditorLayout.Value)
+				assert.Empty(t, request.EditorLayout.Value)
+			},
+		},
+		"controls": {
+			setValue: func(model *EditorInterfaceModel, unknown bool) {
+				if unknown {
+					model.Controls = NewTypedListUnknown[TypedObject[EditorInterfaceControlValue]]()
+				} else {
+					model.Controls = NewTypedList([]TypedObject[EditorInterfaceControlValue]{})
+				}
+			},
+			expectedPath: "controls",
+			assertSet: func(t *testing.T, request cm.EditorInterfaceData) {
+				t.Helper()
+				assert.True(t, request.Controls.Set)
+				assert.NotNil(t, request.Controls.Value)
+				assert.Empty(t, request.Controls.Value)
+			},
+		},
+		"group controls": {
+			setValue: func(model *EditorInterfaceModel, unknown bool) {
+				if unknown {
+					model.GroupControls = NewTypedListUnknown[TypedObject[EditorInterfaceGroupControlValue]]()
+				} else {
+					model.GroupControls = NewTypedList([]TypedObject[EditorInterfaceGroupControlValue]{})
+				}
+			},
+			expectedPath: "group_controls",
+			assertSet: func(t *testing.T, request cm.EditorInterfaceData) {
+				t.Helper()
+				assert.True(t, request.GroupControls.Set)
+				assert.NotNil(t, request.GroupControls.Value)
+				assert.Empty(t, request.GroupControls.Value)
+			},
+		},
+		"sidebar": {
+			setValue: func(model *EditorInterfaceModel, unknown bool) {
+				if unknown {
+					model.Sidebar = NewTypedListUnknown[TypedObject[EditorInterfaceSidebarValue]]()
+				} else {
+					model.Sidebar = NewTypedList([]TypedObject[EditorInterfaceSidebarValue]{})
+				}
+			},
+			expectedPath: "sidebar",
+			assertSet: func(t *testing.T, request cm.EditorInterfaceData) {
+				t.Helper()
+				assert.True(t, request.Sidebar.Set)
+				assert.NotNil(t, request.Sidebar.Value)
+				assert.Empty(t, request.Sidebar.Value)
+			},
+		},
+	} {
+		t.Run(name+" null is omitted", func(t *testing.T) {
+			t.Parallel()
+
+			model := newNullEditorInterfaceModel()
+			request, diags := model.ToEditorInterfaceData(t.Context())
+
+			require.False(t, diags.HasError(), diags.Errors())
+			assert.Equal(t, cm.EditorInterfaceData{}, request)
+		})
+
+		t.Run(name+" known empty is preserved", func(t *testing.T) {
+			t.Parallel()
+
+			model := newNullEditorInterfaceModel()
+			test.setValue(&model, false)
+
+			request, diags := model.ToEditorInterfaceData(t.Context())
+
+			require.False(t, diags.HasError(), diags.Errors())
+			test.assertSet(t, request)
+		})
+
+		t.Run(name+" unknown is rejected", func(t *testing.T) {
+			t.Parallel()
+
+			model := newNullEditorInterfaceModel()
+			test.setValue(&model, true)
+
+			request, diags := model.ToEditorInterfaceData(t.Context())
+
+			assert.Equal(t, cm.EditorInterfaceData{}, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+//nolint:dupl // Parallel table tests intentionally exercise matching request model shapes.
+func TestEditorInterfaceControlRequestValues(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		mutate       func(*EditorInterfaceControlValue)
+		expectedPath string
+	}{
+		"field id":         {mutate: func(value *EditorInterfaceControlValue) { value.FieldID = types.StringUnknown() }, expectedPath: "controls[2].field_id"},
+		"widget namespace": {mutate: func(value *EditorInterfaceControlValue) { value.WidgetNamespace = types.StringUnknown() }, expectedPath: "controls[2].widget_namespace"},
+		"widget id":        {mutate: func(value *EditorInterfaceControlValue) { value.WidgetID = types.StringUnknown() }, expectedPath: "controls[2].widget_id"},
+		"settings":         {mutate: func(value *EditorInterfaceControlValue) { value.Settings = jsontypes.NewNormalizedUnknown() }, expectedPath: "controls[2].settings"},
+	} {
+		t.Run(name+" unknown", func(t *testing.T) {
+			t.Parallel()
+
+			value := validEditorInterfaceControlValue()
+			test.mutate(&value)
+
+			item, diags := value.ToEditorInterfaceDataControlsItem(t.Context(), path.Root("controls").AtListIndex(2))
+
+			assert.Equal(t, cm.EditorInterfaceDataControlsItem{}, item)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+
+	value := validEditorInterfaceControlValue()
+	value.WidgetNamespace = types.StringNull()
+	value.WidgetID = types.StringNull()
+	value.Settings = jsontypes.NewNormalizedNull()
+
+	item, diags := value.ToEditorInterfaceDataControlsItem(t.Context(), path.Root("controls").AtListIndex(0))
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, cm.EditorInterfaceDataControlsItem{FieldId: "field"}, item)
+}
+
+//nolint:dupl // Parallel table tests intentionally exercise matching request model shapes.
+func TestEditorInterfaceGroupControlRequestValues(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		mutate       func(*EditorInterfaceGroupControlValue)
+		expectedPath string
+	}{
+		"group id":         {mutate: func(value *EditorInterfaceGroupControlValue) { value.GroupID = types.StringUnknown() }, expectedPath: "group_controls[1].group_id"},
+		"widget namespace": {mutate: func(value *EditorInterfaceGroupControlValue) { value.WidgetNamespace = types.StringUnknown() }, expectedPath: "group_controls[1].widget_namespace"},
+		"widget id":        {mutate: func(value *EditorInterfaceGroupControlValue) { value.WidgetID = types.StringUnknown() }, expectedPath: "group_controls[1].widget_id"},
+		"settings":         {mutate: func(value *EditorInterfaceGroupControlValue) { value.Settings = jsontypes.NewNormalizedUnknown() }, expectedPath: "group_controls[1].settings"},
+	} {
+		t.Run(name+" unknown", func(t *testing.T) {
+			t.Parallel()
+
+			value := validEditorInterfaceGroupControlValue()
+			test.mutate(&value)
+
+			item, diags := value.ToEditorInterfaceDataGroupControlsItem(t.Context(), path.Root("group_controls").AtListIndex(1))
+
+			assert.Equal(t, cm.EditorInterfaceDataGroupControlsItem{}, item)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+
+	value := validEditorInterfaceGroupControlValue()
+	value.WidgetNamespace = types.StringNull()
+	value.WidgetID = types.StringNull()
+	value.Settings = jsontypes.NewNormalizedNull()
+
+	item, diags := value.ToEditorInterfaceDataGroupControlsItem(t.Context(), path.Root("group_controls").AtListIndex(0))
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, cm.EditorInterfaceDataGroupControlsItem{GroupId: "group"}, item)
+}
+
+//nolint:dupl // Parallel table tests intentionally exercise matching request model shapes.
+func TestEditorInterfaceSidebarRequestValues(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		mutate       func(*EditorInterfaceSidebarValue)
+		expectedPath string
+	}{
+		"widget namespace": {mutate: func(value *EditorInterfaceSidebarValue) { value.WidgetNamespace = types.StringUnknown() }, expectedPath: "sidebar[3].widget_namespace"},
+		"widget id":        {mutate: func(value *EditorInterfaceSidebarValue) { value.WidgetID = types.StringUnknown() }, expectedPath: "sidebar[3].widget_id"},
+		"settings":         {mutate: func(value *EditorInterfaceSidebarValue) { value.Settings = jsontypes.NewNormalizedUnknown() }, expectedPath: "sidebar[3].settings"},
+		"disabled":         {mutate: func(value *EditorInterfaceSidebarValue) { value.Disabled = types.BoolUnknown() }, expectedPath: "sidebar[3].disabled"},
+	} {
+		t.Run(name+" unknown", func(t *testing.T) {
+			t.Parallel()
+
+			value := validEditorInterfaceSidebarValue()
+			test.mutate(&value)
+
+			item, diags := value.ToEditorInterfaceDataSidebarItem(t.Context(), path.Root("sidebar").AtListIndex(3))
+
+			assert.Equal(t, cm.EditorInterfaceDataSidebarItem{}, item)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+
+	value := validEditorInterfaceSidebarValue()
+	value.Settings = jsontypes.NewNormalizedNull()
+	value.Disabled = types.BoolNull()
+
+	item, diags := value.ToEditorInterfaceDataSidebarItem(t.Context(), path.Root("sidebar").AtListIndex(0))
+
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, cm.EditorInterfaceDataSidebarItem{WidgetNamespace: "builtin", WidgetId: "widget"}, item)
+}
+
+func TestEditorInterfaceEditorLayoutRejectsUnresolvedNestedValues(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		item         EditorInterfaceEditorLayoutItemValue
+		expectedPath string
+	}{
+		"required top-level group": {
+			item:         EditorInterfaceEditorLayoutItemValue{Group: NewTypedObjectUnknown[EditorInterfaceEditorLayoutItemGroupValue]()},
+			expectedPath: "editor_layout[0].group",
+		},
+		"null top-level group": {
+			item:         EditorInterfaceEditorLayoutItemValue{Group: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupValue]()},
+			expectedPath: "editor_layout[0].group",
+		},
+		"group id": {
+			item: editorLayoutGroup(types.StringUnknown(), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(editorLayoutFieldUnion(types.StringValue("field"))),
+			})),
+			expectedPath: "editor_layout[0].group.group_id",
+		},
+		"group name": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringNull(), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(editorLayoutFieldUnion(types.StringValue("field"))),
+			})),
+			expectedPath: "editor_layout[0].group.name",
+		},
+		"group items": {
+			item:         editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedListUnknown[TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]]()),
+			expectedPath: "editor_layout[0].group.items",
+		},
+		"null group items": {
+			item:         editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedListNull[TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]]()),
+			expectedPath: "editor_layout[0].group.items",
+		},
+		"no union alternative": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemValue{
+					Field: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupItemFieldValue](),
+					Group: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupItemGroupValue](),
+				}),
+			})),
+			expectedPath: "editor_layout[0].group.items[0]",
+		},
+		"unknown union alternative": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemValue{
+					Field: NewTypedObjectUnknown[EditorInterfaceEditorLayoutItemGroupItemFieldValue](),
+					Group: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupItemGroupValue](),
+				}),
+			})),
+			expectedPath: "editor_layout[0].group.items[0].field",
+		},
+		"field id": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(editorLayoutFieldUnion(types.StringUnknown())),
+			})),
+			expectedPath: "editor_layout[0].group.items[0].field.field_id",
+		},
+		"nested field object": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(editorLayoutNestedGroupUnion(NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemGroupItemValue]{
+					NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemGroupItemValue{
+						Field: NewTypedObjectUnknown[EditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValue](),
+					}),
+				}))),
+			})),
+			expectedPath: "editor_layout[0].group.items[0].group.items[0].field",
+		},
+		"null nested field object": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(editorLayoutNestedGroupUnion(NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemGroupItemValue]{
+					NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemGroupItemValue{
+						Field: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValue](),
+					}),
+				}))),
+			})),
+			expectedPath: "editor_layout[0].group.items[0].group.items[0].field",
+		},
+		"nested field id": {
+			item: editorLayoutGroup(types.StringValue("group"), types.StringValue("name"), NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]{
+				NewTypedObject(editorLayoutNestedGroupUnion(NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemGroupItemGroupItemValue]{
+					NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemGroupItemValue{
+						Field: NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemGroupItemFieldValue{FieldID: types.StringUnknown()}),
+					}),
+				}))),
+			})),
+			expectedPath: "editor_layout[0].group.items[0].group.items[0].field.field_id",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := newNullEditorInterfaceModel()
+			model.EditorLayout = NewTypedList([]TypedObject[EditorInterfaceEditorLayoutItemValue]{NewTypedObject(test.item)})
+
+			request, diags := model.ToEditorInterfaceData(t.Context())
+
+			assert.Equal(t, cm.EditorInterfaceData{}, request)
+			require.True(t, diags.HasError())
+			assert.Equal(t, []string{test.expectedPath}, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestToEditorInterfaceDataFailsAtomically(t *testing.T) {
+	t.Parallel()
+
+	model := newNullEditorInterfaceModel()
+	model.Controls = NewTypedList([]TypedObject[EditorInterfaceControlValue]{NewTypedObject(validEditorInterfaceControlValue())})
+	invalidSidebar := validEditorInterfaceSidebarValue()
+	invalidSidebar.WidgetID = types.StringUnknown()
+	model.Sidebar = NewTypedList([]TypedObject[EditorInterfaceSidebarValue]{NewTypedObject(invalidSidebar)})
+
+	request, diags := model.ToEditorInterfaceData(t.Context())
+
+	assert.Equal(t, cm.EditorInterfaceData{}, request)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"sidebar[0].widget_id"}, diagnosticPaths(t, diags))
+}
+
+func TestToEditorInterfaceDataRejectsUnknownListElement(t *testing.T) {
+	t.Parallel()
+
+	model := newNullEditorInterfaceModel()
+	model.Controls = NewTypedList([]TypedObject[EditorInterfaceControlValue]{
+		NewTypedObject(validEditorInterfaceControlValue()),
+		NewTypedObjectUnknown[EditorInterfaceControlValue](),
+	})
+
+	request, diags := model.ToEditorInterfaceData(t.Context())
+
+	assert.Equal(t, cm.EditorInterfaceData{}, request)
+	require.True(t, diags.HasError())
+	assert.Equal(t, []string{"controls[1]"}, diagnosticPaths(t, diags))
+}
+
+func newNullEditorInterfaceModel() EditorInterfaceModel {
+	return EditorInterfaceModel{
+		EditorLayout:  NewTypedListNull[TypedObject[EditorInterfaceEditorLayoutItemValue]](),
+		Controls:      NewTypedListNull[TypedObject[EditorInterfaceControlValue]](),
+		GroupControls: NewTypedListNull[TypedObject[EditorInterfaceGroupControlValue]](),
+		Sidebar:       NewTypedListNull[TypedObject[EditorInterfaceSidebarValue]](),
+	}
+}
+
+func validEditorInterfaceControlValue() EditorInterfaceControlValue {
+	return EditorInterfaceControlValue{
+		FieldID:         types.StringValue("field"),
+		WidgetNamespace: types.StringValue("builtin"),
+		WidgetID:        types.StringValue("widget"),
+		Settings:        NewNormalizedJSONTypesNormalizedValue([]byte(`{"key":"value"}`)),
+	}
+}
+
+func validEditorInterfaceGroupControlValue() EditorInterfaceGroupControlValue {
+	return EditorInterfaceGroupControlValue{
+		GroupID:         types.StringValue("group"),
+		WidgetNamespace: types.StringValue("builtin"),
+		WidgetID:        types.StringValue("widget"),
+		Settings:        NewNormalizedJSONTypesNormalizedValue([]byte(`{"key":"value"}`)),
+	}
+}
+
+func validEditorInterfaceSidebarValue() EditorInterfaceSidebarValue {
+	return EditorInterfaceSidebarValue{
+		WidgetNamespace: types.StringValue("builtin"),
+		WidgetID:        types.StringValue("widget"),
+		Settings:        NewNormalizedJSONTypesNormalizedValue([]byte(`{"key":"value"}`)),
+		Disabled:        types.BoolValue(false),
+	}
+}
+
+func editorLayoutGroup(
+	groupID types.String,
+	name types.String,
+	items TypedList[TypedObject[EditorInterfaceEditorLayoutItemGroupItemValue]],
+) EditorInterfaceEditorLayoutItemValue {
+	return EditorInterfaceEditorLayoutItemValue{
+		Group: NewTypedObject(EditorInterfaceEditorLayoutItemGroupValue{
+			GroupID: groupID,
+			Name:    name,
+			Items:   items,
+		}),
+	}
+}
+
+func editorLayoutFieldUnion(fieldID types.String) EditorInterfaceEditorLayoutItemGroupItemValue {
+	return EditorInterfaceEditorLayoutItemGroupItemValue{
+		Field: NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemFieldValue{FieldID: fieldID}),
+		Group: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupItemGroupValue](),
+	}
+}
+
+func editorLayoutNestedGroupUnion(
+	items TypedList[TypedObject[EditorInterfaceEditorLayoutItemGroupItemGroupItemValue]],
+) EditorInterfaceEditorLayoutItemGroupItemValue {
+	return EditorInterfaceEditorLayoutItemGroupItemValue{
+		Field: NewTypedObjectNull[EditorInterfaceEditorLayoutItemGroupItemFieldValue](),
+		Group: NewTypedObject(EditorInterfaceEditorLayoutItemGroupItemGroupValue{
+			GroupID: types.StringValue("nested-group"),
+			Name:    types.StringValue("nested name"),
+			Items:   items,
+		}),
+	}
 }

--- a/internal/provider/editor_interface_model_sidebar.go
+++ b/internal/provider/editor_interface_model_sidebar.go
@@ -11,25 +11,31 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func (v EditorInterfaceSidebarValue) ToEditorInterfaceDataSidebarItem(_ context.Context, _ path.Path) (cm.EditorInterfaceDataSidebarItem, diag.Diagnostics) {
+func (v EditorInterfaceSidebarValue) ToEditorInterfaceDataSidebarItem(_ context.Context, valuePath path.Path) (cm.EditorInterfaceDataSidebarItem, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	item := cm.EditorInterfaceDataSidebarItem{
-		WidgetNamespace: v.WidgetNamespace.ValueString(),
-		WidgetId:        v.WidgetID.ValueString(),
+	widgetNamespace, widgetNamespaceDiags := requestRequiredString(v.WidgetNamespace, valuePath.AtName("widget_namespace"))
+	diags.Append(widgetNamespaceDiags...)
+
+	widgetID, widgetIDDiags := requestRequiredString(v.WidgetID, valuePath.AtName("widget_id"))
+	diags.Append(widgetIDDiags...)
+
+	disabled, disabledDiags := requestOptionalBool(v.Disabled, valuePath.AtName("disabled"))
+	diags.Append(disabledDiags...)
+
+	settings, settingsDiags := editorInterfaceOptionalSettings(v.Settings, valuePath.AtName("settings"))
+	diags.Append(settingsDiags...)
+
+	if diags.HasError() {
+		return cm.EditorInterfaceDataSidebarItem{}, diags
 	}
 
-	modelDisabled := v.Disabled.ValueBoolPointer()
-	if modelDisabled != nil {
-		item.Disabled.SetTo(*modelDisabled)
-	}
-
-	modelSettingsString := v.Settings.ValueString()
-	if modelSettingsString != "" {
-		item.Settings = []byte(modelSettingsString)
-	}
-
-	return item, diags
+	return cm.EditorInterfaceDataSidebarItem{
+		WidgetNamespace: widgetNamespace,
+		WidgetId:        widgetID,
+		Disabled:        disabled,
+		Settings:        settings,
+	}, diags
 }
 
 func NewEditorInterfaceSidebarValueFromResponse(path path.Path, item cm.EditorInterfaceSidebarItem) (TypedObject[EditorInterfaceSidebarValue], diag.Diagnostics) {

--- a/internal/provider/editor_interface_request.go
+++ b/internal/provider/editor_interface_request.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"context"
+
+	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func editorInterfaceOptionalObjectList[T any, R any](
+	ctx context.Context,
+	valuePath path.Path,
+	value TypedList[TypedObject[T]],
+	convert knownObjectListElementConverter[T, R],
+) ([]R, bool, diag.Diagnostics) {
+	if value.IsUnknown() {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown list",
+			"The list value must be known before it can be sent to Contentful.",
+		)
+
+		return nil, false, diags
+	}
+
+	if value.IsNull() {
+		return nil, false, nil
+	}
+
+	items, diags := convertKnownObjectListElements(ctx, valuePath, value.Elements(), convert)
+	if diags.HasError() {
+		return nil, false, diags
+	}
+
+	return items, true, diags
+}
+
+//nolint:ireturn // The concrete result type is supplied by each TypedObject caller.
+func editorInterfaceRequiredObject[T any](value TypedObject[T], valuePath path.Path) (T, diag.Diagnostics) {
+	if object, ok := value.GetValue(); ok {
+		return object, nil
+	}
+
+	var zero T
+
+	diags := diag.Diagnostics{}
+	if value.IsUnknown() {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown object",
+			"The object value must be known before it can be sent to Contentful.",
+		)
+	} else {
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null object",
+			"The required object value cannot be null.",
+		)
+	}
+
+	return zero, diags
+}
+
+func editorInterfaceOptionalSettings(value jsontypes.Normalized, valuePath path.Path) ([]byte, diag.Diagnostics) {
+	if value.IsUnknown() {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown settings",
+			"Settings must be known before they can be sent to Contentful.",
+		)
+
+		return nil, diags
+	}
+
+	if value.IsNull() || value.ValueString() == "" {
+		return nil, nil
+	}
+
+	return []byte(value.ValueString()), nil
+}
+
+func toEditorInterfaceEditorLayoutGroupItem[T any](
+	ctx context.Context,
+	valuePath path.Path,
+	groupID types.String,
+	name types.String,
+	items TypedList[TypedObject[T]],
+	convert knownObjectListElementConverter[T, cm.EditorInterfaceEditorLayoutItem],
+) (cm.EditorInterfaceEditorLayoutGroupItem, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	knownGroupID, groupIDDiags := requestRequiredString(groupID, valuePath.AtName("group_id"))
+	diags.Append(groupIDDiags...)
+
+	knownName, nameDiags := requestRequiredString(name, valuePath.AtName("name"))
+	diags.Append(nameDiags...)
+
+	itemsPath := valuePath.AtName("items")
+
+	switch {
+	case items.IsUnknown():
+		diags.AddAttributeError(
+			itemsPath,
+			"Unexpected unknown editor layout items",
+			"Editor layout items must be known before they can be sent to Contentful.",
+		)
+	case items.IsNull():
+		diags.AddAttributeError(
+			itemsPath,
+			"Unexpected null editor layout items",
+			"Editor layout items are required.",
+		)
+	}
+
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutGroupItem{}, diags
+	}
+
+	knownItems, itemDiags := convertKnownObjectListElements(ctx, itemsPath, items.Elements(), convert)
+	diags.Append(itemDiags...)
+
+	if diags.HasError() {
+		return cm.EditorInterfaceEditorLayoutGroupItem{}, diags
+	}
+
+	return cm.EditorInterfaceEditorLayoutGroupItem{
+		GroupId: knownGroupID,
+		Name:    knownName,
+		Items:   knownItems,
+	}, diags
+}


### PR DESCRIPTION
## Summary
- reject unknown top-level Editor Interface collections while preserving null omission and known empty lists
- validate control, group-control, sidebar, layout-group, nested-field, and settings values before constructing mutation payloads
- enforce the field/group request union through the shared exact-one-known-alternative converter
- return a zero complete request when any nested conversion reports an error

No response conversion, schema, generated documentation, or remote-response discriminator behavior is changed.

## Stack
- Depends on #606 (`codex/request-scalar-values`).
- #606 depends on `codex/content-type-request-unions`.

## Validation
- focused Editor Interface request and round-trip tests
- `go test ./...`
- `go generate ./...` (no generated diff)
- `golangci-lint cache clean` immediately followed by `golangci-lint run` (0 issues)