### PR TITLE
fix(webhook): reject unresolved filter values

### DIFF
--- a/internal/provider/webhook_filters_request.go
+++ b/internal/provider/webhook_filters_request.go
@@ -7,214 +7,290 @@ import (
 	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const webhookDefinitionBinaryFilterTermCount = 2
+func ToOptNilWebhookDefinitionFilterArray(
+	ctx context.Context,
+	valuePath path.Path,
+	filterValuesList TypedList[TypedObject[WebhookFilterValue]],
+) (cm.OptNilWebhookDefinitionFilterArray, diag.Diagnostics) {
+	if filterValuesList.IsUnknown() {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown webhook filters",
+			"Webhook filters must be known before they can be sent to Contentful.",
+		)
 
-func ToOptNilWebhookDefinitionFilterArray(ctx context.Context, path path.Path, filterValuesList TypedList[TypedObject[WebhookFilterValue]]) (cm.OptNilWebhookDefinitionFilterArray, diag.Diagnostics) {
-	if filterValuesList.IsNull() || filterValuesList.IsUnknown() {
+		return cm.OptNilWebhookDefinitionFilterArray{}, diags
+	}
+
+	if filterValuesList.IsNull() {
 		return cm.NewOptNilWebhookDefinitionFilterArrayNull(), nil
 	}
 
-	diags := diag.Diagnostics{}
-
-	filterValues := filterValuesList.Elements()
-
-	filters := make([]cm.WebhookDefinitionFilter, len(filterValues))
-
-	for index, filterValue := range filterValues {
-		path := path.AtListIndex(index)
-
-		filter, filterDiags := ToWebhookDefinitionFilter(ctx, path, filterValue.Value())
-		diags.Append(filterDiags...)
-
-		filters[index] = filter
+	filters, diags := convertKnownObjectListElements(
+		ctx,
+		valuePath,
+		filterValuesList.Elements(),
+		ToWebhookDefinitionFilter,
+	)
+	if diags.HasError() {
+		return cm.OptNilWebhookDefinitionFilterArray{}, diags
 	}
 
 	return cm.NewOptNilWebhookDefinitionFilterArray(filters), diags
 }
 
-func ToWebhookDefinitionFilter(ctx context.Context, path path.Path, value WebhookFilterValue) (cm.WebhookDefinitionFilter, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+func ToWebhookDefinitionFilter(
+	ctx context.Context,
+	valuePath path.Path,
+	value WebhookFilterValue,
+) (cm.WebhookDefinitionFilter, diag.Diagnostics) {
+	return convertExactlyOneKnownAlternative(
+		valuePath,
+		knownUnionAlternative[cm.WebhookDefinitionFilter]{
+			Name:  "not",
+			Path:  valuePath.AtName("not"),
+			Value: value.Not,
+			Convert: func() (cm.WebhookDefinitionFilter, diag.Diagnostics) {
+				notValue, _ := value.Not.GetValue()
+				not, diags := ToWebhookDefinitionFilterNot(ctx, valuePath.AtName("not"), notValue)
 
-	filter := cm.WebhookDefinitionFilter{}
+				return cm.WebhookDefinitionFilter{Not: not}, diags
+			},
+		},
+		knownUnionAlternative[cm.WebhookDefinitionFilter]{
+			Name:  "equals",
+			Path:  valuePath.AtName("equals"),
+			Value: value.Equals,
+			Convert: func() (cm.WebhookDefinitionFilter, diag.Diagnostics) {
+				equalsValue, _ := value.Equals.GetValue()
+				equals, diags := ToWebhookDefinitionFilterEquals(ctx, valuePath.AtName("equals"), equalsValue)
 
-	notValue, notValueOk := value.Not.GetValue()
-	if notValueOk {
-		path := path.AtName("not")
+				return cm.WebhookDefinitionFilter{Equals: equals}, diags
+			},
+		},
+		knownUnionAlternative[cm.WebhookDefinitionFilter]{
+			Name:  "in",
+			Path:  valuePath.AtName("in"),
+			Value: value.In,
+			Convert: func() (cm.WebhookDefinitionFilter, diag.Diagnostics) {
+				inValue, _ := value.In.GetValue()
+				in, diags := ToWebhookDefinitionFilterIn(ctx, valuePath.AtName("in"), inValue)
 
-		filterNot, filterNotDiags := ToWebhookDefinitionFilterNot(ctx, path, notValue)
-		diags.Append(filterNotDiags...)
+				return cm.WebhookDefinitionFilter{In: in}, diags
+			},
+		},
+		knownUnionAlternative[cm.WebhookDefinitionFilter]{
+			Name:  "regexp",
+			Path:  valuePath.AtName("regexp"),
+			Value: value.Regexp,
+			Convert: func() (cm.WebhookDefinitionFilter, diag.Diagnostics) {
+				regexpValue, _ := value.Regexp.GetValue()
+				regexp, diags := ToWebhookDefinitionFilterRegexp(ctx, valuePath.AtName("regexp"), regexpValue)
 
-		filter.Not = filterNot
-	}
-
-	equalsValue, equalsValueOk := value.Equals.GetValue()
-	if equalsValueOk {
-		path := path.AtName("equals")
-
-		filterEquals, filterEqualsDiags := ToWebhookDefinitionFilterEquals(ctx, path, equalsValue)
-		diags.Append(filterEqualsDiags...)
-
-		filter.Equals = filterEquals
-	}
-
-	inValue, inValueOk := value.In.GetValue()
-	if inValueOk {
-		path := path.AtName("in")
-
-		filterIn, filterInDiags := ToWebhookDefinitionFilterIn(ctx, path, inValue)
-		diags.Append(filterInDiags...)
-
-		filter.In = filterIn
-	}
-
-	regexpValue, regexpValueOk := value.Regexp.GetValue()
-	if regexpValueOk {
-		path := path.AtName("regexp")
-
-		filterRegexp, filterRegexpDiags := ToWebhookDefinitionFilterRegexp(ctx, path, regexpValue)
-		diags.Append(filterRegexpDiags...)
-
-		filter.Regexp = filterRegexp
-	}
-
-	return filter, diags
+				return cm.WebhookDefinitionFilter{Regexp: regexp}, diags
+			},
+		},
+	)
 }
 
-func ToWebhookDefinitionFilterNot(ctx context.Context, path path.Path, value WebhookFilterNotValue) (cm.OptWebhookDefinitionFilterNot, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+func ToWebhookDefinitionFilterNot(
+	ctx context.Context,
+	valuePath path.Path,
+	value WebhookFilterNotValue,
+) (cm.OptWebhookDefinitionFilterNot, diag.Diagnostics) {
+	filterNot, diags := convertExactlyOneKnownAlternative(
+		valuePath,
+		knownUnionAlternative[cm.WebhookDefinitionFilterNot]{
+			Name:  "equals",
+			Path:  valuePath.AtName("equals"),
+			Value: value.Equals,
+			Convert: func() (cm.WebhookDefinitionFilterNot, diag.Diagnostics) {
+				equalsValue, _ := value.Equals.GetValue()
+				equals, diags := ToWebhookDefinitionFilterEquals(ctx, valuePath.AtName("equals"), equalsValue)
 
-	filterNot := cm.WebhookDefinitionFilterNot{}
+				return cm.WebhookDefinitionFilterNot{Equals: equals}, diags
+			},
+		},
+		knownUnionAlternative[cm.WebhookDefinitionFilterNot]{
+			Name:  "in",
+			Path:  valuePath.AtName("in"),
+			Value: value.In,
+			Convert: func() (cm.WebhookDefinitionFilterNot, diag.Diagnostics) {
+				inValue, _ := value.In.GetValue()
+				in, diags := ToWebhookDefinitionFilterIn(ctx, valuePath.AtName("in"), inValue)
 
-	if equalsValue, equalsValueOk := value.Equals.GetValue(); equalsValueOk {
-		path := path.AtName("equals")
+				return cm.WebhookDefinitionFilterNot{In: in}, diags
+			},
+		},
+		knownUnionAlternative[cm.WebhookDefinitionFilterNot]{
+			Name:  "regexp",
+			Path:  valuePath.AtName("regexp"),
+			Value: value.Regexp,
+			Convert: func() (cm.WebhookDefinitionFilterNot, diag.Diagnostics) {
+				regexpValue, _ := value.Regexp.GetValue()
+				regexp, diags := ToWebhookDefinitionFilterRegexp(ctx, valuePath.AtName("regexp"), regexpValue)
 
-		equals, equalsDiags := ToWebhookDefinitionFilterEquals(ctx, path, equalsValue)
-		diags.Append(equalsDiags...)
-
-		filterNot.Equals = equals
-	}
-
-	if inValue, inValueOk := value.In.GetValue(); inValueOk {
-		path := path.AtName("in")
-
-		in, inDiags := ToWebhookDefinitionFilterIn(ctx, path, inValue)
-		diags.Append(inDiags...)
-
-		filterNot.In = in
-	}
-
-	if regexpValue, regexpValueOk := value.Regexp.GetValue(); regexpValueOk {
-		path := path.AtName("regexp")
-
-		regexp, regexpDiags := ToWebhookDefinitionFilterRegexp(ctx, path, regexpValue)
-		diags.Append(regexpDiags...)
-
-		filterNot.Regexp = regexp
+				return cm.WebhookDefinitionFilterNot{Regexp: regexp}, diags
+			},
+		},
+	)
+	if diags.HasError() {
+		return cm.OptWebhookDefinitionFilterNot{}, diags
 	}
 
 	return cm.NewOptWebhookDefinitionFilterNot(filterNot), diags
 }
 
-func ToWebhookDefinitionFilterEquals(ctx context.Context, path path.Path, value WebhookFilterEqualsValue) (cm.WebhookDefinitionFilterEquals, diag.Diagnostics) {
+func ToWebhookDefinitionFilterEquals(
+	ctx context.Context,
+	valuePath path.Path,
+	value WebhookFilterEqualsValue,
+) (cm.WebhookDefinitionFilterEquals, diag.Diagnostics) {
+	doc, docDiags := toWebhookDefinitionFilterTermStringObject(ctx, valuePath.AtName("doc"), "doc", value.Doc)
+	filterValue, valueDiags := toWebhookDefinitionFilterTermString(ctx, valuePath.AtName("value"), value.Value)
 	diags := diag.Diagnostics{}
+	diags.Append(docDiags...)
+	diags.Append(valueDiags...)
 
-	filter := make(cm.WebhookDefinitionFilterEquals, 0, webhookDefinitionBinaryFilterTermCount)
+	if diags.HasError() {
+		return nil, diags
+	}
 
-	filterTermDoc, filterTermDocDiags := toWebhookDefinitionFilterTermStringObject(ctx, path.AtName("doc"), "doc", value.Doc)
-	diags.Append(filterTermDocDiags...)
-
-	filter = append(filter, filterTermDoc)
-
-	filterTermValue, filterTermValueDiags := toWebhookDefinitionFilterTermString(ctx, path.AtName("value"), value.Value)
-	diags.Append(filterTermValueDiags...)
-
-	filter = append(filter, filterTermValue)
-
-	return filter, diags
+	return cm.WebhookDefinitionFilterEquals{doc, filterValue}, diags
 }
 
-func ToWebhookDefinitionFilterIn(ctx context.Context, path path.Path, value WebhookFilterInValue) (cm.WebhookDefinitionFilterIn, diag.Diagnostics) {
+func ToWebhookDefinitionFilterIn(
+	ctx context.Context,
+	valuePath path.Path,
+	value WebhookFilterInValue,
+) (cm.WebhookDefinitionFilterIn, diag.Diagnostics) {
+	doc, docDiags := toWebhookDefinitionFilterTermStringObject(ctx, valuePath.AtName("doc"), "doc", value.Doc)
+	values, valuesDiags := toWebhookDefinitionFilterTermStringArray(ctx, valuePath.AtName("values"), value.Values)
 	diags := diag.Diagnostics{}
+	diags.Append(docDiags...)
+	diags.Append(valuesDiags...)
 
-	filter := make(cm.WebhookDefinitionFilterIn, 0, webhookDefinitionBinaryFilterTermCount)
+	if diags.HasError() {
+		return nil, diags
+	}
 
-	filterTermDoc, filterTermDocDiags := toWebhookDefinitionFilterTermStringObject(ctx, path.AtName("doc"), "doc", value.Doc)
-	diags.Append(filterTermDocDiags...)
-
-	filter = append(filter, filterTermDoc)
-
-	filterTermValues, filterTermValuesDiags := toWebhookDefinitionFilterTermStringArray(ctx, path.AtName("values"), value.Values)
-	diags.Append(filterTermValuesDiags...)
-
-	filter = append(filter, filterTermValues)
-
-	return filter, diags
+	return cm.WebhookDefinitionFilterIn{doc, values}, diags
 }
 
-func ToWebhookDefinitionFilterRegexp(ctx context.Context, path path.Path, value WebhookFilterRegexpValue) (cm.WebhookDefinitionFilterRegexp, diag.Diagnostics) {
+func ToWebhookDefinitionFilterRegexp(
+	ctx context.Context,
+	valuePath path.Path,
+	value WebhookFilterRegexpValue,
+) (cm.WebhookDefinitionFilterRegexp, diag.Diagnostics) {
+	doc, docDiags := toWebhookDefinitionFilterTermStringObject(ctx, valuePath.AtName("doc"), "doc", value.Doc)
+	pattern, patternDiags := toWebhookDefinitionFilterTermStringObject(ctx, valuePath.AtName("pattern"), "pattern", value.Pattern)
 	diags := diag.Diagnostics{}
+	diags.Append(docDiags...)
+	diags.Append(patternDiags...)
 
-	filter := make(cm.WebhookDefinitionFilterRegexp, 0, webhookDefinitionBinaryFilterTermCount)
+	if diags.HasError() {
+		return nil, diags
+	}
 
-	filterTermDoc, filterTermDocDiags := toWebhookDefinitionFilterTermStringObject(ctx, path.AtName("doc"), "doc", value.Doc)
-	diags.Append(filterTermDocDiags...)
-
-	filter = append(filter, filterTermDoc)
-
-	filterTermPattern, filterTermPatternDiags := toWebhookDefinitionFilterTermStringObject(ctx, path.AtName("pattern"), "pattern", value.Pattern)
-	diags.Append(filterTermPatternDiags...)
-
-	filter = append(filter, filterTermPattern)
-
-	return filter, diags
+	return cm.WebhookDefinitionFilterRegexp{doc, pattern}, diags
 }
 
-func toWebhookDefinitionFilterTermString(_ context.Context, path path.Path, value types.String) (jx.Raw, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
+func toWebhookDefinitionFilterTermString(_ context.Context, valuePath path.Path, value types.String) (jx.Raw, diag.Diagnostics) {
+	stringValue, diags := requestRequiredString(value, valuePath)
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	encoder := jx.Encoder{}
+	if encoder.Str(stringValue) {
+		diags.AddAttributeError(valuePath, "failed to encode value", "")
+	}
 
-	if encoder.Str(value.ValueString()) {
-		diags.AddAttributeError(path, "failed to encode value", "")
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return encoder.Bytes(), diags
 }
 
-func toWebhookDefinitionFilterTermStringArray(ctx context.Context, path path.Path, value TypedList[types.String]) (jx.Raw, diag.Diagnostics) {
+func toWebhookDefinitionFilterTermStringArray(
+	_ context.Context,
+	valuePath path.Path,
+	value TypedList[types.String],
+) (jx.Raw, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
+
+	switch {
+	case value.IsUnknown():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected unknown webhook filter values",
+			"Webhook filter values must be known before they can be sent to Contentful.",
+		)
+	case value.IsNull():
+		diags.AddAttributeError(
+			valuePath,
+			"Unexpected null webhook filter values",
+			"Required webhook filter values cannot be null.",
+		)
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	values, valueDiags := knownStringListElements(valuePath, value.Elements())
+	diags.Append(valueDiags...)
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
 	encoder := jx.Encoder{}
-
 	if encoder.Arr(func(encoder *jx.Encoder) {
-		values := make([]string, len(value.Elements()))
-		diags.Append(tfsdk.ValueAs(ctx, value, &values)...)
-
-		for index, v := range values {
-			path := path.AtListIndex(index)
-			if encoder.Str(v) {
-				diags.AddAttributeError(path, "failed to encode value", "")
+		for index, stringValue := range values {
+			elementPath := valuePath.AtListIndex(index)
+			if encoder.Str(stringValue) {
+				diags.AddAttributeError(elementPath, "failed to encode value", "")
 			}
 		}
 	}) {
-		diags.AddAttributeError(path, "failed to encode value", "")
+		diags.AddAttributeError(valuePath, "failed to encode value", "")
+	}
+
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return encoder.Bytes(), diags
 }
 
-func toWebhookDefinitionFilterTermStringObject(_ context.Context, path path.Path, name string, value types.String) (jx.Raw, diag.Diagnostics) {
-	diags := diag.Diagnostics{}
-	encoder := jx.Encoder{}
+func toWebhookDefinitionFilterTermStringObject(
+	_ context.Context,
+	valuePath path.Path,
+	name string,
+	value types.String,
+) (jx.Raw, diag.Diagnostics) {
+	stringValue, diags := requestRequiredString(value, valuePath)
+	if diags.HasError() {
+		return nil, diags
+	}
 
+	encoder := jx.Encoder{}
 	if encoder.Obj(func(encoder *jx.Encoder) {
-		if encoder.Field(name, func(encoder *jx.Encoder) { encoder.Str(value.ValueString()) }) {
-			diags.AddAttributeError(path, "failed to encode value", "")
+		if encoder.Field(name, func(encoder *jx.Encoder) { encoder.Str(stringValue) }) {
+			diags.AddAttributeError(valuePath, "failed to encode value", "")
 		}
 	}) {
-		diags.AddAttributeError(path, "failed to encode value", "")
+		diags.AddAttributeError(valuePath, "failed to encode value", "")
+	}
+
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	return encoder.Bytes(), diags

--- a/internal/provider/webhook_filters_request_test.go
+++ b/internal/provider/webhook_filters_request_test.go
@@ -6,39 +6,333 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	. "github.com/cysp/terraform-provider-contentful/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToOptNilWebhookDefinitionFilterArrayNil(t *testing.T) {
+func TestWebhookFilterArrayPreservesOmissionAndRejectsUnknownContainer(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-
-	testcases := map[string]struct {
-		input TypedList[TypedObject[WebhookFilterValue]]
+	filterPath := path.Root("filters")
+	tests := map[string]struct {
+		value         TypedList[TypedObject[WebhookFilterValue]]
+		expected      cm.OptNilWebhookDefinitionFilterArray
+		expectedPaths []string
 	}{
-		"null": {
-			input: NewTypedListNull[TypedObject[WebhookFilterValue]](),
+		"null is omitted": {
+			value:         NewTypedListNull[TypedObject[WebhookFilterValue]](),
+			expected:      cm.NewOptNilWebhookDefinitionFilterArrayNull(),
+			expectedPaths: []string{},
 		},
-		"unknown": {
-			input: NewTypedListUnknown[TypedObject[WebhookFilterValue]](),
+		"known empty list is preserved": {
+			value:         NewTypedList([]TypedObject[WebhookFilterValue]{}),
+			expected:      cm.NewOptNilWebhookDefinitionFilterArray([]cm.WebhookDefinitionFilter{}),
+			expectedPaths: []string{},
+		},
+		"unknown is rejected": {
+			value:         NewTypedListUnknown[TypedObject[WebhookFilterValue]](),
+			expectedPaths: []string{"filters"},
 		},
 	}
 
-	expected := cm.NewOptNilWebhookDefinitionFilterArrayNull()
-
-	for name, testcase := range testcases {
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			result, diags := ToOptNilWebhookDefinitionFilterArray(
-				ctx,
-				path.Root("test"),
-				testcase.input,
-			)
+			actual, diags := ToOptNilWebhookDefinitionFilterArray(t.Context(), filterPath, test.value)
 
-			assert.Equal(t, expected, result)
-			assert.Empty(t, diags)
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
 		})
+	}
+}
+
+func TestWebhookFilterArrayRejectsUnresolvedElementsAtomically(t *testing.T) {
+	t.Parallel()
+
+	filters := NewTypedList([]TypedObject[WebhookFilterValue]{
+		webhookEqualsFilter(types.StringValue("sys.type"), types.StringValue("Entry")),
+		NewTypedObjectNull[WebhookFilterValue](),
+		NewTypedObjectUnknown[WebhookFilterValue](),
+	})
+
+	actual, diags := ToOptNilWebhookDefinitionFilterArray(t.Context(), path.Root("filters"), filters)
+
+	assert.Equal(t, cm.OptNilWebhookDefinitionFilterArray{}, actual)
+	assert.Equal(t, []string{"filters[1]", "filters[2]"}, diagnosticPaths(t, diags))
+}
+
+func TestWebhookFilterRequiresExactlyOneKnownAlternative(t *testing.T) {
+	t.Parallel()
+
+	filterPath := path.Root("filters").AtListIndex(0)
+	equals := webhookEqualsValue(types.StringValue("sys.type"), types.StringValue("Entry"))
+	inFilter := webhookInValue(types.StringValue("sys.id"), NewTypedList([]types.String{types.StringValue("entry")}))
+	regexp := webhookRegexpValue(types.StringValue("sys.id"), types.StringValue("entry.*"))
+	not := NewTypedObject(webhookNotValue(equals, NewTypedObjectNull[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()))
+
+	tests := map[string]struct {
+		value         WebhookFilterValue
+		expected      cm.WebhookDefinitionFilter
+		expectedPaths []string
+	}{
+		"not": {
+			value: webhookFilterValue(not, NewTypedObjectNull[WebhookFilterEqualsValue](), NewTypedObjectNull[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expected: cm.WebhookDefinitionFilter{
+				Not: cm.NewOptWebhookDefinitionFilterNot(cm.WebhookDefinitionFilterNot{
+					Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`"Entry"`)},
+				}),
+			},
+			expectedPaths: []string{},
+		},
+		"equals": {
+			value: webhookFilterValue(NewTypedObjectNull[WebhookFilterNotValue](), equals, NewTypedObjectNull[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expected: cm.WebhookDefinitionFilter{
+				Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`"Entry"`)},
+			},
+			expectedPaths: []string{},
+		},
+		"in": {
+			value: webhookFilterValue(NewTypedObjectNull[WebhookFilterNotValue](), NewTypedObjectNull[WebhookFilterEqualsValue](), inFilter, NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expected: cm.WebhookDefinitionFilter{
+				In: cm.WebhookDefinitionFilterIn{[]byte(`{"doc":"sys.id"}`), []byte(`["entry"]`)},
+			},
+			expectedPaths: []string{},
+		},
+		"regexp": {
+			value: webhookFilterValue(NewTypedObjectNull[WebhookFilterNotValue](), NewTypedObjectNull[WebhookFilterEqualsValue](), NewTypedObjectNull[WebhookFilterInValue](), regexp),
+			expected: cm.WebhookDefinitionFilter{
+				Regexp: cm.WebhookDefinitionFilterRegexp{[]byte(`{"doc":"sys.id"}`), []byte(`{"pattern":"entry.*"}`)},
+			},
+			expectedPaths: []string{},
+		},
+		"none": {
+			value:         webhookFilterValue(NewTypedObjectNull[WebhookFilterNotValue](), NewTypedObjectNull[WebhookFilterEqualsValue](), NewTypedObjectNull[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expectedPaths: []string{"filters[0]"},
+		},
+		"multiple": {
+			value:         webhookFilterValue(NewTypedObjectNull[WebhookFilterNotValue](), equals, inFilter, NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expectedPaths: []string{"filters[0]"},
+		},
+		"unknown alternative": {
+			value:         webhookFilterValue(NewTypedObjectNull[WebhookFilterNotValue](), equals, NewTypedObjectUnknown[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expectedPaths: []string{"filters[0].in"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := ToWebhookDefinitionFilter(t.Context(), filterPath, test.value)
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestWebhookFilterNotRequiresExactlyOneKnownAlternative(t *testing.T) {
+	t.Parallel()
+
+	filterPath := path.Root("filters").AtListIndex(0).AtName("not")
+	equals := webhookEqualsValue(types.StringValue("sys.type"), types.StringValue("Entry"))
+	inFilter := webhookInValue(types.StringValue("sys.id"), NewTypedList([]types.String{types.StringValue("entry")}))
+	regexp := webhookRegexpValue(types.StringValue("sys.id"), types.StringValue("entry.*"))
+
+	tests := map[string]struct {
+		value         WebhookFilterNotValue
+		expected      cm.OptWebhookDefinitionFilterNot
+		expectedPaths []string
+	}{
+		"equals": {
+			value:         webhookNotValue(equals, NewTypedObjectNull[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expected:      cm.NewOptWebhookDefinitionFilterNot(cm.WebhookDefinitionFilterNot{Equals: cm.WebhookDefinitionFilterEquals{[]byte(`{"doc":"sys.type"}`), []byte(`"Entry"`)}}),
+			expectedPaths: []string{},
+		},
+		"in": {
+			value:         webhookNotValue(NewTypedObjectNull[WebhookFilterEqualsValue](), inFilter, NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expected:      cm.NewOptWebhookDefinitionFilterNot(cm.WebhookDefinitionFilterNot{In: cm.WebhookDefinitionFilterIn{[]byte(`{"doc":"sys.id"}`), []byte(`["entry"]`)}}),
+			expectedPaths: []string{},
+		},
+		"regexp": {
+			value:         webhookNotValue(NewTypedObjectNull[WebhookFilterEqualsValue](), NewTypedObjectNull[WebhookFilterInValue](), regexp),
+			expected:      cm.NewOptWebhookDefinitionFilterNot(cm.WebhookDefinitionFilterNot{Regexp: cm.WebhookDefinitionFilterRegexp{[]byte(`{"doc":"sys.id"}`), []byte(`{"pattern":"entry.*"}`)}}),
+			expectedPaths: []string{},
+		},
+		"none": {
+			value:         webhookNotValue(NewTypedObjectNull[WebhookFilterEqualsValue](), NewTypedObjectNull[WebhookFilterInValue](), NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expectedPaths: []string{"filters[0].not"},
+		},
+		"multiple": {
+			value:         webhookNotValue(equals, inFilter, NewTypedObjectNull[WebhookFilterRegexpValue]()),
+			expectedPaths: []string{"filters[0].not"},
+		},
+		"unknown alternative": {
+			value:         webhookNotValue(NewTypedObjectUnknown[WebhookFilterEqualsValue](), NewTypedObjectNull[WebhookFilterInValue](), regexp),
+			expectedPaths: []string{"filters[0].not.equals"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, diags := ToWebhookDefinitionFilterNot(t.Context(), filterPath, test.value)
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+		})
+	}
+}
+
+func TestWebhookFilterOperandsRejectUnresolvedValues(t *testing.T) {
+	t.Parallel()
+
+	filterPath := path.Root("filters").AtListIndex(0)
+	tests := map[string]struct {
+		convert       func() (any, []string)
+		expectedPaths []string
+	}{
+		"equals unknown doc": {
+			convert:       webhookEqualsConversion(t, filterPath.AtName("equals"), types.StringUnknown(), types.StringValue("Entry")),
+			expectedPaths: []string{"filters[0].equals.doc"},
+		},
+		"equals null value": {
+			convert:       webhookEqualsConversion(t, filterPath.AtName("equals"), types.StringValue("sys.type"), types.StringNull()),
+			expectedPaths: []string{"filters[0].equals.value"},
+		},
+		"in null doc": {
+			convert:       webhookInConversion(t, filterPath.AtName("in"), types.StringNull(), NewTypedList([]types.String{})),
+			expectedPaths: []string{"filters[0].in.doc"},
+		},
+		"in unknown values": {
+			convert:       webhookInConversion(t, filterPath.AtName("in"), types.StringValue("sys.id"), NewTypedListUnknown[types.String]()),
+			expectedPaths: []string{"filters[0].in.values"},
+		},
+		"in null values": {
+			convert:       webhookInConversion(t, filterPath.AtName("in"), types.StringValue("sys.id"), NewTypedListNull[types.String]()),
+			expectedPaths: []string{"filters[0].in.values"},
+		},
+		"in unresolved elements": {
+			convert: webhookInConversion(t, filterPath.AtName("in"), types.StringValue("sys.id"), NewTypedList([]types.String{
+				types.StringValue("entry"),
+				types.StringNull(),
+				types.StringUnknown(),
+			})),
+			expectedPaths: []string{"filters[0].in.values[1]", "filters[0].in.values[2]"},
+		},
+		"regexp unknown doc and pattern": {
+			convert:       webhookRegexpConversion(t, filterPath.AtName("regexp"), types.StringUnknown(), types.StringUnknown()),
+			expectedPaths: []string{"filters[0].regexp.doc", "filters[0].regexp.pattern"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, paths := test.convert()
+
+			assert.Zero(t, actual)
+			assert.Equal(t, test.expectedPaths, paths)
+		})
+	}
+}
+
+func TestWebhookFilterArrayReturnsNoPartialOutputAfterElementError(t *testing.T) {
+	t.Parallel()
+
+	filters := NewTypedList([]TypedObject[WebhookFilterValue]{
+		webhookEqualsFilter(types.StringValue("sys.type"), types.StringValue("Entry")),
+		webhookEqualsFilter(types.StringUnknown(), types.StringValue("Entry")),
+	})
+
+	actual, diags := ToOptNilWebhookDefinitionFilterArray(t.Context(), path.Root("filters"), filters)
+
+	assert.Equal(t, cm.OptNilWebhookDefinitionFilterArray{}, actual)
+	assert.Equal(t, []string{"filters[1].equals.doc"}, diagnosticPaths(t, diags))
+}
+
+func webhookFilterValue(
+	not TypedObject[WebhookFilterNotValue],
+	equals TypedObject[WebhookFilterEqualsValue],
+	in TypedObject[WebhookFilterInValue],
+	regexp TypedObject[WebhookFilterRegexpValue],
+) WebhookFilterValue {
+	return WebhookFilterValue{Not: not, Equals: equals, In: in, Regexp: regexp}
+}
+
+func webhookNotValue(
+	equals TypedObject[WebhookFilterEqualsValue],
+	in TypedObject[WebhookFilterInValue],
+	regexp TypedObject[WebhookFilterRegexpValue],
+) WebhookFilterNotValue {
+	return WebhookFilterNotValue{Equals: equals, In: in, Regexp: regexp}
+}
+
+func webhookEqualsValue(doc types.String, value types.String) TypedObject[WebhookFilterEqualsValue] {
+	return NewTypedObject(WebhookFilterEqualsValue{Doc: doc, Value: value})
+}
+
+func webhookInValue(doc types.String, values TypedList[types.String]) TypedObject[WebhookFilterInValue] {
+	return NewTypedObject(WebhookFilterInValue{Doc: doc, Values: values})
+}
+
+func webhookRegexpValue(doc types.String, pattern types.String) TypedObject[WebhookFilterRegexpValue] {
+	return NewTypedObject(WebhookFilterRegexpValue{Doc: doc, Pattern: pattern})
+}
+
+func webhookEqualsFilter(doc types.String, value types.String) TypedObject[WebhookFilterValue] {
+	return NewTypedObject(webhookFilterValue(
+		NewTypedObjectNull[WebhookFilterNotValue](),
+		webhookEqualsValue(doc, value),
+		NewTypedObjectNull[WebhookFilterInValue](),
+		NewTypedObjectNull[WebhookFilterRegexpValue](),
+	))
+}
+
+func webhookEqualsConversion(
+	t *testing.T,
+	valuePath path.Path,
+	doc types.String,
+	value types.String,
+) func() (any, []string) {
+	t.Helper()
+
+	return func() (any, []string) {
+		actual, diags := ToWebhookDefinitionFilterEquals(t.Context(), valuePath, WebhookFilterEqualsValue{Doc: doc, Value: value})
+
+		return actual, diagnosticPaths(t, diags)
+	}
+}
+
+func webhookInConversion(
+	t *testing.T,
+	valuePath path.Path,
+	doc types.String,
+	values TypedList[types.String],
+) func() (any, []string) {
+	t.Helper()
+
+	return func() (any, []string) {
+		actual, diags := ToWebhookDefinitionFilterIn(t.Context(), valuePath, WebhookFilterInValue{Doc: doc, Values: values})
+
+		return actual, diagnosticPaths(t, diags)
+	}
+}
+
+func webhookRegexpConversion(
+	t *testing.T,
+	valuePath path.Path,
+	doc types.String,
+	pattern types.String,
+) func() (any, []string) {
+	t.Helper()
+
+	return func() (any, []string) {
+		actual, diags := ToWebhookDefinitionFilterRegexp(t.Context(), valuePath, WebhookFilterRegexpValue{Doc: doc, Pattern: pattern})
+
+		return actual, diagnosticPaths(t, diags)
 	}
 }

--- a/internal/provider/webhook_model_request.go
+++ b/internal/provider/webhook_model_request.go
@@ -6,7 +6,6 @@ import (
 	cm "github.com/cysp/terraform-provider-contentful/internal/contentful-management-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
 func (model *WebhookModel) ToWebhookDefinitionData(ctx context.Context, path path.Path) (cm.WebhookDefinitionData, diag.Diagnostics) {
@@ -51,27 +50,10 @@ func (model *WebhookModel) ToWebhookDefinitionData(ctx context.Context, path pat
 		req.Topics = topics
 	}
 
-	if model.Filters.IsNull() || model.Filters.IsUnknown() {
-		req.Filters = cm.NewOptNilWebhookDefinitionFilterArrayNull()
-	} else {
-		path := path.AtName("filters")
+	filters, filterDiags := ToOptNilWebhookDefinitionFilterArray(ctx, path.AtName("filters"), model.Filters)
+	diags.Append(filterDiags...)
 
-		modelFilters := make([]WebhookFilterValue, len(model.Filters.Elements()))
-		diags.Append(tfsdk.ValueAs(ctx, model.Filters, &modelFilters)...)
-
-		filters := make([]cm.WebhookDefinitionFilter, len(modelFilters))
-
-		for index, modelFilter := range modelFilters {
-			path := path.AtListIndex(index)
-
-			filter, filterDiags := ToWebhookDefinitionFilter(ctx, path, modelFilter)
-			diags.Append(filterDiags...)
-
-			filters[index] = filter
-		}
-
-		req.Filters = cm.NewOptNilWebhookDefinitionFilterArray(filters)
-	}
+	req.Filters = filters
 
 	headersList, headersListDiags := ToWebhookDefinitionHeaders(ctx, path.AtName("headers"), model.Headers)
 	diags.Append(headersListDiags...)

--- a/internal/provider/webhook_model_request_test.go
+++ b/internal/provider/webhook_model_request_test.go
@@ -216,3 +216,58 @@ func TestWebhookModelToWebhookDefinitionData(t *testing.T) {
 		})
 	}
 }
+
+func TestWebhookModelFilterContainerSemantics(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		filters       TypedList[TypedObject[WebhookFilterValue]]
+		expected      cm.OptNilWebhookDefinitionFilterArray
+		expectedPaths []string
+	}{
+		"null is omitted": {
+			filters:       NewTypedListNull[TypedObject[WebhookFilterValue]](),
+			expected:      cm.NewOptNilWebhookDefinitionFilterArrayNull(),
+			expectedPaths: []string{},
+		},
+		"known empty is explicit": {
+			filters:       NewTypedList([]TypedObject[WebhookFilterValue]{}),
+			expected:      cm.NewOptNilWebhookDefinitionFilterArray([]cm.WebhookDefinitionFilter{}),
+			expectedPaths: []string{},
+		},
+		"unknown fails closed": {
+			filters:       NewTypedListUnknown[TypedObject[WebhookFilterValue]](),
+			expectedPaths: []string{"filters"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			model := WebhookModel{
+				Name:              types.StringValue("filters-webhook"),
+				URL:               types.StringValue("https://example.com/webhook"),
+				Topics:            NewTypedListNull[types.String](),
+				Filters:           test.filters,
+				HTTPBasicUsername: types.StringNull(),
+				HTTPBasicPassword: types.StringNull(),
+				Headers:           NewTypedMapNull[TypedObject[WebhookHeaderValue]](),
+				Transformation:    NewTypedObjectNull[WebhookTransformationValue](),
+				Active:            types.BoolValue(true),
+			}
+
+			actual, diags := model.ToWebhookDefinitionData(t.Context(), path.Empty())
+
+			assert.Equal(t, test.expectedPaths, diagnosticPaths(t, diags))
+
+			if len(test.expectedPaths) > 0 {
+				assert.Equal(t, cm.WebhookDefinitionData{}, actual)
+
+				return
+			}
+
+			assert.Equal(t, test.expected, actual.Filters)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- require exactly one known outer Webhook filter alternative and exactly one known nested `not` alternative
- reject unresolved required filter operands, list containers, and list elements at their exact Terraform paths
- route `WebhookModel` filter conversion through the strict helper so unknown Optional-only filters fail closed at the request boundary
- preserve null filter omission and known empty filters while returning no partial request value after diagnostics

## Stack

Depends on the Webhook request-value conversion in #608.

## Validation

- focused Webhook filter and model request tests
- `go test ./...`
- `go generate ./...` (clean worktree)
- `golangci-lint cache clean` immediately followed by `golangci-lint run`